### PR TITLE
fix(#286): restore landing page routing for anonymous users

### DIFF
--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -58,25 +58,37 @@ class HomeController extends Controller
 
     
 
-    public function index()
+    public function index($page = null)
     {
-        $disabled_landing_page = CustomHelper::redirect_based_on_setting();
-        //dd( $disabled_landing_page);
-        if ($disabled_landing_page == '1' && !auth()->check() && !Route::is('frontend.auth.login')) {
+        $disabled_landing_page = (int) CustomHelper::redirect_based_on_setting();
+
+        if ($disabled_landing_page === 1 && !auth()->check() && !Route::is('frontend.auth.login')) {
             return redirect()->route('frontend.auth.login');
         }
 
-        if (request('page')) {
-            $page = \DB::table('pages')->where('slug', '=', request('page'))
-                ->where('published', '=', 1)->first();
-            if ($page != "") {
-                return view($this->path . '.pages.index', compact('page'));
+        // Use the route parameter only; query string "?page=" is reserved for pagination.
+        if (!empty($page)) {
+            $page_data = \DB::table('pages')
+                ->where('slug', '=', $page)
+                ->where('published', '=', 1)
+                ->first();
+
+            if ($page_data) {
+                return view($this->path . '.pages.index', ['page' => $page_data]);
             }
+
             abort(404);
         }
-        $type = config('theme_layout');
-        //dd($type);
+
+        $type = (string) (config('theme_layout') ?: '1');
+        if (!in_array($type, ['1', '2', '3', '4'], true)) {
+            $type = '1';
+        }
+
         $sections = Config::where('key', '=', 'layout_' . $type)->first();
+        if (!$sections && $type !== '1') {
+            $sections = Config::where('key', '=', 'layout_1')->first();
+        }
         $sections = $sections ? json_decode($sections->value): [];
 
         $our_vision = Config::where('key', '=', 'our_vision')->where('lang', config('app.locale'))->first();
@@ -174,8 +186,16 @@ class HomeController extends Controller
 
         
         $categories = Category::get();
-        return view('frontend.index-' . config('theme_layout'), compact('popular_courses', 'featured_courses', 'sponsors', 'total_students', 'total_courses', 'total_teachers', 'testimonials', 'news', 'trending_courses', 'teachers', 'faqs', 'course_categories', 'reasons', 'sections', 'categories', 'about_us', 'events', 'libraries', 'announcements', 'our_mission', 'our_vision'));
-        // return view($this->path . '.index-' . config('theme_layout'), compact('popular_courses', 'featured_courses', 'sponsors', 'total_students', 'total_courses', 'total_teachers', 'testimonials', 'news', 'trending_courses', 'teachers', 'faqs', 'course_categories', 'reasons', 'sections', 'categories','about_us','events','libraries','announcements','our_mission','our_vision'));
+
+        $landing_view = $this->path . '.index-' . $type;
+        if (!view()->exists($landing_view)) {
+            $landing_view = 'frontend.index-' . $type;
+        }
+        if (!view()->exists($landing_view)) {
+            $landing_view = 'frontend.index-1';
+        }
+
+        return view($landing_view, compact('popular_courses', 'featured_courses', 'sponsors', 'total_students', 'total_courses', 'total_teachers', 'testimonials', 'news', 'trending_courses', 'teachers', 'faqs', 'course_categories', 'reasons', 'sections', 'categories', 'about_us', 'events', 'libraries', 'announcements', 'our_mission', 'our_vision'));
     }
 
     public function getFaqs()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -115,6 +115,8 @@ class AppServiceProvider extends ServiceProvider
         if (Schema::hasTable('sliders')) {
             $slides = Slider::where('status', 1)->orderBy('sequence', 'asc')->get();
             View::share('slides', $slides);
+        } else {
+            View::share('slides', collect());
         }
 
         $disabled_landing_page = CustomHelper::redirect_based_on_setting();


### PR DESCRIPTION
## Summary

Fixes **#286** – Landing page returns 404 and redirects to dashboard even when enabled.

---

## Root Causes and Fixes

### 1. Query-string `?page=` treated as a CMS slug (→ 404)

**File:** `app/Http/Controllers/Frontend/HomeController.php`

`HomeController::index()` was reading `request('page')` to look up a CMS page by slug.
Any URL containing a page-based pagination parameter (e.g. `/?page=1`) would trigger a
database query for slug `"1"`, find nothing, and return 404.

**Fix:** the route `/{page?}` already provides the CMS slug as a route parameter.
The method signature was changed to `index($page = null)` so only an explicit
path segment (e.g. `/about-us`) is resolved as a CMS page; query-string
`?page=` values are no longer consumed by this logic.

---

### 2. `theme_layout` null/invalid → `View [frontend.index-] not found`

**File:** `app/Http/Controllers/Frontend/HomeController.php`

`config('theme_layout')` can be `null` or an arbitrary string when the database
is fresh or the config row is missing. The old code built the view name directly
from that value (`frontend.index-{value}`), which would throw a
*View not found* exception.

**Fix:**
- Cast the value to a string and fall back to `'1'` when absent or outside
  the valid range `['1','2','3','4']`.
- Resolve the view through a three-step fallback chain:
  1. `$path.index-{type}` (honours the RTL session path)
  2. `frontend.index-{type}`
  3. `frontend.index-1` (guaranteed to exist)

---

### 3. `$slides` undefined when `sliders` table is absent

**File:** `app/Providers/AppServiceProvider.php`

Layout templates reference the shared `$slides` variable. When the
`sliders` table does not yet exist (e.g. during a fresh install),
the `else` branch was missing and templates crashed.

**Fix:** share `collect()` (an empty collection) as a safe fallback.

---

### 4. Toggle comparison edge-case

The landing-page toggle value arrives from the database as a string.
The old loose comparison (`== '1'`) could silently misfire.
The value is now cast to `int` and compared strictly (`=== 1`).

---

## Files Changed

| File | Change |
|---|---|
| `app/Http/Controllers/Frontend/HomeController.php` | Route-param CMS lookup, theme-layout sanitisation, view fallback chain, strict toggle comparison |
| `app/Providers/AppServiceProvider.php` | Empty-collection fallback for `$slides` |

---

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| Root URL `/` loads landing page when enabled (toggle = 0) | ✅ returns HTTP 200, no redirect |
| Root URL `/` redirects to `/login` when disabled (toggle = 1) | ✅ returns HTTP 302 → /login |
| No 404 on `/?page=1` | ✅ pagination params no longer resolved as CMS slugs |
| No dashboard redirect for guest users when landing is enabled | ✅ confirmed via curl end-to-end |

---

## Testing

```bash
# 1. Landing enabled
php artisan tinker --execute='App\Models\Config::updateOrCreate(["key"=>"landing_page_toggle"],["value"=>0]);'
curl -o /dev/null -w '%{http_code} %{redirect_url}\n' http://127.0.0.1:8000/
# Expected: 200 (empty redirect)

# 2. Landing disabled
php artisan tinker --execute='App\Models\Config::updateOrCreate(["key"=>"landing_page_toggle"],["value"=>1]);'
curl -o /dev/null -w '%{http_code} %{redirect_url}\n' http://127.0.0.1:8000/
# Expected: 302 http://127.0.0.1:8000/login

# 3. Pagination param no longer causes 404
curl -o /dev/null -w '%{http_code}\n' 'http://127.0.0.1:8000/?page=1'
# Expected: 200
```