### PR TITLE
fix: installer no longer crashes php artisan serve due to missing .env

### DIFF
--- a/public/install-b.php
+++ b/public/install-b.php
@@ -32,16 +32,18 @@ if ($step === 'start') {
     // Recreate empty db_config.json
     file_put_contents(__DIR__ . '/db_config.json', '{}');
 
-    // Recreate fresh .env from .env.example
+    // Recreate fresh .env from .env.example using an atomic rename so the file
+    // is never absent — preventing filemtime() crashes in `php artisan serve`.
     $envFile = $basePath . '/.env';
+    $tmpEnvFile = $envFile . '.tmp';
     $example = $basePath . '/.env.example';
-    if (file_exists($envFile)) unlink($envFile);
 
-    if (file_exists($example)) {
-        copy($example, $envFile);
-    } else {
-        // emergency fallback
-        file_put_contents($envFile, '');
+    $envContent = file_exists($example) ? file_get_contents($example) : '';
+    if (file_put_contents($tmpEnvFile, $envContent, LOCK_EX) !== false) {
+        rename($tmpEnvFile, $envFile);
+    } elseif (!file_exists($envFile)) {
+        // Fallback: create an empty .env only if none exists yet
+        file_put_contents($envFile, '', LOCK_EX);
     }
 
     // Log reset

--- a/public/install_ajax.php
+++ b/public/install_ajax.php
@@ -138,7 +138,6 @@ try {
         | CHECK SYSTEM
         */
         case 'check':
-            @unlink($envFile);
             @unlink($dbConfigFile);
             @unlink($migrationDoneFile);
             @unlink($seedDoneFile);
@@ -245,42 +244,112 @@ try {
         | ENV SETUP
         */
         case 'env':
-            if (!file_exists($dbConfigFile)) fail("DB config missing");
+            // Ensure DB config file exists
+            if (!file_exists($dbConfigFile)) {
+                fail("DB config missing");
+            }
+
+            // Load DB configuration
             $config = json_decode(file_get_contents($dbConfigFile), true);
+            if (!is_array($config)) {
+                fail("Invalid DB config");
+            }
 
-            if (!file_exists($basePath . '/.env.example')) fail(".env.example not found");
-            if (!file_exists($envFile)) copy($basePath . '/.env.example', $envFile);
-            if (!is_writable($envFile)) fail(".env not writable. Run: sudo chown \$USER:www-data $envFile && sudo chmod 664 $envFile");
+            // Ensure .env.example exists
+            $envExample = $basePath . '/.env.example';
+            if (!file_exists($envExample)) {
+                fail(".env.example not found");
+            }
 
+            // Create .env only if it does not exist (DO NOT delete existing .env)
+            if (!file_exists($envFile)) {
+                if (!copy($envExample, $envFile)) {
+                    fail("Failed to create .env from .env.example");
+                }
+            }
+
+            // Validate file readability and writability
+            if (!is_readable($envFile)) {
+                fail(".env not readable");
+            }
+
+            if (!is_writable($envFile)) {
+                fail(".env not writable. Run: sudo chown \$USER:www-data $envFile && sudo chmod 664 $envFile");
+            }
+
+            // Read current .env content
             $env = file_get_contents($envFile);
-            $env = preg_replace('/DB_HOST=.*/', 'DB_HOST=' . $config['host'], $env);
-            $env = preg_replace('/DB_DATABASE=.*/', 'DB_DATABASE=' . $config['database'], $env);
-            $env = preg_replace('/DB_USERNAME=.*/', 'DB_USERNAME=' . $config['username'], $env);
-            $env = preg_replace('/DB_PASSWORD=.*/', 'DB_PASSWORD="' . $config['password'] . '"', $env);
-            
-            // Add KEYGEN credentials
-            //$env .= "\nKEYGEN_ACCOUNT_ID=\"20586e9c-e2e3-4347-afec-9d58b919fd0b\"";
-            //env .= "\nKEYGEN_PRODUCT_ID=\"073428fb-f67c-4f39-8081-6f5c8890051e\"";
-            //env .= "\nKEYGEN_API_TOKEN=\"admin-b63462006f5c936ac08de5322b8b1ba20dbfd738d6ff8cb868b5249a7b442d29v3\"\n";
+            if ($env === false) {
+                fail("Failed to read .env");
+            }
+
+            // Prepare DB values
+            $replacements = [
+                'DB_HOST'     => $config['host'] ?? '',
+                'DB_DATABASE' => $config['database'] ?? '',
+                'DB_USERNAME' => $config['username'] ?? '',
+                'DB_PASSWORD' => $config['password'] ?? '',
+            ];
+
+            // Update or append DB variables safely
+            foreach ($replacements as $key => $value) {
+
+                // Escape password properly
+                $escapedValue = ($key === 'DB_PASSWORD')
+                    ? '"' . addcslashes($value, "\\\"") . '"'
+                    : $value;
+
+                // If key exists, replace it; otherwise append it
+                if (preg_match('/^' . preg_quote($key, '/') . '=.*$/m', $env)) {
+                    $env = preg_replace(
+                        '/^' . preg_quote($key, '/') . '=.*$/m',
+                        $key . '=' . $escapedValue,
+                        $env
+                    );
+                } else {
+                    $env .= "\n" . $key . '=' . $escapedValue;
+                }
+            }
+
+            // Append KEYGEN variables only if not already present
             if (strpos($env, 'KEYGEN_ACCOUNT_ID=') === false) {
                 $env .= "\nKEYGEN_ACCOUNT_ID=\"20586e9c-e2e3-4347-afec-9d58b919fd0b\"";
             }
+
             if (strpos($env, 'KEYGEN_PRODUCT_ID=') === false) {
                 $env .= "\nKEYGEN_PRODUCT_ID=\"073428fb-f67c-4f39-8081-6f5c8890051e\"";
             }
+
             if (strpos($env, 'KEYGEN_API_TOKEN=') === false) {
                 $env .= "\nKEYGEN_API_TOKEN=\"admin-b63462006f5c936ac08de5322b8b1ba20dbfd738d6ff8cb868b5249a7b442d29v3\"";
             }
 
-            // External module integration flags (false by default; set to true when module is installed & configured)
+            // Add integration flags if missing
             if (strpos($env, 'ZOOM_INTEGRATION=') === false) {
                 $env .= "\nZOOM_INTEGRATION=false";
             }
 
+            // Ensure file ends with newline
             $env .= "\n";
-            file_put_contents($envFile, $env);
 
-            echo json_encode(['message' => '.env created ✔', 'next' => 'key']);
+            // Write .env atomically to avoid race conditions (important for artisan serve)
+            $tmpEnvFile = $envFile . '.tmp';
+
+            if (file_put_contents($tmpEnvFile, $env, LOCK_EX) === false) {
+                fail("Failed to write temporary .env");
+            }
+
+            // Replace original .env with the new one
+            if (!rename($tmpEnvFile, $envFile)) {
+                @unlink($tmpEnvFile);
+                fail("Failed to replace .env");
+            }
+
+            echo json_encode([
+                'success' => true,
+                'message' => '.env created ✔',
+                'next' => 'key'
+            ]);
             exit;
 
             /*


### PR DESCRIPTION
## Summary

Fixes #345.

`php artisan serve` monitors `.env` via `filemtime()` and crashes immediately if the file disappears, even for a fraction of a second. The installer had three separate places where this could happen.

---

## Changes

### `public/install-b.php` — start step
Replaced the `unlink()` + `copy()` two-step with an atomic **write-to-temp + `rename()`** pattern. The file is now never absent between resets.

**Before:**
```php
if (file_exists($envFile)) unlink($envFile);
if (file_exists($example)) {
    copy($example, $envFile);
} else {
    file_put_contents($envFile, '');
}
```

**After:**
```php
$envContent = file_exists($example) ? file_get_contents($example) : '';
if (file_put_contents($tmpEnvFile, $envContent, LOCK_EX) !== false) {
    rename($tmpEnvFile, $envFile);
    file_put_contents($envFile, '', LOCK_EX);
}
```

---

### `public/install_ajax.php` — check step
Removed the unconditional `@unlink($envFile)` that wiped `.env` at the start of every check run, with no benefit.

---

### `public/install_ajax.php` — env step
- `.env` is now created from `.env.example` only if it does not already exist — never deleted.
- Readability and writability are validated before any write is attempted.
- DB key substitution now uses a per-key regex with an append-if-missing fallback, and passwords are properly escaped (fixing silent breakage for passwords containing `"` or `\`).
- Final write is atomic: content goes to `.env.tmp` first, then `rename()` replaces `.env` in one syscall.

---

## Testing

1. Start `php artisan serve`
2. Navigate to `/install.php` and run through all installation steps
3. Server should remain running throughout; no `filemtime(): stat failed` error