### PR TITLE
security: block installer re-run, neutralize phpinfo, protect db_config

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,14 @@
+# Block sensitive installer and configuration files from web access
+<FilesMatch "^(db_config\.json|phpinfo\.php|install\.php|install-b\.php|install_ajax\.php)$">
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
+</FilesMatch>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/public/install-b.php
+++ b/public/install-b.php
@@ -2,6 +2,15 @@
 ob_start();
 
 // ------------------------------------------
+// Block access if application is already installed
+// ------------------------------------------
+$_basePath = realpath(__DIR__ . '/..');
+if ($_basePath && file_exists($_basePath . '/installed')) {
+    http_response_code(403);
+    exit('Forbidden: Application is already installed.');
+}
+
+// ------------------------------------------
 // RESET INSTALLER ONLY ON STEP = start
 // ------------------------------------------
 $step = $_GET['step'] ?? 'start';

--- a/public/install_ajax.php
+++ b/public/install_ajax.php
@@ -24,7 +24,7 @@ $installedFlag     = $basePath . '/installed';
 | Prevent reinstall
 |--------------------------------------------------------------------------
 */
-if (file_exists($installedFlag) && ($_GET['step'] ?? '') !== 'check') {
+if (file_exists($installedFlag)) {
     echo json_encode(['success' => false, 'message' => '❌ Application already installed']);
     exit;
 }
@@ -331,21 +331,14 @@ try {
         case 'finish':
             file_put_contents($installedFlag, 'installed');
             $env = file_get_contents($envFile);
-            if (strpos($env, 'APP_INSTALLED=true') === false) {
-                $env .= "\nAPP_INSTALLED=true\n";
-            }
-            if (strpos($env, 'APP_INSTALLED=false') === false) {
-                $env .= "\nAPP_INSTALLED=true\n";
-            }
             if (strpos($env, 'APP_INSTALLED=') === false) {
                 $env .= "\nAPP_INSTALLED=true\n";
             }
 
-            //$env .= "\nAPP_URL=" .$siteUrl. "\n";
-
             file_put_contents($envFile, $env);
 
-            
+            // Remove db_config.json now that credentials are in .env
+            @unlink($dbConfigFile);
 
             echo json_encode(['message' => "✔ Installation complete! <a href='/'>Open Application</a>", 'next' => null]);
             exit;

--- a/public/phpinfo.php
+++ b/public/phpinfo.php
@@ -1,2 +1,4 @@
 <?php
-phpinfo();
+// phpinfo() removed for security – do not expose server configuration in production.
+http_response_code(403);
+exit('Forbidden');


### PR DESCRIPTION
## Summary
Closes #269.

This PR addresses the two critical security vulnerabilities reported in #269.

---

## Issue 1 – Installer accessible and re-runnable after deployment

**Root causes found:**

1. `install-b.php` had **no installed-flag guard at all**. Any unauthenticated user could call `/install-b.php?step=start` to delete the `installed`, `.migrations_done` and `.seed_done` flags, re-opening the full installation wizard.

2. `install_ajax.php` **explicitly exempted** the `check` step from the installed guard (`!== 'check'`). The `check` case internally calls `@unlink($envFile)`, meaning calling `/install_ajax.php?step=check` on a live system **silently deletes the production .env** with no authentication required.

**Fixes applied:**
- `install-b.php`: added installed-flag check at the very top; returns HTTP 403 if the application is already installed.
- `install_ajax.php`: removed the `!== 'check'` bypass so the installed guard applies unconditionally to every step.
- `install_ajax.php` (finish step): fixed the triple redundant `APP_INSTALLED` logic and added `@unlink($dbConfigFile)` so `db_config.json` is automatically deleted as soon as installation completes.

---

## Issue 2 – Sensitive files exposed in public/

**`public/db_config.json`** – contains plaintext DB credentials written during installation and never deleted.
**`public/phpinfo.php`** – calls `phpinfo()` directly, exposing PHP configuration, environment variables and file paths.

**Fixes applied:**
- `phpinfo.php`: replaced with a 403 stub.
- `.htaccess`: added a `<FilesMatch>` block that denies direct HTTP access to `db_config.json`, `phpinfo.php`, `install.php`, `install-b.php` and `install_ajax.php` (Apache mod_authz_core and legacy Order/Deny syntax both covered).

---

## Validation
- `php -l` confirms no syntax errors in any of the modified PHP files.
- Hardcoded block at the HTTP layer (`.htaccess`) provides defence-in-depth independent of PHP logic.