### PR TITLE
Fix: Delete Button Not Working for Course Feedback Questions #145

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CourseFeebackController.php
+++ b/app/Http/Controllers/Backend/Admin/CourseFeebackController.php
@@ -64,7 +64,7 @@ class CourseFeebackController extends Controller
                         // $actions .= '<a title="Edit" href="'.$edit_route.'">
                         //                 <i class="fa fa-edit"></i>
                         //             </a>';
-                        $actions .= '<a title="Delete" href="#" 
+                        $actions .= '<a title="Delete" href="#" class="delete-record"
                                         data-name="course feedback question" 
                                         data-type="delete" 
                                         data-url="/user/course-feedback-questions/delete/' . $single->id . '">
@@ -81,9 +81,14 @@ class CourseFeebackController extends Controller
         return view('backend.course_feedback_question.index', compact('courses'));
     }
 
-    public function destroy(Request $request)
+    public function destroy($id)
     {
-        CourseFeedback::where('course_id', $request->id)->delete();
+        $courseFeedback = CourseFeedback::find($id);
+        if ($courseFeedback) {
+            $courseFeedback->delete();
+            return response()->json(['status' => 'success', 'message' => 'Question removed from course successfully']);
+        }
+        return response()->json(['status' => 'error', 'message' => 'Record not found'], 404);
     }
 
     public function edit(Request $request)

--- a/public/js/modal/confirm-modal.js
+++ b/public/js/modal/confirm-modal.js
@@ -85,7 +85,7 @@ $(function () {
           displayNotification(
             "error",
             response?.responseJSON?.message ?? "Something went wrong!",
-            5000
+            5000,
           );
         }
 
@@ -98,6 +98,18 @@ $(function () {
   });
 
   function displayNotification(type, message) {
-    alert(message);
+    if (typeof toastr !== "undefined") {
+      if (type === "success") {
+        toastr.success(message);
+      } else if (type === "error") {
+        toastr.error(message);
+      } else if (type === "warning") {
+        toastr.warning(message);
+      } else {
+        toastr.info(message);
+      }
+    } else {
+      alert(message);
+    }
   }
 });

--- a/resources/views/backend/course_feedback_question/index.blade.php
+++ b/resources/views/backend/course_feedback_question/index.blade.php
@@ -2,6 +2,7 @@
 @extends('backend.layouts.app')
 @section('title', __('labels.backend.lessons.title') . ' | ' . app_name())
 @push('after-styles')
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.css" rel="stylesheet" />
  <style>
 
 .dataTables_paginate.paging_simple_numbers{
@@ -90,6 +91,7 @@ width: 58% !important;
 @stop
 
 @push('after-scripts')
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ asset('js/modal/confirm-modal.js') }}"></script>
     <script>
         $(document).ready(function() {


### PR DESCRIPTION
I have fixed the issue where the delete icon in the Course Feedback Questions list was unresponsive.

Changes Implemented:
Controller Update (
CourseFeebackController.php
):
Added the missing delete-record class to the delete action link in the DataTable. This class is required to trigger the confirmation modal handler.
Refactored the 
destroy
 method to correctly handle row-level deletion using the record's primary ID instead of the course_id.
Updated the 
destroy
 method to return a JSON response, allowing the frontend to display success or error notifications.
Global Confirmation Modal Update (
confirm-modal.js
):
Enhanced the 
displayNotification
 function to use Toastr for premium, non-blocking notifications. I added a fallback to standard browser alerts if Toastr is not available on a specific page, ensuring backward compatibility.
View Enhancement (
index.blade.php
):
Included Toastr CSS and JS dependencies on the Course Feedback Questions index page to meet the requirement for success/error toasts after deletion.
The confirmation dialog now correctly prompts the user before performing the deletion.