### PR TITLE
feat(admin): improve User Feedback Answer filtering (courses, users, date range)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php
+++ b/app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Backend\Admin;
 
 use App\Models\Course;
+use App\Models\Auth\User;
 use App\Models\CourseTimeline;
 use App\Models\Lesson;
 use App\Models\Media;
@@ -15,66 +16,18 @@ use App\Http\Controllers\Controller;
 use App\Models\CourseFeedback;
 use App\Models\FeedbackQuestion;
 use App\Models\UserFeedback;
+use Carbon\Carbon;
 use DB;
 use Yajra\DataTables\Facades\DataTables;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Builder;
 
 class UserFeebackAnswersController extends Controller
 {
-
-    public function index_(Request $request)
-    {
-
-
-        if ($request->ajax()) {
-            $userFeedbackAnswers = UserFeedback::whereHas('courseFeedback')->latest();
-
-            return DataTables::of($userFeedbackAnswers)
-                ->addIndexColumn()
-                ->addColumn('user_name', function ($single) {
-                    return @$single->user->full_name;
-                })
-                ->addColumn('course_name', function ($single) {
-                    return @$single->course->title;
-                })
-                ->addColumn('question_answers', function ($single) {
-                    return $single->question_answers;
-                })
-                ->filter(function ($query) use ($request) {
-                    $search = $request->input('search.value');
-
-                    if (!empty($search)) {
-                        $query->whereHas('user', function ($query) use ($search) {
-                            $query->where(DB::raw("CONCAT(first_name, ' ', last_name)"), 'like', "%{$search}%");
-                        })
-                            ->orWhereHas('course', function ($query) use ($search) {
-                                $query->where('title', 'like', "%{$search}%");
-                            });
-                    }
-                })
-                ->rawColumns(['question_answers'])
-                ->make(true);
-        }
-
-        return view('backend.course_feedback_answer.index');
-    }
-
     public function index(Request $request)
     {
-
-
         if ($request->ajax()) {
-            $userFeedbackAnswers = UserFeedback::select('user_feedback.*')
-                                    ->whereHas('courseFeedback')
-                                    ->whereIn('id', function($q) {
-                                        $q->selectRaw('MAX(id)')
-                                        ->from('user_feedback')
-                                        ->groupBy('user_id', 'course_id');
-                                    })
-                                    ->latest();
-                                    
-
-            //dd($userFeedbackAnswers);
+            $userFeedbackAnswers = $this->buildFeedbackAnswersQuery($request);
 
             return DataTables::of($userFeedbackAnswers)
                 ->addIndexColumn()
@@ -94,21 +47,134 @@ class UserFeebackAnswersController extends Controller
                     $search = $request->input('search.value');
 
                     if (!empty($search)) {
-                            $query->where(function ($q) use ($search) {
-                                $q->whereHas('user', function ($q2) use ($search) {
-                                    $q2->where(DB::raw("CONCAT(first_name, ' ', last_name)"), 'like', "%{$search}%");
-                                })
-                                ->orWhereHas('course', function ($q2) use ($search) {
-                                    $q2->where('title', 'like', "%{$search}%");
-                                });
-                            })->distinct();
+                        $query->where(function ($q) use ($search) {
+                            $q->whereHas('user', function ($q2) use ($search) {
+                                $q2->where(DB::raw("CONCAT(first_name, ' ', last_name)"), 'like', "%{$search}%");
+                            })
+                            ->orWhereHas('course', function ($q2) use ($search) {
+                                $q2->where('title', 'like', "%{$search}%");
+                            });
+                        });
                     }
                 })
                 ->rawColumns(['question_answers'])
                 ->make(true);
         }
 
