### PR TITLE
Add required indicator (*) to Marks field across all question types

### DIFF
--- a/resources/views/backend/test_question_setup/multiple_choice.blade.php
+++ b/resources/views/backend/test_question_setup/multiple_choice.blade.php
@@ -17,8 +17,8 @@
 </div>
 <div class="row">
     <div class="col-12 child">
-        <label>Marks</label>
-        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required />
+        <label>Marks <span style="color:red">*</span></label>
+        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required oninvalid="this.setCustomValidity('Marks is required')" oninput="this.setCustomValidity('')"/>
     </div>
 </div>
 <div class="row">

--- a/resources/views/backend/test_question_setup/short_answer.blade.php
+++ b/resources/views/backend/test_question_setup/short_answer.blade.php
@@ -7,8 +7,8 @@
 </div>
 <div class="row">
     <div class="col-12 child">
-        <label>Marks</label>
-        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required />
+        <label>Marks <span style="color:red">*</span></label>
+        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required oninvalid="this.setCustomValidity('Marks is required')" oninput="this.setCustomValidity('')"/>
     </div>
 </div>
 <div class="row">

--- a/resources/views/backend/test_question_setup/single_choice.blade.php
+++ b/resources/views/backend/test_question_setup/single_choice.blade.php
@@ -17,8 +17,8 @@
 </div>
 <div class="row">
     <div class="col-12 child">
-        <label>Marks</label>
-        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required />
+        <label>Marks <span style="color:red">*</span></label>
+        <input type="number" class="form-control" name="marks" id="marks" placeholder="Enter Marks" required oninvalid="this.setCustomValidity('Marks is required')" oninput="this.setCustomValidity('')"/>
     </div>
 </div>
 <div class="row">

--- a/resources/views/backend/test_questions/create.blade.php
+++ b/resources/views/backend/test_questions/create.blade.php
@@ -452,8 +452,8 @@
 
         <div class="row">
           <div class="col-12 col-md-6 mt-3 notextarea"> 
-                <label>Question</label>
-                <textarea class="form-control editor" rows="3" name="question" id="question" required="required" data-collapsible-toolbar="1"></textarea>
+                <label>Question <span style="color:red">*</span></label>
+                <textarea class="form-control editor" rows="3" name="question" id="question" required="required" data-collapsible-toolbar="1" oninvalid="this.setCustomValidity('Question is required')" oninput="this.setCustomValidity('')"></textarea>
             </div>
          
                 <div class="col-12 col-md-6"> 


### PR DESCRIPTION
## 🔧 Description

This PR adds a visual required indicator (*) to the **Marks** field across all question types (Single Question, MCQ, Short Answer) to improve user experience and form clarity.

Previously, the Marks field was marked as required in the backend but did not have any visible indicator on the UI, which could confuse users.

Additionally, client-side validation messages were added to improve feedback when the field is left empty. The **Question** field was also aligned with the same required field pattern to maintain UI consistency.

Fixes: #372 

---

## ✅ Type of Change

* [x] 🐞 Bug fix
* [x] 🎨 UI/UX update

---

## 📸 Screenshots

### Before

❌ Marks field without required indicator

## <img width="564" height="94" alt="{30B3AB28-ACE8-475B-B8DE-F2C5B576769C}" src="https://github.com/user-attachments/assets/f25433ce-45af-4900-aca7-1e504dacf50f" />

## <img width="740" height="71" alt="{BBC092E8-4211-46F8-BCF3-49AB679D45FE}" src="https://github.com/user-attachments/assets/350a8892-30ca-4b7a-8930-a3013b78f73e" />

*Make changes across short answer, single answer, and multiple choices*

### After

✅ Marks field with required (*) indicator

## <img width="542" height="77" alt="{1F8D4132-8DD4-4376-97FC-704CB46EEE8F}" src="https://github.com/user-attachments/assets/25ab960c-963f-4027-95f5-a80fd998aa59" />


## <img width="665" height="78" alt="{32C58E72-C926-4691-A306-2DDF321C9721}" src="https://github.com/user-attachments/assets/3654cd84-51b9-478f-a418-8c2fbde50a87" />


---

## 🚀 How Has This Been Tested?

* [x] Local environment
* [x] Browser testing

**Details:**

* Verified required indicator (*) appears correctly across all question types
* Tested form submission without entering Marks → validation message is shown
* Confirmed no changes in backend functionality

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to the question creation form
2. Leave the Marks field empty
3. Observe that previously no required indicator was shown
4. After fix, the field clearly shows (*) and validation message appears on submit

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Ensured UI consistency with other required fields
* [ ] Updated documentation (not required)
* [ ] Added/Updated tests (not applicable)
* [x] Verified no sensitive data is included
* [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

* Applied changes consistently across all question types (Single, MCQ, Short Answer)
* Maintained existing backend logic and focused only on UI/UX improvements
