### PR TITLE
feat: add marketplace integration for external apps

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ExternalAppsController.php
+++ b/app/Http/Controllers/Backend/Admin/ExternalAppsController.php
@@ -6,8 +6,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\EnvManagerTrait;
 use App\Models\ExternalApp;
 use App\Services\ExternalApps\ExternalAppService;
+use App\Services\MarketplaceService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Http;
 
 class ExternalAppsController extends Controller
 {
@@ -24,15 +26,16 @@ class ExternalAppsController extends Controller
     /**
      * Display a listing of external apps
      */
-    public function index()
+    public function index(MarketplaceService $marketplaceService)
     {
         if (!auth()->user()->isAdmin()) {
             return abort(403);
         }
 
         $apps = $this->externalAppService->getInstalledApps();
+        $marketplaceApps = $marketplaceService->getApps();
 
-        return view('backend.settings.external-apps.index', compact('apps'));
+        return view('backend.settings.external-apps.index', compact('apps', 'marketplaceApps'));
     }
 
     /**
@@ -214,6 +217,68 @@ class ExternalAppsController extends Controller
             return response()->json([
                 'success' => false,
                 'message' => 'Error uninstalling module: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function installFromMarketplace(Request $request)
+    {
+        if (!auth()->user()->isAdmin()) {
+            return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
+        }
+
+        $request->validate([
+            'download_url' => 'required|url',
+            'name' => 'nullable|string|max:255',
+        ]);
+
+        try {
+            $downloadUrl = $request->input('download_url');
+            $moduleName = $request->input('name', 'module');
+
+            $response = Http::timeout(120)->get($downloadUrl);
+
+            if (! $response->successful()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Failed to download module package.',
+                ], 422);
+            }
+
+            $tempDir = storage_path('app/temp-marketplace');
+            if (!is_dir($tempDir)) {
+                mkdir($tempDir, 0755, true);
+            }
+
+            $safeName = preg_replace('/[^A-Za-z0-9\-_]/', '-', $moduleName);
+            $tempPath = $tempDir . '/' . $safeName . '-' . time() . '.zip';
+
+            file_put_contents($tempPath, $response->body());
+
+            $uploadedFile = new \Illuminate\Http\UploadedFile(
+                $tempPath,
+                basename($tempPath),
+                'application/zip',
+                null,
+                true
+            );
+
+            $result = $this->externalAppService->uploadAndInstall($uploadedFile, basename($tempPath));
+
+            if (file_exists($tempPath)) {
+                @unlink($tempPath);
+            }
+
+            return response()->json($result);
+        } catch (\Throwable $e) {
+            Log::error('Marketplace install failed', [
+                'error' => $e->getMessage(),
+                'download_url' => $request->input('download_url'),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Error installing module: ' . $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Services/MarketplaceService.php
+++ b/app/Services/MarketplaceService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class MarketplaceService
+{
+    public function getApps(): array
+    {
+        return Cache::remember('marketplace_apps', 300, function () {
+            $response = Http::timeout(10)->get('http://localhost:3000/marketplaces/apps.json');
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            $data = $response->json();
+
+            return is_array($data) ? $data : [];
+        });
+    }
+}

--- a/resources/views/backend/settings/external-apps/index.blade.php
+++ b/resources/views/backend/settings/external-apps/index.blade.php
@@ -4,12 +4,145 @@
 
 @section('content')
 
+@php
+    $installedSlugs = collect($apps ?? [])
+        ->pluck('slug')
+        ->map(function ($slug) {
+            return str_replace('_', '-', strtolower(trim($slug)));
+        })
+        ->toArray();
+@endphp
+
 <div class="container-fluid">
+    <div id="externalAppsAlerts"></div>
     <div class="row mb-3">
         <div class="col-12 d-flex justify-content-end">
             <a href="{{ route('admin.external-apps.create') }}" class="btn btn-primary btn-sm">
                 <i class="fas fa-plus mr-1"></i>Upload New Module
             </a>
+        </div>
+    </div>
+    <!-- <div class="alert alert-info d-flex justify-content-between align-items-center mb-3" role="alert">
+        <span>
+            <i class="fas fa-info-circle mr-2"></i>
+            Explore additional external applications from the Marketplace.
+        </span>
+        <a href="https://tadreeblms.com/marketplaces"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-sm btn-outline-primary">
+            View Marketplace
+        </a>
+    </div> -->
+    <div class="card mt-4">
+        <div class="alert alert-info d-flex justify-content-between align-items-center"
+            data-toggle="collapse"
+            data-target="#marketplaceCollapse"
+            aria-expanded="false"
+            aria-controls="marketplaceCollapse"
+            id="marketplaceHeader"
+            style="cursor:pointer;">
+            <div class="d-flex align-items-center">
+                <!-- <strong>Marketplace</strong> -->
+                <i class="fas fa-info-circle text-info mr-2"></i>
+                <div class="text-inherit large">
+                    Explore external applications available in the marketplace.
+                </div>
+            </div>
+
+            <!-- <button class="btn btn-sm btn-outline-primary"
+                    type="button"
+                    data-toggle="collapse"
+                    data-target="#marketplaceCollapse"
+                    aria-expanded="false"
+                    aria-controls="marketplaceCollapse"
+                    id="marketplaceToggleBtn">
+                Show Marketplace ▼
+            </button> -->
+            <i class="fas fa-chevron-down" id="marketplaceArrow"></i>
+        </div>
+
+        <!-- <div class="collapse" id="marketplaceCollapse">
+            <div class="card-body p-0">
+                <iframe
+                    src="https://tadreeblms.com/marketplaces/"
+                    width="100%"
+                    height="700"
+                    style="border: 1px solid #bee5eb;"
+                    loading="lazy">
+                </iframe>
+            </div>
+        </div> -->
+        <div class="collapse" id="marketplaceCollapse">
+            <div class="card-body">
+                <div class="row">
+                    @forelse($marketplaceApps ?? [] as $marketplaceApp)
+                    @php
+                        $marketplaceSlug = basename($marketplaceApp['slug'] ?? '');
+                        $marketplaceSlug = str_replace('_', '-', strtolower(trim($marketplaceSlug)));
+                        $isInstalled = in_array($marketplaceSlug, $installedSlugs);
+                    @endphp
+                        <div class="col-md-4 mb-3">
+                            <div class="card h-100 shadow-sm">
+                                <div class="card-body d-flex flex-column text-center">
+                                    @if(!empty($marketplaceApp['icon']))
+                                        <img
+                                            src="{{ 'http://localhost:3000' . $marketplaceApp['icon'] }}"
+                                            alt="{{ $marketplaceApp['name'] }}"
+                                            style="height:80px; width:auto; object-fit:contain; margin: 0 auto 15px;"
+                                        >
+                                    @endif
+
+                                    <h5 class="mb-2">{{ $marketplaceApp['name'] }}</h5>
+
+                                    @if(!empty($marketplaceApp['summary']))
+                                        <p class="text-muted flex-grow-1">
+                                            {{ $marketplaceApp['summary'] }}
+                                        </p>
+                                    @endif
+
+                                    @if(!empty($marketplaceApp['version']))
+                                        <p class="small text-muted mb-2">
+                                            Version: {{ $marketplaceApp['version'] }}
+                                        </p>
+                                    @endif
+
+                                    <div class="d-flex justify-content-center mt-auto mb-3">
+                                        @if(!empty($marketplaceApp['details_url']))
+                                            <a href="{{ 'http://localhost:3000' . $marketplaceApp['details_url'] }}"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            class="btn btn-sm btn-primary mr-2">
+                                                View Details
+                                            </a>
+                                        @endif
+
+                                        <!-- Installed State -->
+                                        @if($isInstalled)
+                                            <span class="badge badge-success align-self-center px-3 py-2">
+                                                Installed
+                                            </span>
+                                        @else
+                                            <button type="button"
+                                                    class="btn btn-sm btn-primary install-marketplace-app"
+                                                    data-name="{{ $marketplaceApp['name'] }}"
+                                                    data-download-url="{{ $marketplaceApp['download_url'] }}">
+                                                Install
+                                            </button>
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="col-12">
+                            <div class="alert alert-light mb-0">
+                                No marketplace applications are available right now.
+                            </div>
+                        </div>
+                    @endforelse
+                </div>
+            </div>
         </div>
     </div>
     <div class="row">
@@ -258,6 +391,54 @@ $(document).ready(function() {
             }
         });
     });
+
+    $('#marketplaceCollapse').on('show.bs.collapse', function () {
+    $('#marketplaceArrow')
+        .removeClass('fa-chevron-down')
+        .addClass('fa-chevron-up');
+    });
+
+    $('#marketplaceCollapse').on('hide.bs.collapse', function () {
+        $('#marketplaceArrow')
+            .removeClass('fa-chevron-up')
+            .addClass('fa-chevron-down');
+    });
+
+    $('.install-marketplace-app').on('click', function() {
+        const $btn = $(this);
+        const downloadUrl = $btn.data('download-url');
+        const name = $btn.data('name');
+
+        $btn.prop('disabled', true).text('Installing...');
+
+        $.ajax({
+            url: '/user/external-apps/install-from-marketplace',
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            },
+            data: {
+                download_url: downloadUrl,
+                name: name
+            },
+            success: function(response) {
+                if (response.success) {
+                    showAlert(response.message || 'Module installed successfully.', 'success');
+                    setTimeout(function() {
+                        location.reload();
+                    }, 1500);
+                } else {
+                    showAlert(response.message || 'Installation failed.', 'error');
+                    $btn.prop('disabled', false).text('Install');
+                }
+            },
+            error: function(xhr) {
+                const response = xhr.responseJSON || {};
+                showAlert(response.message || 'An error occurred during installation.', 'error');
+                $btn.prop('disabled', false).text('Install');
+            }
+        });
+    });
 });
 
 function showAlert(message, type) {
@@ -273,7 +454,8 @@ function showAlert(message, type) {
         </div>
     `;
 
-    $('.card-body').prepend(alertHtml);
+    // $('.card-body').prepend(alertHtml);
+    $('#externalAppsAlerts').prepend(alertHtml);
 
     setTimeout(() => {
         $('.card-body .alert').fadeOut(function() {

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -206,6 +206,9 @@ Route::group(['middleware' => 'permission:trainer_access'], function () {
     Route::get('external-apps/{slug}/configure', ['uses' => 'Admin\ExternalAppsController@editConfig', 'as' => 'external-apps.edit-config']);
     Route::post('external-apps/{slug}/configure', ['uses' => 'Admin\ExternalAppsController@updateConfig', 'as' => 'external-apps.update-config']);
     Route::delete('external-apps/{slug}', ['uses' => 'Admin\ExternalAppsController@destroy', 'as' => 'external-apps.destroy']);
+    
+    //===== Install From Marketplace Routes =====//
+    Route::post('external-apps/install-from-marketplace', [ 'uses' => 'Admin\ExternalAppsController@installFromMarketplace', 'as'   => 'external-apps.install-from-marketplace']);
 
     //===== S3 Storage Settings =====//
     Route::get('s3-storage-settings', ['uses' => 'Admin\S3StorageSettingsController@index', 'as' => 's3-storage-settings']);


### PR DESCRIPTION
## Feature: Marketplace Integration for External Apps

### 📌 Overview

This PR introduces a **Marketplace integration** inside the External Apps section, allowing users to:

* Discover available integrations (Google Meet, Microsoft Teams, Zoom)
* View detailed documentation via Docusaurus
* Install modules directly from the UI
* See real-time **Installed state** for each module

---

### ✨ Key Features

#### 1. Marketplace UI (Laravel Blade)

* Added marketplace section with collapsible view
* Displays:

  * Icon
  * Name
  * Summary
  * Version
* Actions:

  * **View Details** → Opens documentation page
  * **Install** → Installs module via API
  * **Installed badge** → Shown if already installed

---

#### 2. Installed State Handling

* Dynamically maps installed modules using:

  ```php
  $installedSlugs = collect($apps)
      ->pluck('slug')
      ->map(fn($slug) => str_replace('_', '-', strtolower(trim($slug))))
      ->toArray();
  ```

* Marketplace slugs are normalized before comparison:

  ```php
  $marketplaceSlug = str_replace('_', '-', strtolower(trim($marketplaceApp['slug'])));
  ```

* Ensures consistent matching between:

  * DB stored slugs
  * Marketplace slugs

---

#### 3. Installation Flow

* Clicking **Install**:

  * Calls:

    ```
    POST /user/external-apps/install-from-marketplace
    ```
  * Downloads module via `download_url`
  * Installs automatically
  * Reloads UI and updates state

---

#### 4. Docusaurus Documentation Integration

* Each module includes a `details_url`

* Clicking **View Details** redirects to:

  ```
  /docs/marketplaces/{module-slug}
  ```

* Currently using local setup:

  ```
  http://localhost:3000
  ```

---

### ⚙️ Setup Instructions (Important)

To enable marketplace documentation on your environment:

#### 1. Setup Docusaurus Docs

* Create or use an existing Docusaurus project
* Add docs under:

  ```
  /docs/marketplaces/
  ```

#### 2. Example Module Structure

```json
{
    "name": "Google Meet Integration",
    "slug": "/marketplaces/google-meet-integration",
    "version": "1.0.0",
    "summary": "Google Meet integration for live-online classes and virtual meetings.",
    "icon": "/img/marketplace/googlemeet.png",
    "details_url": "/docs/marketplaces/google-meet-integration",
    "download_url": "https://tadreeblms-releases.s3.ap-south-1.amazonaws.com/market-place/Google-Integration-main.zip",
    "category": "Video Conferencing",
    "status": "active"
  }
```

---

#### 3. Configure Base URL

Replace hardcoded localhost with env config:

```env
MARKETPLACE_DOCS_URL=http://localhost:3000
```

Then use:

```php
config('app.marketplace_docs_url')
```

---

#### 4. CORS (if hosted separately)

If docs are hosted on another domain:

* Enable CORS
* Allow iframe or external navigation

---

### 🧠 Notes / Considerations

* Slug normalization is required to avoid mismatch between:

  * `google_meet` vs `google-meet`
* UI reflects installation state based on DB records
* Alerts are now scoped properly (no duplication issue)

---

### 📸 Screenshots

* Marketplace UI with Installed state
* Successful installation flow
* Docusaurus documentation page

---

### ✅ Status

✔ Feature complete
✔ Installed state working for all modules
✔ Alerts fixed (no duplication)
✔ Ready for review

---

### 🙌 Request for Review

@furkhanfathani @Zhey-on
Please review the implementation and let me know if any changes are required.

---

### ❓ Question

Currently using a **local Docusaurus setup** (`localhost:3000`).
Please confirm:

* Do we have a hosted docs URL to use?
* Or should I include the Docusaurus project setup in this repo?

Happy to adjust accordingly.