-        return view('backend.course_feedback_answer.index');
+        $courseFeedbackTable = (new CourseFeedback())->getTable();
+
+        $courses = Course::whereIn('id', function ($query) use ($courseFeedbackTable) {
+                $query->select('course_id')
+                    ->from('user_feedback')
+                ->whereExists(function ($subQuery) use ($courseFeedbackTable) {
+                        $subQuery->selectRaw('1')
+                    ->from($courseFeedbackTable)
+                    ->whereColumn($courseFeedbackTable . '.course_id', 'user_feedback.course_id');
+                    });
+            })
+            ->orderBy('title')
+            ->pluck('title', 'id');
+
+        $users = User::whereIn('id', function ($query) use ($courseFeedbackTable) {
+                $query->select('user_id')
+                    ->from('user_feedback')
+                ->whereExists(function ($subQuery) use ($courseFeedbackTable) {
+                        $subQuery->selectRaw('1')
+                    ->from($courseFeedbackTable)
+                    ->whereColumn($courseFeedbackTable . '.course_id', 'user_feedback.course_id');
+                    });
+            })
+            ->orderBy('first_name')
+            ->orderBy('last_name')
+            ->get(['id', 'first_name', 'last_name', 'email'])
+            ->mapWithKeys(function ($user) {
+                $label = trim($user->full_name);
+
+                if (!empty($user->email)) {
+                    $label .= ' (' . $user->email . ')';
+                }
+
+                return [$user->id => $label];
+            });
+
+        return view('backend.course_feedback_answer.index', compact('courses', 'users'));
+    }
+
+    private function buildFeedbackAnswersQuery(Request $request): Builder
+    {
+        $query = UserFeedback::select('user_feedback.*')
+            ->with(['user:id,first_name,last_name,email', 'course:id,title'])
+            ->whereHas('courseFeedback')
+            ->whereIn('id', function ($subQuery) {
+                $subQuery->selectRaw('MAX(id)')
+                    ->from('user_feedback')
+                    ->groupBy('user_id', 'course_id');
+            })
+            ->latest();
+
+        $courseIds = collect((array) $request->input('course_ids', []));
+
+        $legacyCourseId = $request->input('course_id');
+        if (!empty($legacyCourseId) && is_numeric($legacyCourseId)) {
+            $courseIds->push($legacyCourseId);
+        }
+
+        $courseIds = $courseIds
+            ->filter(function ($id) {
+                return is_numeric($id);
+            })
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->unique()
+            ->values();
+
+        if ($courseIds->isNotEmpty()) {
+            $query->whereIn('course_id', $courseIds->all());
+        }
+
+        $userIds = collect((array) $request->input('user_ids', []))
+            ->filter(function ($id) {
+                return is_numeric($id);
+            })
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->values();
+
+        if ($userIds->isNotEmpty()) {
+            $query->whereIn('user_id', $userIds->all());
+        }
+
+        $fromDate = $this->parseFilterDate($request->input('date_from'));
+        $toDate = $this->parseFilterDate($request->input('date_to'));
+
+        if ($fromDate && $toDate && $fromDate->gt($toDate)) {
+            [$fromDate, $toDate] = [$toDate, $fromDate];
+        }
+
+        if ($fromDate) {
+            $query->where('created_at', '>=', $fromDate->copy()->startOfDay());
+        }
+
+        if ($toDate) {
+            $query->where('created_at', '<=', $toDate->copy()->endOfDay());
+        }
+
+        return $query;
+    }
+
+    private function parseFilterDate(?string $date): ?Carbon
+    {
+        if (empty($date)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($date);
+        } catch (\Exception $exception) {
+            return null;
+        }
     }
 
     public function feedback_detail(Request $request, $id)

--- a/resources/views/backend/course_feedback_answer/index.blade.php
+++ b/resources/views/backend/course_feedback_answer/index.blade.php
@@ -2,9 +2,75 @@
 @extends('backend.layouts.app')
 @section('title', __('User Feedback Answers') . ' | ' . app_name())
 @push('after-styles')
- <style>
-      
-    </style>
+<style>
+    .feedback-filters {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+    }
+
+    .feedback-filters-title {
+        font-size: 15px;
+        font-weight: 700;
+        color: #1f2937;
+    }
+
+    .feedback-filters .control-label {
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #4b5563;
+        margin-bottom: 6px;
+    }
+
+    .feedback-filters .form-control,
+    .feedback-filters .select2-container--default .select2-selection--single,
+    .feedback-filters .select2-container--default .select2-selection--multiple {
+        border: 1px solid #cfd8e3;
+        border-radius: 10px;
+        min-height: 42px;
+    }
+
+    .feedback-filters .select2-container--default .select2-selection--multiple {
+        padding: 4px 8px;
+    }
+
+    .feedback-filters .select2-container--default .select2-selection--multiple .select2-selection__choice {
+        background: #e8f1ff;
+        border: 1px solid #b7d2ff;
+        color: #1d4ed8;
+        border-radius: 999px;
+        padding: 2px 8px;
+        font-size: 12px;
+        margin-top: 3px;
+    }
+
+    .feedback-filters .form-control:focus,
+    .feedback-filters .select2-container--default.select2-container--focus .select2-selection--single,
+    .feedback-filters .select2-container--default.select2-container--focus .select2-selection--multiple {
+        border-color: #86b7fe;
+        box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.15);
+    }
+
+    .btn-reset-filters {
+        background: #C1902D;
+        border: 1px solid #C1902D;
+        color: #fff;
+        border-radius: 999px;
+        font-weight: 600;
+        padding: 0.42rem 1rem;
+    }
+
+    .btn-reset-filters:hover,
+    .btn-reset-filters:focus {
+        background: #A67921;
+        border-color: #9C701E;
+        color: #fff;
+    }
+</style>
 @endpush
 
 @section('content')
@@ -19,6 +85,48 @@
                       <h3 class="page-title d-inline">@lang('User Feedback Answer')</h3>
                   </div> -->
                   <div class="card-body">
