### PR TITLE
Fix:Verified Trainee Not Appearing in User List After Signup #249

### DIFF
--- a/app/Http/Controllers/Backend/Auth/User/UserController.php
+++ b/app/Http/Controllers/Backend/Auth/User/UserController.php
@@ -69,7 +69,6 @@ class UserController extends Controller
                 ->orderBy('users.created_at', 'desc');
         }else{
             $users = User::with('roles', 'permissions', 'providers')
-                ->whereNull('employee_type')
                 ->orderBy('users.created_at', 'desc');
         }
 


### PR DESCRIPTION
I have investigated and fixed the issue where newly registered trainees were not visible in the Admin Panel → User Management → User List.

Root Cause Identified
The issue was caused by a filter in UserController@getData that specifically excluded any user with an employee_type set.

Newly registered trainees are assigned employee_type = 'external' in 

RegisterController
.
Internal employees are assigned employee_type = 'internal' in 

EmployeeController
.
Admin-created users (via User Management) have no employee_type (NULL).
Because the "All Users" list was filtering for whereNull('employee_type'), all trainees (both internal and external) were hidden from this view, even after successful email verification.

Changes Made
1. Updated 

UserController
I modified 

app/Http/Controllers/Backend/Auth/User/UserController.php
 to remove the whereNull('employee_type') filter from the 

getData
 method. This ensures that the "All Users" management list actually displays all users, including newly registered trainees and internal employees.

2. Verified Registration Flow
I confirmed that 

RegisterController.php
:

Correctly creates the user record.
Sets confirmed = 1 immediately upon registration (as requested).
Assigns the 

student
 role (which maps to the Trainee label in the UI).
Correctly sets active = 1 only after the email verification link is clicked.
Verification Steps
Registered User Visibility: Navigate to Admin Panel → User Management → All Users. Newly registered and verified trainees should now appear in this list.
Role Verification: In the user list, the role for these users should appear as Trainee (mapped from the internal 'student' role).
Status Check: Ensure that only after clicking the verification link in the email, the user status changes to "Active" in the admin panel.