### PR TITLE
feat(external-apps): add Marketplace discovery message next to Upload button

### DIFF
--- a/resources/views/backend/settings/external-apps/index.blade.php
+++ b/resources/views/backend/settings/external-apps/index.blade.php
@@ -6,10 +6,17 @@
 
 <div class="container-fluid">
     <div class="row mb-3">
-        <div class="col-12 d-flex justify-content-end">
-            <a href="{{ route('admin.external-apps.create') }}" class="btn btn-primary btn-sm">
-                <i class="fas fa-plus mr-1"></i>Upload New Module
-            </a>
+        <div class="col-12 d-flex align-items-center">
+            <div style="flex: 1;"></div>
+            <div class="alert alert-info mb-0 py-2 px-3" style="font-size: 0.95rem;">
+                You can download the external applications from the Marketplace:
+                <a href="https://tadreeblms.com/marketplaces" target="_blank" rel="noopener noreferrer" class="font-weight-bold">https://tadreeblms.com/marketplaces</a>
+            </div>
+            <div style="flex: 1;" class="d-flex justify-content-end">
+                <a href="{{ route('admin.external-apps.create') }}" class="btn btn-primary btn-sm">
+                    <i class="fas fa-plus mr-1"></i>Upload New Module
+                </a>
+            </div>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
## Summary

Closes #294

<img width="1611" height="472" alt="Schermata del 2026-03-15 11-35-43" src="https://github.com/user-attachments/assets/3640cac1-411c-49d5-90ce-d68a8e9f6cd9" />


Adds a visible info banner on the **Settings → External Applications** page to help administrators discover available external integrations.

## Changes

- **File:** `resources/views/backend/settings/external-apps/index.blade.php`
- Replaced the single right-aligned button row with a flex row containing:
  - A centered `alert-info` banner: *"You can download the external applications from the Marketplace: https://tadreeblms.com/marketplaces"*
  - The existing **Upload New Module** button, kept right-aligned

## Layout

```
[ You can download the external applications from... ]   [ + Upload New Module ]
```

## Testing

1. Login as Admin
2. Navigate to **Settings → External Apps**
3. Verify the blue info banner appears centered with the Marketplace link
4. Verify the **Upload New Module** button is still right-aligned and functional