### PR TITLE
fix(course assignments): store actual admin in Assigned By

### DIFF
--- a/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
+++ b/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
@@ -617,7 +617,7 @@ class AssessmentAccountsController extends Controller
             $course_Ass->course_id = $course_id;
 
 
-            $course_Ass->assign_by = 1;
+            $course_Ass->assign_by = auth()->id();
             $course_Ass->assign_date =  date('Y-m-d');
             $course_Ass->assign_to = $assign_to;
             //dd($course_Ass->assign_to);
@@ -793,7 +793,7 @@ class AssessmentAccountsController extends Controller
         $course_Ass = new courseAssignment;
         $course_Ass->title = 'Course Enrollment - ' . date('Y-m-d');
         $course_Ass->course_id = $course_id;
-        $course_Ass->assign_by = 1;
+        $course_Ass->assign_by = auth()->id();
         $course_Ass->assign_date = date('Y-m-d');
         $course_Ass->assign_to = $assign_to;
         $course_Ass->department_id = $request->department_id;
@@ -1005,7 +1005,7 @@ class AssessmentAccountsController extends Controller
 
             
 
-            $course_Ass->assign_by = 1;
+            $course_Ass->assign_by = auth()->id();
             $course_Ass->assign_date = date('Y-m-d');
             $course_Ass->assign_to = $assign_to;
             //dd($course_Ass->assign_to);


### PR DESCRIPTION
## Summary
This PR fixes the issue where the Course Assignments list always showed a static value in the **Assigned By** column.

Closes #291.

## Root Cause
- The assignment creation logic was using a static assignment value: `assign_by = 1`.
- The authenticated admin reference was missing, so the system was not saving the real actor (`Auth` / `auth()->id()`).

## Fix Applied
Replaced the static value with the logged-in admin id in all course-assignment creation flows:
- `course_assignment(...)`
- `direct_enroll_users(...)`
- `mappingCourseToUser(...)` (invitation/reschedule flow)

## Result
- New course assignments now persist the correct admin id in `assign_by`.
- The **Assigned By** column now correctly displays the admin who performed the assignment.
- Existing historical records remain unchanged.

## Validation
- Verified editor diagnostics: no syntax errors in the updated controller.
- Verified all hardcoded `assign_by = 1` occurrences in this controller were removed.
