### PR TITLE
fix(courses): remove duplicate return statement in status DataTable closure

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -498,8 +498,6 @@ class CoursesController extends Controller
 
     return $text;
 })
-                return $text;
-            })
             ->addColumn('start_date', function ($q) {
     if (empty($q->start_date)) {
         return '-';


### PR DESCRIPTION
## Summary
This PR fixes a pre-existing PHP syntax error that broke the entire Courses Management section.

Closes #308.

## Root Cause
The addColumn status DataTable closure in CoursesController contained a duplicate closing block left over from a previous edit. After the valid closure end, two orphaned lines remained outside any function body, causing PHP to fail with a fatal syntax error: unexpected token return, expecting semicolon.

## Fix
Removed the two duplicate lines. The closure is now properly closed exactly once.

## Note
This bug was pre-existing in main (present since at least commit 4924b4e) and was not introduced by any recent feature branch. It was discovered while working on the Courses page.

## Validation
php -l confirms: No syntax errors detected in CoursesController.php