### PR TITLE
fix: prevent enrollment into expired courses

### DIFF
--- a/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
+++ b/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
@@ -582,6 +582,12 @@ class AssessmentAccountsController extends Controller
         }
 
         $course = Course::find($single_course_id);
+        if (!$course) {
+            return redirect()->back()->withFlashDanger('Course not found.');
+        }
+        if ($course->expire_at && \Carbon\Carbon::parse($course->expire_at)->isPast()) {
+            return redirect()->back()->withFlashDanger('Enrollment is not allowed: this course has already expired.');
+        }
         $course_link = url("/course/$course->slug");
 
         $users = [];
@@ -763,6 +769,9 @@ class AssessmentAccountsController extends Controller
 
         if (!$course) {
             return response()->json(['error' => 'Course not found'], 404);
+        }
+        if ($course->expire_at && \Carbon\Carbon::parse($course->expire_at)->isPast()) {
+            return response()->json(['error' => 'Enrollment is not allowed: this course has already expired.'], 422);
         }
 
         $course_link = url("/course/$course->slug");

--- a/app/Http/Controllers/Backend/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Backend/Admin/EmployeeController.php
@@ -720,6 +720,8 @@ class EmployeeController extends Controller
 
     public function enrolled_student($course_id)
     {
+        $course = \App\Models\Course::findOrFail($course_id);
+
         $already_enrolled_ids = SubscribeCourse::where('course_id', $course_id)
             ->pluck('user_id')
             ->toArray();
@@ -734,10 +736,8 @@ class EmployeeController extends Controller
 
         $departments = Department::all();
 
-        return view('backend.employee.enrolled_employee', compact('course_id', 'teachers', 'departments'));
+        return view('backend.employee.enrolled_employee', compact('course_id', 'course', 'teachers', 'departments'));
     }
-
-
     public function all_enrolled_student($course_id)
     {
         //dd($course_id);

--- a/resources/views/backend/employee/enrolled_employee.blade.php
+++ b/resources/views/backend/employee/enrolled_employee.blade.php
@@ -51,9 +51,19 @@
         <h4 class="">Enrolled Trainee [{{ CustomHelper::getCourseName($course_id); }}]</h4>
     @can('course_create')
         <div class="">
-            <button type="button" class="btn btn-success" data-toggle="modal" data-target="#enrollUsersModal">
-                + Enroll Users
-            </button>
+            @php
+                $courseExpired = isset($course) && $course->expire_at && \Carbon\Carbon::parse($course->expire_at)->isPast();
+            @endphp
+            @if ($courseExpired)
+                <button type="button" class="btn btn-secondary" disabled
+                    title="Enrollment is disabled: this course has already expired.">
+                    + Enroll Users
+                </button>
+            @else
+                <button type="button" class="btn btn-success" data-toggle="modal" data-target="#enrollUsersModal">
+                    + Enroll Users
+                </button>
+            @endif
         </div>
     @endcan
 </div>


### PR DESCRIPTION
## Summary

Closes #315

Admins could enroll trainees into courses whose `expire_at` date had already passed, producing incorrect training records.

## Root Cause

No expiry check existed in any of the enrollment paths before creating a `course_assignment` record.

## Changes

### `AssessmentAccountsController`

**`course_assignment()`** — form-based bulk enrollment (Courses Management page):
```php
if ($course->expire_at && Carbon::parse($course->expire_at)->isPast()) {
    return redirect()->back()->withFlashDanger('Enrollment is not allowed: this course has already expired.');
}
```

**`direct_enroll_users()`** — AJAX modal enrollment (Enrolled Users page):
```php
if ($course->expire_at && Carbon::parse($course->expire_at)->isPast()) {
    return response()->json(['error' => 'Enrollment is not allowed: this course has already expired.'], 422);
}
```

### `EmployeeController::enrolled_student()`

Loads the `$course` model and passes it to the view so the blade can access `expire_at`.

### `enrolled_employee.blade.php`

Disables the **+ Enroll Users** button when the course is expired, giving visual feedback before the admin even opens the modal:
```blade
@if ($courseExpired)
    <button class="btn btn-secondary" disabled title="Enrollment is disabled: this course has already expired.">
        + Enroll Users
    </button>
@else
    <button class="btn btn-success" data-toggle="modal" ...>
        + Enroll Users
    </button>
@endif
```

## Testing

1. Find a course with an `expire_at` in the past
2. Open **Enrolled Users** → the **+ Enroll Users** button is greyed out / disabled
3. Attempt enrollment via the bulk assignment form → flash error is shown
4. Attempt enrollment via the AJAX modal directly → 422 JSON error returned
5. On a non-expired course → enrollment works normally