+                      <div class="feedback-filters">
+                          <div class="d-flex align-items-center mb-3">
+                              <h5 class="feedback-filters-title mb-0">Filters</h5>
+                          </div>
+
+                          <div class="row mb-2">
+                              <div class="col-12 col-lg-4 form-group">
+                                  <label for="filter_course_ids" class="control-label">Courses</label>
+                                  <select name="filter_course_ids[]" id="filter_course_ids" class="form-control custom-select-box js-example-placeholder-courses select2" multiple>
+                                      @foreach($courses as $courseId => $courseName)
+                                          <option value="{{ $courseId }}">{{ $courseName }}</option>
+                                      @endforeach
+                                  </select>
+                              </div>
+
+                              <div class="col-12 col-lg-4 form-group">
+                                  <label for="filter_user_ids" class="control-label">Users</label>
+                                  <select name="filter_user_ids[]" id="filter_user_ids" class="form-control custom-select-box js-example-placeholder-multiple select2" multiple>
+                                      @foreach($users as $userId => $userName)
+                                          <option value="{{ $userId }}">{{ $userName }}</option>
+                                      @endforeach
+                                  </select>
+                              </div>
+
+                              <div class="col-6 col-lg-2 form-group">
+                                  <label for="filter_date_from" class="control-label">From Date</label>
+                                  <input type="date" id="filter_date_from" class="form-control" autocomplete="off">
+                              </div>
+
+                              <div class="col-6 col-lg-2 form-group">
+                                  <label for="filter_date_to" class="control-label">To Date</label>
+                                  <input type="date" id="filter_date_to" class="form-control" autocomplete="off">
+                              </div>
+                          </div>
+
+                          <div class="row mb-0">
+                              <div class="col-12 d-flex justify-content-end">
+                                  <button type="button" id="reset-filters" class="btn btn-reset-filters">Reset Filters</button>
+                              </div>
+                          </div>
+                      </div>
+
                       <div class="">
                           <table id="myTable"
                               class="table dt-select custom-teacher-table table-striped @can('lesson_delete') @if (request('show_deleted') != 1) dt-select @endif @endcan">
@@ -62,7 +170,8 @@
     <script src="{{ asset('js/modal/confirm-modal.js') }}"></script>
     <script>
         $(document).ready(function() {
-            let course_id;
+            let isResettingFilters = false;
+
             const dtTable = $('#myTable').DataTable({
                 processing: true,
                 serverSide: true,
@@ -94,7 +203,10 @@
                         $("#loader").addClass("d-none");
                     },
                     data: function(d) {
-                        d.course_id = course_id; // Pass the course_id parameter to the server
+                        d.course_ids = $('#filter_course_ids').val();
+                        d.user_ids = $('#filter_user_ids').val();
+                        d.date_from = $('#filter_date_from').val();
+                        d.date_to = $('#filter_date_to').val();
                     }
                 },
                 columns: [{
@@ -168,6 +280,38 @@
         'font-weight': 'bold'
     });
 },
+            });
+
+            $(".js-example-placeholder-courses").select2({
+                placeholder: "Select courses",
+                allowClear: true,
+                width: "100%"
+            });
+
+            $(".js-example-placeholder-multiple").select2({
+                placeholder: "Select users",
+                allowClear: true,
+                width: "100%"
+            });
+
+            $('#filter_course_ids, #filter_user_ids, #filter_date_from, #filter_date_to').on('change', function () {
+                if (isResettingFilters) {
+                    return;
+                }
+
+                dtTable.draw();
+            });
+
+            $(document).on('click', '#reset-filters', function () {
+                isResettingFilters = true;
+
+                $('#filter_course_ids').val(null).trigger('change');
+                $('#filter_user_ids').val(null).trigger('change');
+                $('#filter_date_from').val('');
+                $('#filter_date_to').val('');
+
+                isResettingFilters = false;
+                dtTable.draw();
             });
 
         });


### PR DESCRIPTION
## Summary
This PR implements the requested filtering improvements for the **User Feedback Answer** admin page.

Closes #296.

<img width="1617" height="595" alt="Schermata del 2026-03-15 09-51-35" src="https://github.com/user-attachments/assets/133b5e3f-7d2c-43a6-b679-a8a2a36d6cd6" />


## What Was Implemented
- Added **multi-course filtering** (Select2 multi-select) to match the multi-user experience.
- Added and wired **multi-user filtering** and **date range filtering** (`from` / `to`) into the server-side DataTables query.
- Enabled **immediate filtering** on field changes (no separate Apply action required).
- Improved reset behavior so all filters clear cleanly and the table refreshes once.
- Polished the filter panel UI for better readability and consistency.

## Backend Improvements
- Refactored filtering logic into a modular query builder flow.
- Added safe parsing/sanitization for `course_ids`, `user_ids`, and dates.
- Added backward compatibility support for legacy `course_id` input.
- Replaced hardcoded feedback table usage with model-based table resolution to avoid schema name mismatches.

## Validation Performed
- Verified no syntax/editor errors in the updated files.
- Tested DataTables responses with combined filters (multiple courses + users + date range).
- Seeded test data locally and confirmed filtered results are returned correctly.

## Files Updated
- `app/Http/Controllers/Backend/Admin/UserFeebackAnswersController.php`
- `resources/views/backend/course_feedback_answer/index.blade.php`

## Feedback Request
Could you please review and let me know if you would like any further adjustments to either:
1. the **aesthetics** (layout, spacing, button prominence, etc.), or
2. the **filtering behavior** (UX flow, defaults, edge cases)?

I can iterate quickly based on your feedback.
