### PR TITLE
Action buttons in Trainers Trash view do not match TadreebLMS theme #54

### DIFF
--- a/resources/views/backend/datatable/action-trashed.blade.php
+++ b/resources/views/backend/datatable/action-trashed.blade.php
@@ -1,22 +1,58 @@
-<a data-method="restore" data-trans-button-cancel="Cancel"
-   data-trans-button-confirm="Restore" data-trans-title="Are you sure?"
-   class="btn btn-xs mb-1 btn-success text-white" style="cursor:pointer;"
-   onclick="$(this).find('form').submit();">
-    <i class="fa fa-recycle" aria-hidden="true"></i>
-    <form action="{{route($route_label.'.restore',[$label=> $value])}}"
-          method="POST" name="restore_item" style="display:none">
-        @csrf
-    </form>
-</a>
+<style>
+/* Align buttons inside table */
+td .table-actions {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+}
 
-<a data-method="delete" data-trans-button-cancel="Cancel"
-   data-trans-button-confirm="Delete" data-trans-title="Are you sure?"
-   class="btn btn-xs mb-1 btn-danger text-white" style="cursor:pointer;"
-   onclick="$(this).find('form').submit();">
-    <i class="fa fa-trash" aria-hidden="true"></i>
-    <form action="{{route($route_label.'.perma_del',[$label=>$value])}}"
-          method="POST" name="delete_item" style="display:none">
+/* Theme button */
+td .btn-theme {
+    background: linear-gradient(90deg, #2f3e74 0%, #c79a2d 100%) !important;
+     border: none !important;
+    color: #ffffff !important;
+    border-radius: 6px;
+    width: 50px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: all 0.3s ease;
+    font-size : 15px
+}
+
+/* Hover */
+td .btn-theme:hover {
+    background-color: #26345f !important;
+    border-color: #c79a2d !important;
+    color: #ffffff !important;
+}
+
+/* Remove bootstrap effects */
+td .btn-theme:focus,
+td .btn-theme:active {
+    box-shadow: none !important;
+    outline: none !important;
+}
+</style>
+
+<div class="table-actions">
+
+    <form action="{{ route($route_label.'.restore', [$label => $value]) }}" method="POST">
         @csrf
-        {{method_field('DELETE')}}
+        <button type="submit" class="btn-theme">
+            <i class="fa fa-recycle"></i>
+        </button>
     </form>
-</a>
+
+    <form action="{{ route($route_label.'.perma_del', [$label => $value]) }}" method="POST">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn-theme">
+            <i class="fa fa-trash"></i>
+        </button>
+    </form>
+
+</div>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes a UI inconsistency in the Trainers → Trash view where the action buttons (Restore and Delete) were styled using a green theme that does not match the TadreebLMS premium design system.

- What problem does this PR solve?

     - The Trash view action buttons:
         - Used a green color scheme
         - Did not follow TadreebLMS premium theme styling
         - Created visual inconsistency compared to other action buttons in the application
         - Broke the overall design language and UI consistency
  
- What feature does it add?

     - Updated Restore and Permanent Delete buttons to follow TadreebLMS premium theme.
     - Applied correct:
          - Brand color palette
          - Border styling
          - Border radius
          - Hover effects
          - Button sizing
     - Ensured consistency with action buttons used in other modules.

- What issue does it close (if any)?

     Fixes: #54 

---

## ✅ Type of Change

-  🐞 Bug fix
-  🎨 UI/UX update

---

## 📸 Screenshots 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9c47139-00f7-4cca-812a-1a094607c961" />

---

## 🚀 How Has This Been Tested?

-  Local environment
-  Browser testing

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login to admin console
2. Navigate to Trainers
3. Click on Trash
4. Observe action buttons in the Actions column
---

## 🔄 Checklist

-  Followed the project's coding guidelines
-  Verified no sensitive data is included
-  Ensured the app builds without errors

---

## 🙏 Additional Notes

This update only affects styling and does not modify any backend logic or functionality.
No database changes were required.
