### PR TITLE
Fix:Remove Arabic name fields when creating Internal Trainees #71

### DIFF
--- a/resources/views/backend/employee/edit.blade.php
+++ b/resources/views/backend/employee/edit.blade.php
@@ -44,18 +44,18 @@
 </div>
 
 {{-- Arabic First Name --}}
-<div class="col-lg-6 mt-3">
+<!-- <div class="col-lg-6 mt-3">
     <label class="form-control-label">First Name (Arabic)</label>
     <input type="text" name="arabic_first_name" class="form-control"
            value="{{ $teacher->arabic_first_name }}" required>
-</div>
+</div> -->
 
 {{-- Arabic Last Name --}}
-<div class="col-lg-6 mt-3">
+<!-- <div class="col-lg-6 mt-3">
     <label class="form-control-label">Last Name (Arabic)</label>
     <input type="text" name="arabic_last_name" class="form-control"
            value="{{ $teacher->arabic_last_name }}" required>
-</div>
+</div> -->
 
 {{-- Employee ID --}}
 <div class="col-lg-6 mt-3">
@@ -96,14 +96,14 @@
 </div>
 
 {{-- Gender --}}
-<div class="col-lg-12 mt-3">
+<div class="col-lg-6 mt-3">
     <label class="form-control-label">Gender</label><br>
     <label><input type="radio" name="gender" value="male" {{ $teacher->gender == 'male' ? 'checked' : '' }}> Male</label>
     <label class="ml-3"><input type="radio" name="gender" value="female" {{ $teacher->gender == 'female' ? 'checked' : '' }}> Female</label>
 </div>
 
 {{-- Preferred Language --}}
-<div class="col-lg-12 mt-3">
+<div class="col-lg-6 mt-3">
     <label class="form-control-label">Preferred Language</label><br>
     <label><input type="radio" name="fav_lang" value="english" {{ $teacher->fav_lang == 'english' ? 'checked' : '' }}> English</label>
     <label class="ml-3"><input type="radio" name="fav_lang" value="arabic" {{ $teacher->fav_lang == 'arabic' ? 'checked' : '' }}> Arabic</label>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This pull request removes the “First Name in Arabic” and “Last Name in Arabic” fields from the Internal Trainee creation form and replaces them with a clean, language-agnostic approach.

Previously, the form contained hard-coded Arabic-specific fields, which conflicts with Tadreeb LMS’s goal of supporting multiple languages through localization. This change ensures that names are entered once using generic fields, while translations and language preferences are handled globally by the system.

- What problem does this PR solve?

    Removes Arabic-specific name fields from the Internal Trainee form
    Keeps only generic First Name and Last Name inputs
    Aligns the UI with multi-language and localization standards
    Improves form simplicity and consistency across the platform
- What issue does it close (if any)?

Fixes: #71 

---

## ✅ Type of Change


-  ✨ New feature
-  🎨 UI/UX update

---

## 📸 Screenshots (if applicable)

<img width="1919" height="918" alt="Screenshot 2026-01-24 122404" src="https://github.com/user-attachments/assets/036d9fd6-e951-48aa-bedf-67d176796a07" />
<img width="1917" height="915" alt="image" src="https://github.com/user-attachments/assets/6960e0ba-04ea-4a6e-9a92-77a92187cfd4" />


---

## 🚀 How Has This Been Tested?


-  Local environment
-  Browser testing

---

## 🧪 Steps to Reproduce

1. Login to the admin panel
2. Navigate to Trainees → Internal → Create
3. Observe “First Name” and “Last Name” fields
4. Navigate to Trainees → Internal → Edit
5. Observe “First Name” and “Last Name” fields
---

## 🔄 Checklist

-  Followed the project's coding guidelines
-  Verified no sensitive data is included
-  Ensured the app builds without errors

---

## 🙏 Additional Notes

This change improves scalability, UI cleanliness, and future multilingual support by removing language-specific inputs and relying on Tadreeb LMS’s localization framework instead.
