### PR TITLE
fix(messages): prevent /user/messages crash when chat is disabled

### DIFF
--- a/app/Http/Controllers/Backend/MessagesController.php
+++ b/app/Http/Controllers/Backend/MessagesController.php
@@ -16,9 +16,9 @@ class MessagesController extends Controller
     {
         // Chat functionality disabled due to missing package
         return view('backend.messages.index-desktop', [
-            'threads' => [],
+            'threads' => collect(),
             'teachers' => [],
-            'thread' => ""
+            'thread' => null,
         ]);
     }
 

--- a/resources/views/backend/messages/index-desktop.blade.php
+++ b/resources/views/backend/messages/index-desktop.blade.php
@@ -50,13 +50,13 @@
                             </div>
                         </div>
                         <div class="inbox_chat">
-                            @if($threads->count() > 0)
+                            @if(collect($threads)->count() > 0)
                                 @foreach($threads as $item)
                                     @if($item->latestMessage)
                                         <a class="@if($item->userUnreadMessagesCount(auth()->user()->id)) unread
                                             @endif" href="{{route('admin.messages').'?thread='.$item->id}}">
                                             <div data-thread="{{$item->id}}"
-                                                 class="chat_list @if(($thread != "") && ($thread->id == $item->id))  active_chat @endif" >
+                                                 class="chat_list @if(!empty($thread) && ($thread->id == $item->id))  active_chat @endif" >
                                                 <div class="chat_people">
 
                                                     <div class="chat_ib">
@@ -81,7 +81,7 @@
                             @endif
                         </div>
                     </div>
-                    @if(request()->has('thread'))
+                    @if(request()->has('thread') && !empty($thread))
                         <form method="post" action="{{route('admin.messages.reply')}}">
                             @csrf
 

--- a/resources/views/backend/messages/index-mobile.blade.php
+++ b/resources/views/backend/messages/index-mobile.blade.php
@@ -55,13 +55,13 @@
                             </div>
                         </div>
                         <div class="inbox_chat">
-                            @if($threads->count() > 0)
+                            @if(collect($threads)->count() > 0)
                                 @foreach($threads as $item)
                                     @if($item->latestMessage)
                                         <a  href="{{route('admin.messages').'?thread='.$item->id}}" class="@if($item->userUnreadMessagesCount(auth()->user()->id)) unread
                                             @endif">
                                             <div data-thread="{{$item->id}}"
-                                                 class="chat_list @if(($thread != "") && ($thread->id == $item->id))  active_chat @endif ">
+                                                 class="chat_list @if(!empty($thread) && ($thread->id == $item->id))  active_chat @endif ">
                                                 <div class="chat_people">
 
                                                     <div class="chat_ib">
@@ -84,7 +84,7 @@
                             @endif
                         </div>
                     </div>
-                    @if(request()->has('thread'))
+                    @if(request()->has('thread') && !empty($thread))
                         <form method="post" class="compose-reply" action="{{route('admin.messages.reply')}}">
                             @csrf
 


### PR DESCRIPTION
## Summary

This PR fixes a crash on `/user/messages` when chat is disabled.

## Changes

- return `threads` as an empty collection in `MessagesController@index`
- use safe checks in desktop/mobile message views for thread count and active thread state
- avoid rendering thread details when `thread` is missing

## Result

The page no longer throws `Call to a member function count() on array`.

Closes #389
