### PR TITLE
BUG - Lesson Edit: linked video not visible and Vimeo preview fails

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -348,35 +348,45 @@ class LessonsController extends Controller
                 $lesson->lesson_start_date = !empty($rawLessonStartDate) ? date('Y-m-d H:i', strtotime($rawLessonStartDate)) : null;
                 $lesson->save();
 
-                // Save videos for this specific lesson
-                $lessonVideosRaw = $request->input("videos.$i", []);
-                if (empty($lessonVideosRaw)) {
-                    $lessonVideosRaw = $request->input('videos.' . ($i + 1), []);
-                }
-
+                // Save videos for this specific lesson.
+                // The create form uses a global videoIndex (0, 1, 2...) across all videos.
+                // For a single lesson all submitted videos belong to this lesson, so collect
+                // every valid entry from videos[]. For bulk lesson creation keep the existing
+                // lesson-index based mapping.
+                $singleVideoKeys = ['title', 'type', 'url', 'is_preview', 'file'];
                 $lessonVideos = [];
-                if (is_array($lessonVideosRaw) && !empty($lessonVideosRaw)) {
-                    $singleVideoKeys = ['title', 'type', 'url', 'is_preview', 'file'];
-                    $looksLikeSingleVideo = count(array_intersect($singleVideoKeys, array_keys($lessonVideosRaw))) > 0;
 
-                    if ($looksLikeSingleVideo) {
-                        $lessonVideos = [$lessonVideosRaw];
-                    } else {
-                        $lessonVideos = $lessonVideosRaw;
+                if ($count == 1) {
+                    foreach ($request->input('videos', []) as $vIdx => $vData) {
+                        if (is_array($vData) && count(array_intersect($singleVideoKeys, array_keys($vData))) > 0) {
+                            $lessonVideos[$vIdx] = $vData;
+                        }
+                    }
+                } else {
+                    $lessonVideosRaw = $request->input("videos.$i", []);
+                    if (empty($lessonVideosRaw)) {
+                        $lessonVideosRaw = $request->input('videos.' . ($i + 1), []);
+                    }
+                    if (is_array($lessonVideosRaw) && !empty($lessonVideosRaw)) {
+                        $looksLikeSingleVideo = count(array_intersect($singleVideoKeys, array_keys($lessonVideosRaw))) > 0;
+                        if ($looksLikeSingleVideo) {
+                            $lessonVideos[$i] = $lessonVideosRaw;
+                        } else {
+                            $lessonVideos = $lessonVideosRaw;
+                        }
                     }
                 }
 
                 if (count($lessonVideos) > 0) {
                     $sortOrder = 0;
-                    foreach ($lessonVideos as $index => $video) {
+                    foreach ($lessonVideos as $vIdx => $video) {
                         if (!is_array($video)) {
                             continue;
                         }
 
                         $filePath = null;
-                        $fileInputPath = "videos.$i.$index.file";
-                        if ($request->hasFile($fileInputPath)) {
-                            $filePath = $request->file($fileInputPath)
+                        if ($request->hasFile("videos.$vIdx.file")) {
+                            $filePath = $request->file("videos.$vIdx.file")
                                 ->store('lesson_videos', 'public');
                         }
 

--- a/resources/views/backend/lessons/edit.blade.php
+++ b/resources/views/backend/lessons/edit.blade.php
@@ -323,6 +323,26 @@
                 </div>
             @endif
 
+            @if($video->type == 'vimeo' && $video->url)
+                @php
+                    $vimeoUrl = trim((string) $video->url);
+                    $vimeoEmbedUrl = null;
+                    if (preg_match('#(?:vimeo\.com/(?:video/|channels/[^/]+/|groups/[^/]+/videos/|album/[^/]+/video/)?|player\.vimeo\.com/video/)(\d+)#i', $vimeoUrl, $vm)) {
+                        $vimeoEmbedUrl = 'https://player.vimeo.com/video/' . $vm[1];
+                    }
+                @endphp
+                @if($vimeoEmbedUrl)
+                    <div class="mt-3">
+                        <iframe width="420" height="250"
+                            src="{{ $vimeoEmbedUrl }}"
+                            frameborder="0"
+                            allow="autoplay; fullscreen; picture-in-picture"
+                            allowfullscreen>
+                        </iframe>
+                    </div>
+                @endif
+            @endif
+
             <label class="mt-2">
                 <input type="checkbox" name="videos[{{ $index }}][is_preview]" value="1" {{ $video->is_preview ? 'checked' : '' }}>
                 Preview Video


### PR DESCRIPTION
📥 Pull Request Template
🔧 Description

This PR fixes an issue where Vimeo linked videos were not stored correctly during lesson creation and were not visible as a preview in lesson edit mode.

- Fixes video mapping in lesson store flow when payload keys are `videos[1][...]` style.
- Adds Vimeo iframe preview rendering in lesson edit for valid Vimeo URLs.

Closes #396
