### PR TITLE
Fix: Add Date Column in User Feedback Answers #165

### DIFF
--- a/app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php
+++ b/app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php
@@ -84,6 +84,9 @@ class UserFeebackAnswersController extends Controller
                 ->addColumn('course_name', function ($single) {
                     return @$single->course->title;
                 })
+                ->addColumn('submitted_on', function ($single) {
+                    return $single->created_at ? $single->created_at->format('d M Y h:i A') : '-';
+                })
                 ->addColumn('question_answers', function ($single) {
                     return '<a class="badge badge-info feedback-detail" data-id="' . $single->id . '" href="#"> Detail </a>'; //$single->question_answers;
                 })

--- a/resources/views/backend/course_feedback_answer/index.blade.php
+++ b/resources/views/backend/course_feedback_answer/index.blade.php
@@ -27,6 +27,7 @@
                                       <th>S. No.</th>
                                       <th>User Name</th>
                                       <th>Course Name</th>
+                                      <th>Submitted On</th>
                                       <th>Detail</th>
                                   </tr>
                               </thead>
@@ -109,6 +110,10 @@
                     {
                         data: "course_name",
                         name: 'course_name'
+                    },
+                    {
+                        data: "submitted_on",
+                        name: 'submitted_on'
                     },
                     {
                         data: "question_answers",


### PR DESCRIPTION
I've successfully added the "Submitted On" date column to the User Feedback Answers page. Here's what was changed:

✅ Changes Made:
View File (
resources/views/backend/course_feedback_answer/index.blade.php
):
Added <th>Submitted On</th> column header in the table (line 30)
Added the corresponding DataTables column configuration for submitted_on (lines 114-117)
Controller (
app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php
):
Added the submitted_on column to the DataTables response (lines 87-89)
Implemented date formatting using created_at->format('d M Y h:i A') which produces the required format: DD MMM YYYY hh:mm A (e.g., "08 Feb 2026 03:22 PM")