### PR TITLE
BUG - clean scope fix for lesson published null and media handling

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -2,100 +2,159 @@
 
 namespace App\Http\Controllers\Backend\Admin;
 
-use App\Helpers\CustomHelper;
-use App\Http\Controllers\Controller;
-use App\Http\Controllers\Traits\FileUploadTrait;
-use App\Http\Requests\Admin\StoreLessonsRequest;
-use App\Http\Requests\Admin\UpdateLessonsRequest;
 use App\Models\Course;
 use App\Models\CourseTimeline;
 use App\Models\Lesson;
-use App\Models\LessonVideo;
 use App\Models\Media;
 use App\Models\Test;
-use App\Notifications\Backend\LessonNotification;
-use App\Services\NotificationSettingsService;
-use Exception;
+use App\Helpers\CustomHelper;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreLessonsRequest;
+use App\Http\Requests\Admin\UpdateLessonsRequest;
+use App\Http\Controllers\Traits\FileUploadTrait;
+use App\Models\Category;
 use Yajra\DataTables\Facades\DataTables;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+use Exception;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Notifications\Backend\LessonNotification;
+use App\Services\NotificationSettingsService;
+use Illuminate\Support\Str;
+use App\Models\LessonVideo;
 
 class LessonsController extends Controller
 {
     use FileUploadTrait;
 
+    /**
+     * Display a listing of Lesson.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function index(Request $request)
     {
         if (!Gate::allows('lesson_access')) {
             return abort(401);
         }
-
-        $courses = Course::orderBy('title')->get(['id', 'title']);
+        $courses = Course::pluck('title', 'id')->prepend('Please select', '');
 
         return view('backend.lessons.index', compact('courses'));
     }
 
+    /**
+     * Display a listing of Lessons via ajax DataTable.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function getData(Request $request)
     {
-
-        $has_view   = auth()->user()->can('lesson_view');
-        $has_edit   = auth()->user()->can('lesson_edit');
-        $has_delete = auth()->user()->can('lesson_delete');
-
-        $lessons = Lesson::query()
-            ->with(['attendance_list', 'course'])
-            ->where(function ($query) {
-                $query->where('live_lesson', 0)->orWhereNull('live_lesson');
-            });
+        $has_view = false;
+        $has_delete = false;
+        $has_edit = false;
+        $lessons = Lesson::with(['attendance_list', 'course'])
+    ->where('live_lesson', '=', 0)
+    ->whereIn('course_id', Course::pluck('id'));
 
         if ($request->show_deleted == 1) {
             if (!Gate::allows('lesson_delete')) {
                 return abort(401);
             }
-            $lessons->onlyTrashed();
+            $lessons = $lessons->onlyTrashed();
         }
 
-        if ($request->filled('status') && in_array($request->status, ['published', 'unpublished'])) {
-            $lessons->where('published', $request->status === 'published' ? 1 : 0);
+        if ($request->course_id != "") {
+            $lessons = $lessons->where('course_id', (int)$request->course_id);
         }
 
-        if ($request->filled('course_id') && is_numeric($request->course_id)) {
-            $lessons->where('course_id', (int) $request->course_id);
-        }
+        $lessons = $lessons->orderBy('id', 'asc');
 
-        $lessons->orderBy('id', 'asc');
+
+
+
+        if (auth()->user()->can('lesson_view')) {
+            $has_view = true;
+        }
+        if (auth()->user()->can('lesson_edit')) {
+            $has_edit = true;
+        }
+        if (auth()->user()->can('lesson_delete')) {
+            $has_delete = true;
+        }
 
         return DataTables::of($lessons)
             ->addIndexColumn()
+            // ->addColumn('actions', function ($q) use ($has_view, $has_edit, $has_delete, $request) {
+            //     $view = "";
+            //     $edit = "";
+            //     $delete = "";
+            //     if ($request->show_deleted == 1) {
+            //         return view('backend.datatable.action-trashed')->with(['route_label' => 'admin.lessons', 'label' => 'id', 'value' => $q->id]);
+            //     }
+            //     if ($has_view) {
+            //         $view = view('backend.datatable.action-view')
+            //             ->with(['route' => route('admin.lessons.show', ['lesson' => $q->id])])->render();
+            //     }
+            //     if ($has_edit) {
+            //         $edit = view('backend.datatable.action-edit')
+            //             ->with(['route' => route('admin.lessons.edit', ['lesson' => $q->id])])
+            //             ->render();
+            //         $view .= $edit;
+            //     }
+
+            //     if ($has_delete) {
+            //         $delete = view('backend.datatable.action-delete')
+            //             ->with(['route' => route('admin.lessons.destroy', ['lesson' => $q->id])])
+            //             ->render();
+            //         $view .= $delete;
+            //     }
+
+            //     if (auth()->user()->can('test_view')) {
+            //         if ($q->test != "") {
+            //             $view .= '<a href="' . route('admin.tests.index', ['lesson_id' => $q->id]) . '" class="btn btn-success btn-block mb-1">' . trans('labels.backend.tests.title') . '</a>';
+            //         }
+            //     }
+
+            //     return $view;
+            // })
             ->addColumn('actions', function ($q) use ($has_view, $has_edit, $has_delete, $request) {
-                if ($request->show_deleted == 1) {
-                    return view('backend.datatable.action-trashed')->with([
-                        'route_label' => 'admin.lessons',
-                        'label'       => 'id',
-                        'value'       => $q->id,
-                    ]);
-                }
+    if ($request->show_deleted == 1) {
+        return view('backend.datatable.action-trashed')->with([
+            'route_label' => 'admin.lessons',
+            'label' => 'id',
+            'value' => $q->id
+        ]);
+    }
 
-                $actions = '<div class="action-pill">';
+    
+    $actions = '<div class="action-pill">';
 
-                if ($has_view) {
-                    $actions .= '<a href="' . route('admin.lessons.show', ['lesson' => $q->id]) . '">'
-                        . '<i class="fa fa-eye" aria-hidden="true"></i></a>';
-                }
+    if ($has_view) {
+        $actions .= '<a class="" href="' . route('admin.lessons.show', ['lesson' => $q->id]) . '">
+             <i class="fa fa-eye" aria-hidden="true"></i></a>';
+    }
 
-                if ($has_edit) {
-                    $actions .= '<a href="' . route('admin.lessons.edit', ['lesson' => $q->id]) . '">'
-                        . '<i class="fa fa-edit" aria-hidden="true"></i></a>';
-                }
+    if ($has_edit) {
+        $actions .= '<a class="" href="' . route('admin.lessons.edit', ['lesson' => $q->id]) . '">
+           <i class="fa fa-edit" aria-hidden="true"></i></a>';
+    }
 
-                $actions .= '</div>';
+    if ($has_delete) {
+        // $actions .= '
+        //     <form method="POST" action="' . route('admin.lessons.destroy', $q->id) . '" class="" >
+        //         ' . csrf_field() . method_field('DELETE') . '
+        //         <a type="submit" class="" onclick="return confirm(\'Are you sure?\')">
+        //              <i class="fa fa-trash" aria-hidden="true"></i>
+        //         </a>
+        //     </form>';
+    }
 
-                return $actions;
-            })
+    $actions .= '</div>';
+    return $actions;
+})
             ->editColumn('course', function ($q) {
     if ($q->course) {
         return '<a href="'.route('admin.courses.edit', $q->course->id).'">'
@@ -107,100 +166,132 @@ class LessonsController extends Controller
             ->addColumn('attendance', function ($q) {
                 $courseId = (int) ($q->course_id ?? optional($q->course)->id ?? 0);
 
-                if ($courseId <= 0 || !$q->attendance_list || $q->attendance_list->isEmpty()) {
+                if ($courseId <= 0) {
                     return 0;
                 }
 
-                return '<a href="' . route('attendance.attendance.list', [$courseId, $q->id]) . '">'
-                    . 'View All (' . $q->attendance_list->count() . ')</a>';
-            })
-            ->addColumn('qr_code', function ($q) {
-                $courseId = (int) ($q->course_id ?? optional($q->course)->id ?? 0);
-
-                if ($courseId <= 0) {
-                    return 'N/A';
+                if (isset($q->attendance_list) && count($q->attendance_list)) {
+                    return $q->attendance_list ? '<a href="' . route('attendance.attendance.list', [$courseId, $q->id]) . '">View All (' . count($q->attendance_list) . ')</a>' : 0;
+                } else {
+                    return 0;
                 }
-
-                $modalId    = 'qrModal_' . $q->id;
-                $qrCodeHtml = \QrCode::size(200)->generate(
-                    route('attendance.attendance.lesson', [$courseId, $q->id])
-                );
-
-                return '
-                    <a href="javascript:void(0);" data-toggle="modal" data-target="#' . $modalId . '">
-                        <i class="fa fa-qrcode ml-3" style="color:#ccc;"></i>
-                    </a>
-                    <div class="modal fade" id="' . $modalId . '" tabindex="-1" role="dialog"
-                         aria-labelledby="qrModalLabel_' . $q->id . '" aria-hidden="true">
-                        <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title" id="qrModalLabel_' . $q->id . '">QR Code</h5>
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-                                <div class="modal-body text-center">
-                                    ' . $qrCodeHtml . '
-                                    <p class="mt-2 small text-muted">Scan to open attendance link</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>';
             })
+            // ->addColumn('qr_code', function ($q) {
+            //     return QrCode::size(80)->generate(route('attendance.attendance.lesson', [$q->course->id, $q->id]));
+            // })
+                ->addColumn('qr_code', function ($q) {
+            $courseId = (int) ($q->course_id ?? optional($q->course)->id ?? 0);
+            if ($courseId <= 0) {
+            return 'N/A';
+            }
+
+    $modalId = 'qrModal_' . $q->id;
+
+    // Use original logic to generate the QR code
+            $qrCodeHtml = \QrCode::size(200)->generate(route('attendance.attendance.lesson', [$courseId, $q->id]));
+
+    $html = '
+        <a href="javascript:void(0);" data-toggle="modal" data-target="#' . $modalId . '">
+            <i class="fa fa-qrcode ml-3" style="color:#ccc;"></i>
+        </a>
+
+        <!-- Modal -->
+        <div class="modal fade" id="' . $modalId . '" tabindex="-1" role="dialog" aria-labelledby="qrModalLabel_' . $q->id . '" aria-hidden="true">
+            <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="qrModalLabel_' . $q->id . '">QR Code</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body text-center">
+                        ' . $qrCodeHtml . '
+                        <p class="mt-2 small text-muted">Scan to open attendance link</p>
+                    </div>
+                </div>
+            </div>
+        </div>';
+
+    return $html;
+})
             ->editColumn('lesson_image', function ($q) {
-                return $q->lesson_image
-                    ? '<img height="50px" src="' . asset('storage/uploads/' . $q->lesson_image) . '">'
-                    : 'N/A';
+                return ($q->lesson_image != null) ? '<img height="50px" src="' . asset('storage/uploads/' . $q->lesson_image) . '">' : 'N/A';
             })
-            ->editColumn('free_lesson', fn($q) => $q->free_lesson == 1 ? 'Yes' : 'No')
-            ->editColumn('published', fn($q) => $q->published == 1 ? 'Yes' : 'No')
-            ->rawColumns(['lesson_image', 'qr_code', 'attendance', 'actions'])
+            ->editColumn('free_lesson', function ($q) {
+                return ($q->free_lesson == 1) ? "Yes" : "No";
+            })
+            ->editColumn('published', function ($q) {
+                return ($q->published == 1) ? "Yes" : "No";
+            })
+            ->rawColumns(['lesson_image', 'qr_code', 'attendance', 'actions' , 'course'])
             ->make();
     }
 
+    /**
+     * Show the form for creating new Lesson.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
     public function selectCourse()
-    {
-        if (!Gate::allows('lesson_create')) {
-            return abort(401);
-        }
-
-        $courses = Course::has('category')->orderBy('title')->get();
-
-        return view('backend.lessons.select-course', compact('courses'));
+{
+    if (!Gate::allows('lesson_create')) {
+        return abort(401);
     }
+
+    $courses = Course::has('category')->orderBy('title')->get();
+     return view('backend.lessons.select-course', compact('courses'));
+}
 
     public function create(Request $request)
     {
+        //dd($request->all());
+
         if (!Gate::allows('lesson_create')) {
             return abort(401);
         }
+       
 
-        $courses     = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
-        $courses_all = null;
-        $temp_id     = bin2hex(random_bytes(8));
+        //dd( $course); 
 
-        return view('backend.lessons.create', compact('courses', 'courses_all', 'temp_id'));
+        $courses = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
+         $courses_all = null;
+    $temp_id = uniqid();
+        return view('backend.lessons.create', compact('courses' ,   'courses_all','temp_id'));
     }
+
+    /**
+     * Store a newly created Lesson in storage.
+     *
+     * @param  \App\Http\Requests\StoreLessonsRequest $request
+     * @return \Illuminate\Http\Response
+     */
 
     public function checkCourse(Request $request)
-    {
-        $course = Course::with('category')->find((int) $request->id);
+{
+    $course = Course::with('category')->find($request->id);
 
-        return response()->json([
-            'success'  => true,
-            'category' => $course->category->name ?? null,
-        ]);
-    }
+    return response()->json([
+        'success' => true,
+        'category' => $course->category->name ?? null
+    ]);
+}
 
     public function store(StoreLessonsRequest $request)
+{
+    if (!Gate::allows('lesson_create')) {
+        return abort(401);
+    }
     {
+        
+        //dd("jj");
         if (!Gate::allows('lesson_create')) {
             return abort(401);
         }
-
+        //dd($request->title);
+        // $count = count($request->title);
         $titles = $request->input('title', []);
-
         $count = is_array($titles) ? count($titles) : 0;
 
         if ($count < 1) {
@@ -210,20 +301,31 @@ class LessonsController extends Controller
             ], 422);
         }
 
-
         DB::beginTransaction();
+
+        //dd($request->all());
+
+        //dd($request->all(), );
 
         try {
             for ($i = 0; $i < $count; $i++) {
-                $slug = bin2hex(random_bytes(8)) . Str::slug($request->title[$i]);
+                $slug = "";
+                
+                
+                $slug = uniqid() . Str::slug($request->title[$i]);
+                
 
-                if (Lesson::where('slug', $slug)->exists()) {
-                    throw new Exception('Slug already exists.');
+                $slug_lesson = Lesson::where('slug', '=', $slug)->first();
+                if ($slug_lesson != null) {
+                    throw new Exception("Slug is already exits");
                 }
 
 
                 $lesson_data = $request->except('downloadable_files', 'lesson_image', 'slug', 'title', 'arabic_title', 'short_text', 'full_text', 'duration', 'lesson_start_date', 'videos')
                 + ['position' => Lesson::where('course_id', $request->course_id)->max('position') + 1];
+
+                // Checkbox fields can be omitted by some clients; enforce a DB-safe value.
+                $lesson_data['published'] = (int) $request->boolean('published');
 
                 //dd($lesson_data);
                 
@@ -297,7 +399,6 @@ class LessonsController extends Controller
                     }
                 }
                 // Lesson added notification
-
                 try {
                     $notificationSettings = app(NotificationSettingsService::class);
                     if ($notificationSettings->shouldNotify('lessons', 'lesson_added', 'email')) {
@@ -309,299 +410,209 @@ class LessonsController extends Controller
                     Log::error('Failed to send lesson added notification: ' . $e->getMessage());
                 }
 
-                $filesPointer    = $i + 1;
-                $mediaTypes      = $request->input('media_type_' . $filesPointer, []);
-                $videoFiles      = $request->file('video_file_' . $filesPointer, []);
-                $downloadedFiles = $request->file('downloadable_files_' . $filesPointer, []);
-                $addPdfs         = $request->file('add_pdf_' . $filesPointer, []);
-                $audioFiles      = $request->file('add_audio_' . $filesPointer, []);
+                $media = null;
 
-                if (!empty($downloadedFiles)) {
-                    $this->saveAllFilesByLesson($downloadedFiles, 'downloadable_files', Lesson::class, $lesson, $filesPointer, 'download_file');
+                //dd($request->downloadable_files, $lesson->id);
+                $lession_iddd = $lesson->id;
+                $files_pointer = $i + 1;
+                //dd($files_pointer);
+                $mediaTypes = $request->input('media_type_' . $files_pointer, []);
+
+                $video_files = $request->file('video_file_' . $files_pointer, []);
+
+                $downloadedFiles = $request->file('downloadable_files_' . $files_pointer, []);
+
+                $addPdfs = $request->file('add_pdf_' . $files_pointer, []);
+
+                //dd($addPdfs);
+
+                $audioFiles = $request->file('add_audio_' . $files_pointer, []);
+
+                //dd($downloadedFiles);
+
+if (!empty($downloadedFiles)) {                    
+                    $this->saveAllFilesByLesson($downloadedFiles, 'downloadable_files', Lesson::class, $lesson, $files_pointer, "download_file");
+                    
                 }
 
+    $titles = $request->input('title', []);
+    $count = is_array($titles) ? count($titles) : 0;
+    $temp_id = $request->temp_id ?? null;
 
-                if (!empty($addPdfs)) {
-                    $this->saveAllFilesByLesson($addPdfs, 'add_pdf', Lesson::class, $lesson, $filesPointer, 'lesson_pdf');
-                }
+    DB::beginTransaction();
 
-                if (!empty($audioFiles)) {
-                    $this->saveAllFilesByLesson($audioFiles, 'add_audio', Lesson::class, $lesson, $filesPointer, 'lesson_audio');
-                }
-
-                if (!empty($mediaTypes)) {
-                    foreach ($mediaTypes as $mediaType) {
-                        if (in_array($mediaType, ['youtube', 'vimeo', 'embed'])) {
-                            $videoUrl = trim((string) $request->video);
-                            $name     = $lesson->title . ' - video';
-                            Media::create([
-                                'model_type' => Lesson::class,
-                                'model_id'   => $lesson->id,
-                                'name'       => $name,
-                                'url'        => $videoUrl,
-                                'type'       => $mediaType,
-                                'file_name'  => $name,
-                                'size'       => 0,
-                            ]);
-                        }
-
-                        if ($mediaType === 'upload') {
-                            $this->saveAllFilesByLesson($videoFiles, 'video_file', Lesson::class, $lesson, $filesPointer, $mediaType);
-                        }
-                    }
-                }
-
-                $sequence = 1;
-                if ($lesson->course->courseTimeline->count() > 0) {
-                    $sequence = $lesson->course->courseTimeline->max('sequence') + 1;
-                }
-
-                if ($lesson->published == 1) {
-                    $timeline = CourseTimeline::where('model_type', Lesson::class)
-                        ->where('model_id', $lesson->id)
-                        ->where('course_id', $request->course_id)
-                        ->first();
-
-                    if (!$timeline) {
-                        $timeline             = new CourseTimeline();
-                        $timeline->course_id  = $request->course_id;
-                        $timeline->model_id   = $lesson->id;
-                        $timeline->model_type = Lesson::class;
-                        $timeline->sequence   = $sequence;
-                        $timeline->save();
-                    }
-                }
+    try {
+        for ($i = 0; $i < $count; $i++) {
+            // Generate unique slug
+            $slug = uniqid() . Str::slug($request->title[$i]);
+            if (Lesson::where('slug', $slug)->exists()) {
+                throw new Exception("Slug already exists");
             }
 
-            Course::where('id', $request->course_id)->update(['current_step' => 'lesson-added']);
+            // Prepare lesson data
+            $lesson_data = $request->except(
+                'downloadable_files', 'lesson_image', 'slug', 'title', 'arabic_title',
+                'short_text', 'full_text', 'duration', 'lesson_start_date'
+            ) + [
+                'position' => Lesson::where('course_id', $request->course_id)->max('position') + 1,
+                'temp_id' => $temp_id,
+                'slug' => $slug,
+                'title' => $request->title[$i],
+                'arabic_title' => $request->arabic_title[$i] ?? null,
+            ];
 
-  
+            // Handle duration
+            $durationValue = $request->input("duration.$i", null);
+            if (is_array($durationValue)) {
+                $durationValue = json_encode($durationValue);
+            }
+            $lesson_data['duration'] = $durationValue;
+
+            // Handle lesson_start_date
+            $lessonStartDateValue = $request->input("lesson_start_date.$i", null);
+            if (is_array($lessonStartDateValue)) {
+                $lessonStartDateValue = $lessonStartDateValue['date'] ?? null;
+            }
+            $lesson_data['lesson_start_date'] = $lessonStartDateValue ? date('Y-m-d H:i', strtotime($lessonStartDateValue)) : null;
+
+            // Create lesson
+            $lesson = Lesson::create($lesson_data);
+
+            // Save lesson videos
+            $lessonVideos = $request->input("videos.$i", []);
+            foreach ($lessonVideos as $index => $video) {
+                $filePath = null;
+                if ($request->hasFile("videos.$i.$index.file")) {
+                    $filePath = $request->file("videos.$i.$index.file")->store('lesson_videos', 'public');
+                }
+
+                LessonVideo::create([
+                    'lesson_id' => $lesson->id,
+                    'title' => $video['title'] ?? null,
+                    'type' => $video['type'] ?? 'upload',
+                    'url' => $video['url'] ?? null,
+                    'file_path' => $filePath,
+                    'sort_order' => $index,
+                    'is_preview' => isset($video['is_preview']) ? 1 : 0
+                ]);
+            }
+
+            // Save downloadable files, PDFs, audio
+            $files_pointer = $i + 1;
+            $downloadedFiles = $request->file('downloadable_files_' . $files_pointer, []);
+            $addPdfs = $request->file('add_pdf_' . $files_pointer, []);
+            $audioFiles = $request->file('add_audio_' . $files_pointer, []);
+            $video_files = $request->file('video_file_' . $files_pointer, []);
+            $mediaTypes = $request->input('media_type_' . $files_pointer, []);
+            //dd();
+
+            //Update Course step
+            Course::where('id',$request->course_id)->update([
+                'current_step' => 'lesson-added'
+            ]);
+
+            $course = Course::with('latestModuleWeightage')->find($request->course_id);
+
+            //dd("kk");
 
             DB::commit();
 
+            // update the progress instantly
             CustomHelper::updateToAllUserAssignedToCourse($request->course_id);
 
-            return response()->json([
-                'status'     => 'success',
-                'temp_id'    => $request->temp_id,
-                'media_type' => $request->media_type,
-                'clientmsg'  => 'Added successfully',
-            ]);
+            return response()->json(['status' => 'success', 'temp_id' =>$request->temp_id, 'media_type' => $request->media_type, 'clientmsg' => 'Added successfully']);
         } catch (Exception $e) {
-            DB::rollBack();
+            DB::rollBack(); 
             Log::error('Lesson save failed: ' . $e->getMessage());
-
             return response()->json(['status' => 'error', 'clientmsg' => 'Error: ' . $e->getMessage()], 500);
         }
+        
+        // return redirect()->route('admin.assessment_accounts.new-assisment', ['course_id' => $request->course_id])->withFlashSuccess(__('Attach test or assisment for course'));
     }
 
+
+    /**
+     * Show the form for editing Lesson.
+     *
+     * @param  int $id
+     * @return \Illuminate\Http\Response
+     */
     public function edit($id)
     {
         if (!Gate::allows('lesson_edit')) {
             return abort(401);
         }
+        $videos = '';
+        $courses = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
 
+        $lesson = Lesson::with(['media', 'mediaVideo', 'videos'])->findOrFail($id);
 
-        $courses    = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
-        $lesson     = Lesson::with(['media', 'mediaVideo'])->findOrFail($id);
-        $videos     = $lesson->media ? $lesson->media()->pluck('url')->implode(',') : '';
-        $mediavideo = $lesson->mediaVideo;
-
-        return view('backend.lessons.edit', compact('mediavideo', 'lesson', 'courses', 'videos'));
-    }
-
-    public function update(UpdateLessonsRequest $request, $id)
-    {
-        if (!Gate::allows('lesson_edit')) {
-            return abort(401);
-        }
-
-        DB::beginTransaction();
-
-        try {
-            $slug = blank($request->slug) ? Str::slug($request->title) : $request->slug;
-
-            if (Lesson::where('slug', $slug)->where('id', '!=', $id)->exists()) {
-                return back()->withFlashDanger(__('alerts.backend.general.slug_exist'));
+            if (!empty($downloadedFiles)) {
+                $this->saveAllFilesByLesson($downloadedFiles, 'downloadable_files', Lesson::class, $lesson, $files_pointer, "download_file");
             }
-
-            $lesson                    = Lesson::findOrFail($id);
-            $lesson->update($request->except('downloadable_files', 'lesson_image'));
-            $lesson->slug              = $slug;
-            $lesson->duration          = $request->duration;
-            $lesson->lesson_start_date = date('Y-m-d H:i', strtotime($request->lesson_start_date));
-            $lesson->save();
-
-            try {
-                $notificationSettings = app(NotificationSettingsService::class);
-                if ($notificationSettings->shouldNotify('lessons', 'lesson_updated', 'email')) {
-                    $lessonCourse = Course::find($lesson->course_id);
-                    LessonNotification::sendLessonUpdatedEmail(\Auth::user(), $lesson, $lessonCourse);
-                    LessonNotification::createLessonUpdatedBell(\Auth::user(), $lesson, $lessonCourse);
-                }
-            } catch (\Exception $e) {
-                Log::error('Failed to send lesson updated notification: ' . $e->getMessage());
+            if (!empty($addPdfs)) {
+                $this->saveAllFilesByLesson($addPdfs, 'add_pdf', Lesson::class, $lesson, $files_pointer, "lesson_pdf");
             }
-
-            if (!blank($request->media_type)) {
-                $name  = $lesson->title . ' - video';
-                $media = $lesson->mediavideo ?: new Media();
-
-                if ($request->media_type !== 'upload') {
-                    $url      = $request->video;
-                    $videoId  = in_array($request->media_type, ['youtube', 'vimeo'])
-                        ? array_last(explode('/', $request->video))
-                        : '';
-
-                    $media->model_type = Lesson::class;
-                    $media->model_id   = $lesson->id;
-                    $media->name       = $name;
-                    $media->url        = $url;
-                    $media->type       = $request->media_type;
-                    $media->file_name  = $videoId;
-                    $media->size       = 0;
-                    $media->save();
-                }
-
-                if ($request->media_type === 'upload' && \Illuminate\Support\Facades\Request::hasFile('video_file')) {
-                    $file     = \Illuminate\Support\Facades\Request::file('video_file');
-                    $filename = time() . '-' . $file->getClientOriginalName();
-
-                    try {
-                        $url = CustomHelper::uploadToS3($file, $filename);
-                    } catch (Exception $e) {
-                        throw new Exception('The video could not be uploaded.');
-
+            if (!empty($audioFiles)) {
+                $this->saveAllFilesByLesson($audioFiles, 'add_audio', Lesson::class, $lesson, $files_pointer, "lesson_audio");
+            }
+            if ($mediaTypes && count($mediaTypes) > 0) {
+                foreach ($mediaTypes as $media) {
+                    if (in_array($media, ['youtube', 'vimeo', 'embed'])) {
+                        $video_url = trim((string)$request->video);
+                        $name = $lesson->title . ' - video';
+                        Media::create([
+                            'model_type' => Lesson::class,
+                            'model_id' => $lesson->id,
+                            'name' => $name,
+                            'url' => $video_url,
+                            'type' => $media,
+                            'file_name' => $name,
+                            'size' => 0,
+                        ]);
                     }
-
-                    $media = Media::query()
-                        ->where('model_type', Lesson::class)
-                        ->where('model_id', $lesson->id)
-                        ->first() ?? new Media();
-
-                    $media->model_type = Lesson::class;
-                    $media->model_id   = $lesson->id;
-                    $media->name       = $name;
-                    $media->url        = $url;
-                    $media->aws_url    = $url;
-                    $media->type       = $request->media_type;
-                    $media->file_name  = $filename;
-                    $media->size       = 0;
-                    $media->save();
+                    if ($media == 'upload') {
+                        $this->saveAllFilesByLesson($video_files, 'video_file', Lesson::class, $lesson, $files_pointer, $media);
+                    }
                 }
             }
 
-
-            if ($request->hasFile('add_pdf')) {
-                optional($lesson->mediaPDF)->delete();
-            }
-
-            $this->saveAllFiles($request, 'downloadable_files', Lesson::class, $lesson);
-
-            $sequence = 1;
-            if ($lesson->course->courseTimeline->count() > 0) {
-                $sequence = $lesson->course->courseTimeline->max('sequence') + 1;
-            }
-
-            if ((int) $request->published === 1) {
-                $timeline = CourseTimeline::where('model_type', Lesson::class)
-                    ->where('model_id', $lesson->id)
-                    ->where('course_id', $request->course_id)
-                    ->firstOrNew([]);
-
-                $timeline->course_id  = $request->course_id;
-                $timeline->model_id   = $lesson->id;
-                $timeline->model_type = Lesson::class;
+            // Add to course timeline if published
+            if ($lesson->published == 1) {
+                $sequence = $lesson->course->courseTimeline->max('sequence') ?? 0;
+                $sequence++;
+                $timeline = CourseTimeline::firstOrNew([
+                    'course_id' => $request->course_id,
+                    'model_type' => Lesson::class,
+                    'model_id' => $lesson->id
+                ]);
+                $timeline->sequence = $sequence;
                 $timeline->save();
             }
 
-            DB::commit();
+        } // end for loop
 
-            return redirect()
-                ->route('admin.lessons.index', ['course_id' => $request->course_id])
-                ->withFlashSuccess(__('alerts.backend.general.updated'));
-        } catch (Exception $e) {
-            DB::rollBack();
+        // Update course step
+        Course::where('id', $request->course_id)->update(['current_step' => 'lesson-added']);
 
-            return back()->withFlashDanger('Error while updating...');
-        }
+        DB::commit();
+
+        // update progress instantly
+        CustomHelper::updateToAllUserAssignedToCourse($request->course_id);
+
+        return response()->json([
+            'status' => 'success',
+            'temp_id' => $temp_id,
+            'media_type' => $request->media_type,
+            'clientmsg' => 'Added successfully'
+        ]);
+    } catch (Exception $e) {
+        DB::rollBack();
+        Log::error('Lesson save failed: ' . $e->getMessage());
+        return response()->json([
+            'status' => 'error',
+            'clientmsg' => 'Error: ' . $e->getMessage()
+        ], 500);
     }
-
-    public function show($id)
-    {
-        if (!Gate::allows('lesson_view')) {
-            return abort(401);
-        }
-
-        $courses = Course::get()->pluck('title', 'id')->prepend('Please select', '');
-        $tests   = Test::where('lesson_id', $id)->get();
-        $lesson  = Lesson::findOrFail($id);
-
-        return view('backend.lessons.show', compact('lesson', 'tests', 'courses'));
-    }
-
-    public function destroy($id)
-    {
-        if (!Gate::allows('lesson_delete')) {
-            return abort(401);
-        }
-
-        $lesson = Lesson::findOrFail($id);
-        $lesson->chapterStudents()->where('course_id', $lesson->course_id)->forceDelete();
-        $lesson->delete();
-
-        return back()->withFlashSuccess(__('alerts.backend.general.deleted'));
-    }
-
-    public function massDestroy(Request $request)
-    {
-        if (!Gate::allows('lesson_delete')) {
-            return abort(401);
-        }
-
-        if ($request->input('ids')) {
-            Lesson::whereIn('id', $request->input('ids'))->get()->each->delete();
-        }
-    }
-
-    public function restore($id)
-    {
-        if (!Gate::allows('lesson_delete')) {
-            return abort(401);
-        }
-
-        Lesson::onlyTrashed()->findOrFail($id)->restore();
-
-        return back()->withFlashSuccess(trans('alerts.backend.general.restored'));
-    }
-
-    public function perma_del($id)
-    {
-        if (!Gate::allows('lesson_delete')) {
-            return abort(401);
-        }
-
-        $lesson = Lesson::onlyTrashed()->findOrFail($id);
-
-        if (File::exists(public_path('/storage/uploads/' . $lesson->lesson_image))) {
-            File::delete(public_path('/storage/uploads/' . $lesson->lesson_image));
-            File::delete(public_path('/storage/uploads/thumb/' . $lesson->lesson_image));
-        }
-
-        $lessonFile = Media::where('model_type', Lesson::class)->where('model_id', $lesson->id)->first();
-        if ($lessonFile) {
-            File::delete(public_path('/storage/uploads/' . $lessonFile->file_name));
-        }
-
-        $timelineStep = CourseTimeline::where('model_id', $id)
-            ->where('course_id', $lesson->course->id)
-            ->first();
-
-        optional($timelineStep)->delete();
-
-        $lesson->forceDelete();
-
-        return back()->withFlashSuccess(trans('alerts.backend.general.deleted'));
-
-    }
+}
 }

--- a/app/Http/Controllers/Backend/Admin/MediaController.php
+++ b/app/Http/Controllers/Backend/Admin/MediaController.php
@@ -8,24 +8,32 @@ use App\Http\Controllers\Controller;
 
 class MediaController extends Controller
 {
-    public function destroy(Request $request){
-        $media_id =  $request->media_id;
+    public function destroy(Request $request)
+    {
+        $media_id = $request->media_id;
         $media = Media::find($media_id);
 
-        if($media){
-            //Delete Related data
+        if ($media) {
+            // Delete related data.
             $filename = $media->file_name;
 
             $media->delete();
 
-            //Delete Photo
+            // Delete file from local uploads if present.
             $destinationPath = public_path() . '/storage/uploads/'.$filename;
             if (file_exists($destinationPath)) {
                 unlink($destinationPath);
             }
-            return response()->json(['success'=>'Deleted Successfully']);
-        }else{
-            return response()->json(['failure'=>'No Gallery']);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Deleted successfully',
+            ]);
+        } else {
+            return response()->json([
+                'success' => false,
+                'message' => 'File not found',
+            ], 404);
         }
     }
 }

--- a/app/Http/Controllers/Traits/FileUploadTrait.php
+++ b/app/Http/Controllers/Traits/FileUploadTrait.php
@@ -250,7 +250,12 @@ trait FileUploadTrait
                 if ($request->hasFile($key)) {
     
                     if ($key == $downloadable_file_input) {
-                        foreach ($request->file($key) as $item) {
+                        $downloadableItems = $request->file($key);
+                        if (!is_array($downloadableItems)) {
+                            $downloadableItems = [$downloadableItems];
+                        }
+
+                        foreach ($downloadableItems as $item) {
                             $extension = array_last(explode('.', $item->getClientOriginalName()));
                             $name = array_first(explode('.', $item->getClientOriginalName()));
                             $filename = time() . '-' . Str::slug($name) . '.' . $extension;
@@ -261,7 +266,7 @@ trait FileUploadTrait
                                 'model_id' => $model->id,
                                 'name' => $filename,
                                 'url' => asset('storage/uploads/' . $filename),
-                                'type' => $item->getClientMimeType(),
+                                'type' => 'download_file',
                                 'file_name' => $filename,
                                 'size' => $size,
                             ]);
@@ -272,43 +277,55 @@ trait FileUploadTrait
                     } else {
                         if ($key != 'video_file') {
                             if ($key == 'add_pdf') {
-                                $file = $request->file($key);
-    
-                                $extension = array_last(explode('.', $request->file($key)->getClientOriginalName()));
-                                $name = array_first(explode('.', $request->file($key)->getClientOriginalName()));
-                                $filename = time() . '-' . Str::slug($name) . '.' . $extension;
-    
-                                $size = $file->getSize() / 1024;
-                                $file->move(public_path('storage/uploads'), $filename);
-                                Media::create([
-                                    'model_type' => $model_type,
-                                    'model_id' => $model->id,
-                                    'name' => $filename,
-                                    'url' => asset('storage/uploads/' . $filename),
-                                    'type' => 'lesson_pdf',
-                                    'file_name' => $filename,
-                                    'size' => $size,
-                                ]);
-                                $finalRequest = new Request(array_merge($finalRequest->all(), [$key => $filename]));
+                                $pdfFiles = $request->file($key);
+                                if (!is_array($pdfFiles)) {
+                                    $pdfFiles = [$pdfFiles];
+                                }
+
+                                foreach ($pdfFiles as $file) {
+                                    $extension = array_last(explode('.', $file->getClientOriginalName()));
+                                    $name = array_first(explode('.', $file->getClientOriginalName()));
+                                    $filename = time() . '-' . Str::slug($name) . '.' . $extension;
+
+                                    $size = $file->getSize() / 1024;
+                                    $file->move(public_path('storage/uploads'), $filename);
+                                    Media::create([
+                                        'model_type' => $model_type,
+                                        'model_id' => $model->id,
+                                        'name' => $filename,
+                                        'url' => asset('storage/uploads/' . $filename),
+                                        'type' => 'lesson_pdf',
+                                        'file_name' => $filename,
+                                        'size' => $size,
+                                    ]);
+                                }
+
+                                $finalRequest = new Request(array_merge($finalRequest->all(), [$key => true]));
                             } elseif ($key == 'add_audio') {
-                                $file = $request->file($key);
-    
-                                $extension = array_last(explode('.', $request->file($key)->getClientOriginalName()));
-                                $name = array_first(explode('.', $request->file($key)->getClientOriginalName()));
-                                $filename = time() . '-' . Str::slug($name) . '.' . $extension;
-    
-                                $size = $file->getSize() / 1024;
-                                $file->move(public_path('storage/uploads'), $filename);
-                                Media::create([
-                                    'model_type' => $model_type,
-                                    'model_id' => $model->id,
-                                    'name' => $filename,
-                                    'type' => 'lesson_audio',
-                                    'file_name' => $filename,
-                                    'url' => asset('storage/uploads/' . $filename),
-                                    'size' => $size,
-                                ]);
-                                $finalRequest = new Request(array_merge($finalRequest->all(), [$key => $filename]));
+                                $audioFiles = $request->file($key);
+                                if (!is_array($audioFiles)) {
+                                    $audioFiles = [$audioFiles];
+                                }
+
+                                foreach ($audioFiles as $file) {
+                                    $extension = array_last(explode('.', $file->getClientOriginalName()));
+                                    $name = array_first(explode('.', $file->getClientOriginalName()));
+                                    $filename = time() . '-' . Str::slug($name) . '.' . $extension;
+
+                                    $size = $file->getSize() / 1024;
+                                    $file->move(public_path('storage/uploads'), $filename);
+                                    Media::create([
+                                        'model_type' => $model_type,
+                                        'model_id' => $model->id,
+                                        'name' => $filename,
+                                        'type' => 'lesson_audio',
+                                        'file_name' => $filename,
+                                        'url' => asset('storage/uploads/' . $filename),
+                                        'size' => $size,
+                                    ]);
+                                }
+
+                                $finalRequest = new Request(array_merge($finalRequest->all(), [$key => true]));
                             } else {
                                 if(is_array($request->file($key))){
                                     foreach($request->file($key) as $f){

--- a/app/Http/Requests/Admin/StoreLessonsRequest.php
+++ b/app/Http/Requests/Admin/StoreLessonsRequest.php
@@ -26,6 +26,14 @@ class StoreLessonsRequest extends FormRequest
             'course_id' => 'required|integer|exists:courses,id',
             'title' => 'required|array|min:1',
             'title.*' => 'required|string|max:255',
+            'published' => 'nullable|boolean',
         ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'published' => (int) $this->boolean('published'),
+        ]);
     }
 }

--- a/app/Http/Requests/Admin/UpdateLessonsRequest.php
+++ b/app/Http/Requests/Admin/UpdateLessonsRequest.php
@@ -24,6 +24,14 @@ class UpdateLessonsRequest extends FormRequest
     {
         return [
             'title' => 'required',
+            'published' => 'nullable|boolean',
         ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'published' => (int) $this->boolean('published'),
+        ]);
     }
 }

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -44,6 +44,15 @@ class Lesson extends Model
                 $lesson->media()->delete();
             }
 
+            static::creating(function ($lesson) {
+                if ($lesson->published === null) {
+                    $lesson->published = 0;
+                }
+
+                if ($lesson->free_lesson === null) {
+                    $lesson->free_lesson = 1;
+                }
+            });
         });
     }
 

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -42,7 +42,8 @@ class Media extends Model
         $storage = config('filesystems.default');
 
         if ($storage == 'local') {
-            return $this->aws_url;
+            // Backward compatibility: older rows may store only `url` without `aws_url`.
+            return $this->aws_url ?: ($this->attributes['url'] ?? $value);
         } else {
             return Storage::disk('s3')->temporaryUrl(
                 $awsPath,

--- a/database/migrations/2026_04_01_120000_fix_lessons_published_default.php
+++ b/database/migrations/2026_04_01_120000_fix_lessons_published_default.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class FixLessonsPublishedDefault extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasTable('lessons')) {
+            return;
+        }
+
+        // Backfill legacy null values before enforcing default/non-null.
+        DB::table('lessons')->whereNull('published')->update(['published' => 0]);
+
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE lessons MODIFY published TINYINT(1) NOT NULL DEFAULT 0");
+        } elseif ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE lessons ALTER COLUMN published SET DEFAULT 0");
+            DB::statement("ALTER TABLE lessons ALTER COLUMN published SET NOT NULL");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (!Schema::hasTable('lessons')) {
+            return;
+        }
+
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE lessons MODIFY published TINYINT(1) NULL DEFAULT 0");
+        } elseif ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE lessons ALTER COLUMN published DROP NOT NULL");
+            DB::statement("ALTER TABLE lessons ALTER COLUMN published DROP DEFAULT");
+        }
+    }
+}

--- a/resources/views/backend/lessons/create.blade.php
+++ b/resources/views/backend/lessons/create.blade.php
@@ -121,7 +121,7 @@
                         <i class="fa fa-times remove_less_slug"
                             onclick="removeLesslug(this)"
                             style="position:absolute; top:-10px; right:-10px; color:red; font-size:18px; cursor:pointer; display:none;"
-                            title="Remove Lesson"></i>
+                            title="{{ __('course_pages.admin_lessons_create.remove_lesson') }}"></i>
 
                         <div class="row">
                             <div class="col-md-6">
@@ -148,12 +148,12 @@
                                 <div class="form-group">
                                     <div for="lesson_image" class="control-label mb-2">
                                         {{ trans('labels.backend.lessons.fields.lesson_image') }}
-                                        {{ trans('labels.backend.lessons.max_file_size') }}
+                                        {{ trans('labels.backend.lessons.max_file_size') }} (JPEG, PNG, GIF)
                                     </div>
                                     <div class="custom-file-upload-wrapper">
                                         <input type="file" name="lesson_image[]" class="custom-file-input">
                                         <label class="custom-file-label">
-                                            <i class="fa fa-upload mr-1"></i> Choose a file
+                                            <i class="fa fa-upload mr-1"></i> {{ __('course_pages.admin_lessons_create.choose_file') }}
                                         </label>
                                     </div>
                                 </div>
@@ -196,7 +196,7 @@
                                     <div class="custom-file-upload-wrapper">
                                         <input type="file" name="downloadable_files_1[]" class="custom-file-input">
                                         <label class="custom-file-label">
-                                            <i class="fa fa-upload mr-1"></i> Choose a file
+                                            <i class="fa fa-upload mr-1"></i> {{ __('course_pages.admin_lessons_create.choose_file') }}
                                         </label>
                                     </div>
                                 </div>
@@ -210,7 +210,7 @@
                                     <div class="custom-file-upload-wrapper">
                                         <input type="file" name="add_pdf_1[]" class="custom-file-input">
                                         <label class="custom-file-label">
-                                            <i class="fa fa-upload mr-1"></i> Choose a file
+                                            <i class="fa fa-upload mr-1"></i> {{ __('course_pages.admin_lessons_create.choose_file') }}
                                         </label>
                                     </div>
                                 </div>
@@ -224,7 +224,7 @@
                                     <div class="custom-file-upload-wrapper">
                                         <input type="file" name="add_audio_1[]" class="custom-file-input">
                                         <label class="custom-file-label">
-                                            <i class="fa fa-upload mr-1"></i> Choose a file
+                                            <i class="fa fa-upload mr-1"></i> {{ __('course_pages.admin_lessons_create.choose_file') }}
                                         </label>
                                     </div>
                                 </div>
@@ -234,47 +234,47 @@
                         <div class="row addvideocol">
                             <div class="col-md-4 form-group parent_group mt-2">
                                 <div class="videos-section">
-                                    <h5>Lesson Videos</h5>
+                                    <h5>{{ __('course_pages.admin_lessons_create.lesson_videos') }}</h5>
 
                                     <div class="videos-wrapper"></div>
 
                                     <button type="button" class="btn btn-primary mt-2 addVideo">
-                                        Add Video
+                                        {{ __('course_pages.admin_lessons_create.add_video') }}
                                     </button>
                                 </div>
 
                                 <div class="video-template d-none">
                                     <div class="video-item card p-3 mb-3">
-                                        <label>Video Title</label>
+                                        <label>{{ __('course_pages.admin_lessons_create.video_title') }}</label>
                                         <input type="text" name="videos[INDEX][title]" class="form-control" disabled>
 
-                                        <label>Type</label>
+                                        <label>{{ __('course_pages.admin_lessons_create.type') }}</label>
                                         <select name="videos[INDEX][type]" class="form-control video-type" disabled>
-                                            <option value="upload">Upload</option>
+                                            <option value="upload">{{ __('course_pages.admin_lessons_create.upload') }}</option>
                                             <option value="youtube">YouTube</option>
                                             <option value="vimeo">Vimeo</option>
-                                            <option value="embed">Embed</option>
+                                            <option value="embed">{{ __('course_pages.admin_lessons_create.embed') }}</option>
                                         </select>
 
                                         <div class="video-url mt-2 d-none">
-                                            <label>Video URL</label>
+                                            <label>{{ __('course_pages.admin_lessons_create.video_url') }}</label>
                                             <input type="text" name="videos[INDEX][url]"
                                                 class="form-control video-url-input" disabled>
                                         </div>
 
                                         <div class="video-file mt-2 d-none">
-                                            <label>Upload File</label>
+                                            <label>{{ __('course_pages.admin_lessons_create.upload_file') }}</label>
                                             <input type="file" name="videos[INDEX][file]"
                                                 class="form-control video-file-input" disabled>
                                         </div>
 
                                         <label class="mt-2">
                                             <input type="checkbox" name="videos[INDEX][is_preview]" value="1" disabled>
-                                            Preview Video
+                                            {{ __('course_pages.admin_lessons_create.preview_video') }}
                                         </label>
 
                                         <button type="button" class="removeVideo btn btn-danger btn-sm mt-2">
-                                            Remove
+                                            {{ __('course_pages.admin_lessons_create.remove') }}
                                         </button>
                                     </div>
                                 </div>
@@ -287,15 +287,15 @@
 
                         <div class="form-group row">
                             <div class="col-md-4 col-sm-12">
-                                <div for="duration" class="form-control-label mb-2">Duration</div>
+                                <div for="duration" class="form-control-label mb-2">{{ __('course_pages.admin_lessons_create.duration') }}</div>
                                 <div>
                                     <input type="text" name="duration[]" class="form-control"
-                                        placeholder="Duration [minutes]">
+                                        placeholder="{{ __('course_pages.admin_lessons_create.duration_minutes') }}">
                                 </div>
                             </div>
 
                             <div class="col-md-4 col-sm-12 start_date">
-                                <div for="duration" class="form-control-label mb-2">Lesson Start Date</div>
+                                <div for="duration" class="form-control-label mb-2">{{ __('course_pages.admin_lessons_create.lesson_start_date') }}</div>
                                 <div>
                                     <input class="form-control" type="date" name="lesson_start_date[]"
                                         id="lesson_start_date">
@@ -323,11 +323,11 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <button type="button" name="addmorebtn" id="addmorebtn"
-                                class="btn btn-outline-info">Add More Lesson</button>
+                                class="btn btn-outline-info">{{ __('course_pages.admin_lessons_create.add_more_lesson') }}</button>
                         </div>
                         <div>
                             <button type="submit" class="btn cancel-btn frm_submit" id="doneBtn">
-                                Save As Draft
+                                {{ __('course_pages.admin_lessons_create.save_as_draft') }}
                             </button>
                             <button type="submit" class="btn add-btn frm_submit next" id="nextBtn">
                                 Next
@@ -405,10 +405,22 @@
         }
     }
 
+    function renumberLessonFileInputs() {
+        $('.lesson-box').each(function (index) {
+            const pointer = index + 1;
+            $(this).find('input[name^="downloadable_files_"]').attr('name', 'downloadable_files_' + pointer + '[]');
+            $(this).find('input[name^="add_pdf_"]').attr('name', 'add_pdf_' + pointer + '[]');
+            $(this).find('input[name^="add_audio_"]').attr('name', 'add_audio_' + pointer + '[]');
+            $(this).find('input[name^="video_file_"]').attr('name', 'video_file_' + pointer + '[]');
+            $(this).find('input[name^="media_type_"]').attr('name', 'media_type_' + pointer + '[]');
+        });
+    }
+
     window.videoIndex = window.videoIndex || 0;
 
     $(document).ready(function () {
         initEditors($(document));
+        renumberLessonFileInputs();
 
         $(document).on('click', '.addVideo', function () {
             const $parent = $(this).closest('.parent_group');
@@ -435,7 +447,7 @@
 
         $(document).on('change', '.custom-file-input', function (e) {
             const label = this.nextElementSibling;
-            const fileName = e.target.files.length > 0 ? e.target.files[0].name : 'Choose a file';
+            const fileName = e.target.files.length > 0 ? e.target.files[0].name : '{{ __('course_pages.admin_lessons_create.choose_file') }}';
 
             if (label) {
                 label.innerHTML = '<i class="fa fa-upload mr-1"></i> ' + fileName;
@@ -485,115 +497,125 @@
     });
 
     $(document).on('submit', '#addLesson', function (e) {
-        e.preventDefault();
+    e.preventDefault();
 
-        function parseIniSizeToBytes(sizeText) {
-            if (!sizeText) return 0;
-            const value = String(sizeText).trim();
-            const unit = value.slice(-1).toUpperCase();
-            const num = parseFloat(value);
-            if (isNaN(num)) return 0;
-            if (unit === 'G') return Math.round(num * 1024 * 1024 * 1024);
-            if (unit === 'M') return Math.round(num * 1024 * 1024);
-            if (unit === 'K') return Math.round(num * 1024);
-            return Math.round(num);
+    function parseIniSizeToBytes(sizeText) {
+        if (!sizeText) return 0;
+        const value = String(sizeText).trim();
+        const unit = value.slice(-1).toUpperCase();
+        const num = parseFloat(value);
+
+        if (isNaN(num)) return 0;
+        if (unit === 'G') return Math.round(num * 1024 * 1024 * 1024);
+        if (unit === 'M') return Math.round(num * 1024 * 1024);
+        if (unit === 'K') return Math.round(num * 1024);
+        return Math.round(num);
+    }
+
+    const phpPostMax = parseIniSizeToBytes('{{ ini_get('post_max_size') }}');
+    const phpUploadMax = parseIniSizeToBytes('{{ ini_get('upload_max_filesize') }}');
+
+    let totalBytes = 0;
+    let singleTooLarge = false;
+
+    $('#addLesson input[type="file"]').each(function () {
+        if (!this.files || !this.files.length) {
+            return;
         }
 
-        const phpPostMax = parseIniSizeToBytes('{{ ini_get('post_max_size') }}');
-        const phpUploadMax = parseIniSizeToBytes('{{ ini_get('upload_max_filesize') }}');
+        for (let idx = 0; idx < this.files.length; idx++) {
+            const f = this.files[idx];
+            totalBytes += f.size;
 
-        let totalBytes = 0;
-        let singleTooLarge = false;
+            if (phpUploadMax > 0 && f.size > phpUploadMax) {
+                singleTooLarge = true;
+            }
+        }
+    });
 
-        $('#addLesson input[type="file"]').each(function () {
-            if (!this.files || !this.files.length) {
+    if (singleTooLarge) {
+        const maxMb = Math.floor(phpUploadMax / (1024 * 1024));
+        alert('One file exceeds upload_max_filesize (' + maxMb + 'MB). Please reduce file size or increase PHP limits.');
+        return;
+    }
+
+    if (phpPostMax > 0 && totalBytes > phpPostMax) {
+        const maxMb = Math.floor(phpPostMax / (1024 * 1024));
+        alert('Total upload exceeds post_max_size (' + maxMb + 'MB). Please reduce files or increase PHP limits.');
+        return;
+    }
+
+    $('.loading').text('{{ __('course_pages.admin_lessons_create.processing_please_wait') }}');
+    $('#nextBtn,#doneBtn').prop('disabled', true);
+
+    var form = $('#addLesson')[0];
+    var data = new FormData(form);
+
+    let url = '{{ route('admin.lessons.store') }}';
+    let redirect_url_course = $("#lesson_index").val();
+    let redirect_question_url = $("#add_question_url").val();
+    let course_id = $(".course_id").first().val();
+
+    $.ajax({
+        type: 'POST',
+        url: url,
+        data: data,
+        processData: false,
+        contentType: false,
+
+        success: function (res) {
+            $('.loading').text('');
+
+            if (!res || res.status !== 'success') {
+                $('#nextBtn,#doneBtn').prop('disabled', false);
+
+                const fallbackMessage = '{{ __('course_pages.admin_lessons_create.something_went_wrong') }}';
+                let msg = (res && (res.clientmsg || res.message))
+                    ? (res.clientmsg || res.message)
+                    : fallbackMessage;
+
+                if (typeof res === 'string' && res.indexOf('POST Content-Length') !== -1) {
+                    msg = 'Upload is too large for current server limits (post_max_size/upload_max_filesize). Increase PHP limits and try again.';
+                }
+
+                alert(msg);
                 return;
             }
 
-            for (let idx = 0; idx < this.files.length; idx++) {
-                const f = this.files[idx];
-                totalBytes += f.size;
-                if (phpUploadMax > 0 && f.size > phpUploadMax) {
-                    singleTooLarge = true;
+            let clicked = $('#btn_clicked').val();
+
+            if (clicked === 'nextBtn') {
+                window.location.href = redirect_question_url + "/" + course_id + "/" + res.temp_id;
+            }
+
+            if (clicked === 'doneBtn') {
+                window.location.href = redirect_url_course;
+            }
+        },
+
+        error: function (xhr) {
+            $('.loading').text('');
+            $('#nextBtn,#doneBtn').prop('disabled', false);
+
+            console.log(xhr.responseText);
+
+            let message = '{{ __('course_pages.admin_lessons_create.something_went_wrong') }}';
+
+            if (xhr.responseJSON && xhr.responseJSON.clientmsg) {
+                message = xhr.responseJSON.clientmsg;
+            } else if (xhr.status === 413) {
+                message = 'Upload is too large for server limits. Please reduce the video size and try again.';
+            } else if (xhr.status === 422 && xhr.responseJSON && xhr.responseJSON.errors) {
+                const firstKey = Object.keys(xhr.responseJSON.errors)[0];
+                if (firstKey && xhr.responseJSON.errors[firstKey] && xhr.responseJSON.errors[firstKey][0]) {
+                    message = xhr.responseJSON.errors[firstKey][0];
                 }
             }
-        });
 
-        if (singleTooLarge) {
-            const maxMb = Math.floor(phpUploadMax / (1024 * 1024));
-            alert('One file exceeds upload_max_filesize (' + maxMb + 'MB). Please reduce file size or increase PHP limits.');
-            return;
+            alert(message);
         }
-
-        if (phpPostMax > 0 && totalBytes > phpPostMax) {
-            const maxMb = Math.floor(phpPostMax / (1024 * 1024));
-            alert('Total upload exceeds post_max_size (' + maxMb + 'MB). Please reduce files or increase PHP limits.');
-            return;
-        }
-
-        $('.loading').text('processing please wait...');
-        $('#nextBtn,#doneBtn').prop('disabled', true);
-
-        var form = $('#addLesson')[0];
-        var data = new FormData(form);
-
-        let url = '{{ route('admin.lessons.store') }}';
-        let redirect_url_course = $("#lesson_index").val();
-        let redirect_question_url = $("#add_question_url").val();
-        let course_id = $(".course_id").first().val();
-
-        $.ajax({
-            type: 'POST',
-            url: url,
-            data: data,
-            processData: false,
-            contentType: false,
-
-            success: function (res) {
-                $('.loading').text('');
-
-                if (!res || res.status !== 'success') {
-                    $('#nextBtn,#doneBtn').prop('disabled', false);
-                    const fallbackMessage = 'Something went wrong';
-                    let msg = (res && (res.clientmsg || res.message)) ? (res.clientmsg || res.message) : fallbackMessage;
-                    if (typeof res === 'string' && res.indexOf('POST Content-Length') !== -1) {
-                        msg = 'Upload is too large for current server limits (post_max_size/upload_max_filesize). Increase PHP limits and try again.';
-                    }
-                    alert(msg);
-                    return;
-                }
-
-                let clicked = $('#btn_clicked').val();
-
-                if (clicked === 'nextBtn') {
-                    window.location.href = redirect_question_url + "/" + course_id + "/" + res.temp_id;
-                }
-
-                if (clicked === 'doneBtn') {
-                    window.location.href = redirect_url_course;
-                }
-            },
-
-            error: function (xhr) {
-                $('.loading').text('');
-                $('#nextBtn,#doneBtn').prop('disabled', false);
-
-                console.log(xhr.responseText);
-                let message = 'Something went wrong';
-                if (xhr.responseJSON && xhr.responseJSON.clientmsg) {
-                    message = xhr.responseJSON.clientmsg;
-                } else if (xhr.status === 413) {
-                    message = 'Upload is too large for server limits. Please reduce the video size and try again.';
-                } else if (xhr.status === 422 && xhr.responseJSON && xhr.responseJSON.errors) {
-                    const firstKey = Object.keys(xhr.responseJSON.errors)[0];
-                    if (firstKey && xhr.responseJSON.errors[firstKey] && xhr.responseJSON.errors[firstKey][0]) {
-                        message = xhr.responseJSON.errors[firstKey][0];
-                    }
-                }
-                alert(message);
-            }
-        });
     });
+});
 
     var i = 1;
 
@@ -601,8 +623,8 @@
         ++i;
         $("#dynamicAddRemove").append(
             '<tr>' +
-                '<td><input type="text" name="addMoreInputFields[' + i + '][subject]" placeholder="Enter subject" class="form-control" /></td>' +
-                '<td><button type="button" class="btn btn-outline-danger remove-input-field">Delete</button></td>' +
+                '<td><input type="text" name="addMoreInputFields[' + i + '][subject]" placeholder="{{ __('course_pages.admin_lessons_create.enter_subject') }}" class="form-control" /></td>' +
+                '<td><button type="button" class="btn btn-outline-danger remove-input-field">{{ __('course_pages.admin_lessons_create.delete') }}</button></td>' +
             '</tr>'
         );
     });
@@ -640,6 +662,7 @@
         $(".mo_create").append(clone);
 
         initEditors(clone);
+        renumberLessonFileInputs();
     });
 
     function removeLesslug(el) {
@@ -653,6 +676,7 @@
         });
 
         box.remove();
+        renumberLessonFileInputs();
     }
 </script>
 @endpush

--- a/resources/views/backend/lessons/edit.blade.php
+++ b/resources/views/backend/lessons/edit.blade.php
@@ -31,6 +31,69 @@
             border-radius: 3px;
         }
 
+        .media-file-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 8px 10px;
+            border: 1px solid #e9ecef;
+            border-radius: 6px;
+            margin-bottom: 8px;
+            background: #fff;
+        }
+
+        .media-file-row .file-name {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            max-width: 90%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .media-file-row .file-type-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 40px;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.2px;
+            background: #eef2f7;
+            color: #344054;
+        }
+
+        .media-file-row .file-type-badge.pdf {
+            background: #fee2e2;
+            color: #b42318;
+        }
+
+        .media-file-row .file-type-badge.audio {
+            background: #e0f2fe;
+            color: #0369a1;
+        }
+
+        .media-file-row .file-type-badge.file {
+            background: #ecfdf3;
+            color: #027a48;
+        }
+
+        .media-file-row .remove-file {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 40px;
+            height: 28px;
+            border-radius: 14px;
+            padding: 0 10px;
+            gap: 4px;
+            font-size: 12px;
+        }
+
     </style>
 
 @endpush
@@ -95,7 +158,7 @@
 
                     <div class="col-md-12 col-lg-5 form-group">
 
-                        <label for="lesson_image" class="control-label">{{ trans('labels.backend.lessons.fields.lesson_image').' '.trans('labels.backend.lessons.max_file_size') }}</label>
+                        <label for="lesson_image" class="control-label">{{ trans('labels.backend.lessons.fields.lesson_image').' '.trans('labels.backend.lessons.max_file_size') }} (JPEG, PNG, GIF)</label>
                         <input type="file" name="lesson_image" class="form-control" accept="image/jpeg,image/gif,image/png" style="margin-top: 4px;">
                         <input type="hidden" name="lesson_image_max_size" value="8">
                         <input type="hidden" name="lesson_image_max_width" value="4000">
@@ -110,10 +173,10 @@
                     <div class="col-md-12 col-lg-6 form-group">
 
                                 <div for="lesson_image" class="control-label mb-2">
-                         {{ trans('labels.backend.lessons.fields.lesson_image') }} {{ trans('labels.backend.lessons.max_file_size') }}
+                         {{ trans('labels.backend.lessons.fields.lesson_image') }} {{ trans('labels.backend.lessons.max_file_size') }} (JPEG, PNG, GIF)
                     </div>
-                     <div class="custom-file-upload-wrapper">
-                            <input type="file" name="image" id="customFileInput" class="custom-file-input">
+                    <div class="custom-file-upload-wrapper">
+                        <input type="file" name="lesson_image" id="lessonImageInput" class="custom-file-input">
                             <label for="customFileInput" class="custom-file-label">
                             <i class="fa fa-upload mr-1"></i> Choose a file
                             </label>
@@ -139,8 +202,8 @@
                 <div class="col-12 form-group">
                     <label for="downloadable_files" class="control-label">{{ trans('labels.backend.lessons.fields.downloadable_files').' '.trans('labels.backend.lessons.max_file_size') }}</label>
                      <div class="custom-file-upload-wrapper">
-                            <input type="file" name="image" id="customFileInput" class="custom-file-input">
-                            <label for="customFileInput" class="custom-file-label">
+                            <input type="file" name="downloadable_files[]" id="downloadableFilesInput" class="custom-file-input" multiple>
+                            <label for="downloadableFilesInput" class="custom-file-label">
                             <i class="fa fa-upload mr-1"></i> Choose a file
                             </label>
                         </div>
@@ -155,14 +218,16 @@
                         <div class="files-list">
                             @if(count($lesson->media) > 0)
                                 @foreach($lesson->media as $media)
-                                        @if($media->type == 'download_file')
-                                            <p class="form-group">
-                                                <a download href="{{ $media->url }}"
-                                                target="_blank">{{ $media->file_name }}
-                                                    ({{ $media->size }} KB)</a>
-                                                <a href="#" data-media-id="{{$media->id}}"
-                                                class="btn btn-xs btn-danger delete remove-file">@lang('labels.backend.lessons.remove')</a>
-                                            </p>
+                                        @if($media->type == 'download_file' || str_contains((string)$media->type, '/'))
+                                            <div class="media-file-row">
+                                                <a class="file-name" download href="{{ $media->url }}" target="_blank" title="{{ $media->file_name }}">
+                                                    <span class="file-type-badge file">FILE</span>
+                                                    <span>{{ $media->file_name }}</span>
+                                                </a>
+                                                <a href="#" data-media-id="{{$media->id}}" class="btn btn-xs btn-danger delete remove-file" title="@lang('labels.backend.lessons.remove')">
+                                                    <span aria-hidden="true">🗑</span><span>@lang('labels.backend.lessons.remove')</span>
+                                                </a>
+                                            </div>
                                         @endif
                                 @endforeach
                             @endif
@@ -174,27 +239,27 @@
                 <div class="col-12 form-group">
                     <label for="pdf_files" class="control-label">{{ trans('labels.backend.lessons.fields.add_pdf') }}</label>
                     <div class="custom-file-upload-wrapper">
-                            <input type="file" name="image" id="customFileInput" class="custom-file-input">
-                            <label for="customFileInput" class="custom-file-label">
+                            <input type="file" name="add_pdf" id="lessonPdfInput" class="custom-file-input" accept="application/pdf">
+                            <label for="lessonPdfInput" class="custom-file-label">
                             <i class="fa fa-upload mr-1"></i> Choose a file
                             </label>
                         </div>
                     <div class="photo-block mt-3">
                         <div class="files-list">
                             @if($lesson->media)
-                                {{-- {{ dd($lesson->media) }} --}}
-                                <p class="form-group">
-                                    {{-- <a href="{{ asset('storage/uploads/'.$lesson->media->name) }}"
-                                       target="_blank">{{ $lesson->media?->name }}
-                                        ({{ $lesson->media->size }} KB)</a> --}}
-                                    {{-- <a href="#" data-media-id="{{$lesson->media->id}}"
-                                       class="btn btn-xs btn-danger delete remove-file">@lang('labels.backend.lessons.remove')</a> --}}
-                                    @foreach($lesson->media as $media)
-                                        @if($media->type == 'lesson_pdf')
-                                        <iframe src="{{ $media->url }}" width="100%" height="500px"></iframe>
-                                        @endif
-                                    @endforeach
-                                </p>
+                                @foreach($lesson->media as $media)
+                                    @if($media->type == 'lesson_pdf')
+                                        <div class="media-file-row">
+                                            <a class="file-name" href="{{ $media->url }}" target="_blank" title="{{ $media->file_name }}">
+                                                <span class="file-type-badge pdf">PDF</span>
+                                                <span>{{ $media->file_name }}</span>
+                                            </a>
+                                            <a href="#" data-media-id="{{$media->id}}" class="btn btn-xs btn-danger delete remove-file" title="@lang('labels.backend.lessons.remove')">
+                                                <span aria-hidden="true">🗑</span><span>@lang('labels.backend.lessons.remove')</span>
+                                            </a>
+                                        </div>
+                                    @endif
+                                @endforeach
                             @endif
                         </div>
                     </div>
@@ -205,8 +270,8 @@
                 <div class="col-12 form-group">
                     <label for="pdf_files" class="control-label">{{ trans('labels.backend.lessons.fields.add_audio') }}</label>
                    <div class="custom-file-upload-wrapper">
-                            <input type="file" name="image" id="customFileInput" class="custom-file-input">
-                            <label for="customFileInput" class="custom-file-label">
+                            <input type="file" name="add_audio" id="lessonAudioInput" class="custom-file-input" accept="audio/*">
+                            <label for="lessonAudioInput" class="custom-file-label">
                             <i class="fa fa-upload mr-1"></i> Choose a file
                             </label>
                         </div>
@@ -215,16 +280,15 @@
                             @if($lesson->media)
                                     @foreach($lesson->media as $media)
                                         @if($media->type == 'lesson_audio')
-                                            <p class="form-group">
-                                                <a href="{{ $media->url }}"
-                                                target="_blank">{{ $media->file_name }}
-                                                    ({{ $media->size }} KB)</a>
-                                                <a href="#" data-media-id="{{$media->id}}"
-                                                class="btn btn-xs btn-danger delete remove-file">@lang('labels.backend.lessons.remove')</a>
-                                                <audio id="player" controls>
-                                                    <source src="{{ $media->url }}" type="audio/mp3" />
-                                                </audio>
-                                            </p>
+                                            <div class="media-file-row">
+                                                <a class="file-name" href="{{ $media->url }}" target="_blank" title="{{ $media->file_name }}">
+                                                    <span class="file-type-badge audio">AUDIO</span>
+                                                    <span>{{ $media->file_name }}</span>
+                                                </a>
+                                                <a href="#" data-media-id="{{$media->id}}" class="btn btn-xs btn-danger delete remove-file" title="@lang('labels.backend.lessons.remove')">
+                                                    <span aria-hidden="true">🗑</span><span>@lang('labels.backend.lessons.remove')</span>
+                                                </a>
+                                            </div>
                                     @endif
                                 @endforeach
                             @endif
@@ -311,6 +375,26 @@
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen>
+                        </iframe>
+                    </div>
+                @endif
+            @endif
+
+            @if($video->type == 'vimeo' && $video->url)
+                @php
+                    $vimeoUrl = trim((string) $video->url);
+                    $vimeoEmbedUrl = null;
+                    if (preg_match('#(?:vimeo\.com/(?:video/|channels/[^/]+/|groups/[^/]+/videos/|album/[^/]+/video/)?|player\.vimeo\.com/video/)(\d+)#i', $vimeoUrl, $vm)) {
+                        $vimeoEmbedUrl = 'https://player.vimeo.com/video/' . $vm[1];
+                    }
+                @endphp
+                @if($vimeoEmbedUrl)
+                    <div class="mt-3">
+                        <iframe width="420" height="250"
+                            src="{{ $vimeoEmbedUrl }}"
+                            frameborder="0"
+                            allow="autoplay; fullscreen; picture-in-picture"
                             allowfullscreen>
                         </iframe>
                     </div>
@@ -460,17 +544,36 @@
         $(document).ready(function () {
             $(document).on('click', '.delete', function (e) {
                 e.preventDefault();
-                var parent = $(this).parent('.form-group');
+                var row = $(this).closest('.media-file-row');
+                if (!row.length) {
+                    row = $(this).closest('.form-group');
+                }
                 var confirmation = confirm('{{trans('strings.backend.general.are_you_sure')}}')
                 if (confirmation) {
+                    var trigger = $(this);
                     var media_id = $(this).data('media-id');
-                    $.post('{{route('admin.media.destroy')}}', {media_id: media_id, _token: '{{csrf_token()}}'},
-                        function (data, status) {
-                            if (data.success) {
-                                parent.remove();
+                    // Instant UI feedback.
+                    row.stop(true, true).fadeOut(150);
+                    trigger.prop('disabled', true);
+
+                    $.post('{{route('admin.media.destroy')}}', {media_id: media_id, _token: '{{csrf_token()}}'})
+                        .done(function (data) {
+                            if (data && data.success) {
+                                row.remove();
                             } else {
-                                alert('Something Went Wrong')
+                                row.show();
+                                trigger.prop('disabled', false);
+                                alert((data && data.message) ? data.message : 'Something went wrong');
                             }
+                        })
+                        .fail(function (xhr) {
+                            row.show();
+                            trigger.prop('disabled', false);
+                            var message = 'Something went wrong';
+                            if (xhr.responseJSON && xhr.responseJSON.message) {
+                                message = xhr.responseJSON.message;
+                            }
+                            alert(message);
                         });
                 }
             })

--- a/resources/views/backend/lessons/index.blade.php
+++ b/resources/views/backend/lessons/index.blade.php
@@ -1,251 +1,285 @@
 @inject('request', 'Illuminate\Http\Request')
 @extends('backend.layouts.app')
 @section('title', __('labels.backend.lessons.title').' | '.app_name())
-
 @push('after-styles')
-<style>
-    .select2-container--default .select2-selection--single {
+ <style>
+       
+.select2-container--default .select2-selection--single {
         border: 1px solid #ccc !important;
         border-radius: 5px !important;
+        /* padding: 4px; */
     }
     .select2-container .select2-selection--single {
-        box-sizing: border-box;
-        cursor: pointer;
-        display: block;
-        height: 34px;
-        user-select: none;
-        -webkit-user-select: none;
-    }
-    .select2-container--default .select2-selection--single .select2-selection__rendered {
-        color: #444;
-        line-height: 30px;
-    }
-    .select2-container--default .select2-selection--single .select2-selection__arrow {
-        height: 26px;
-        position: absolute;
-        top: 4px;
-        right: 1px;
-        width: 20px;
-    }
-    .dropdown-item {
+    box-sizing: border-box;
+    cursor: pointer;
+    display: block;
+    height: 34px;
+    user-select: none;
+    -webkit-user-select: none;
+}
+.select2-container--default .select2-selection--single .select2-selection__rendered {
+    color: #444;
+    line-height: 30px;
+}
+.select2-container--default .select2-selection--single .select2-selection__arrow {
+    height: 26px;
+    position: absolute;
+    top: 4px;
+    right: 1px;
+    width: 20px;
+}
+    .dropdown-item{
         border-bottom: none;
     }
-    table.dataTable td {
-        overflow: visible;
-        position: relative;
-    }
-</style>
+
+     table.dataTable td {
+    overflow: visible;
+    position: relative;
+}
+ 
+    </style>
+
 @endpush
 
 @section('content')
 
+
 <div class="pb-3 d-flex justify-content-between align-items-center">
-    <h4>@lang('labels.backend.lessons.title')</h4>
+   <h4>
+      @lang('labels.backend.lessons.title')
+   </h4>
     @can('lesson_create')
-        <a href="{{ route('admin.lessons.create') }}@if(request('course_id')){{'?course_id='.request('course_id')}}@endif"
-           class="btn add-btn">@lang('strings.backend.general.app_add_new')</a>
-    @endcan
+       <div class="">
+           <a href="{{ route('admin.lessons.create') }}@if(request('course_id')){{'?course_id='.request('course_id')}}@endif"
+              class="btn add-btn">@lang('strings.backend.general.app_add_new')</a>
+
+       </div>
+   @endcan
+ 
 </div>
+    <div class="card">
+        <!-- <div class="card-header">
+            
+            <h3 class="page-title d-inline">@lang('labels.backend.lessons.title')</h3>
+            @can('lesson_create')
+                <div class="float-right">
+                    <a href="{{ route('admin.lessons.create') }}@if(request('course_id')){{'?course_id='.request('course_id')}}@endif"
+                       class="btn btn-success">@lang('strings.backend.general.app_add_new')</a>
 
-<div class="card">
-    <div class="card-body">
-
-        {{-- Filter Bar --}}
-        <div class="row align-items-end mb-3">
-            <div class="col-12 col-lg-4 form-group mb-0">
-                <label for="course_id" class="control-label">{{ trans('labels.backend.lessons.fields.course') }}</label>
-                <div class="custom-select-wrapper">
-                    <select id="course_id" name="course_id" class="form-control custom-select-box select2">
-                        <option value="">{{ __('All Courses') }}</option>
-                        @foreach($courses as $course)
-                            <option value="{{ $course->id }}" {{ request('course_id') == $course->id ? 'selected' : '' }}>
-                                {{ $course->title }}
-                            </option>
-                        @endforeach
-                    </select>
-                    <span class="custom-select-icon"><i class="fa fa-chevron-down"></i></span>
+                </div>
+            @endcan
+        </div> -->
+        <div class="card-body">
+            <div class="row">
+                <div class="col-12 col-lg-6 form-group">
+                    <label for="course_id" class="control-label">
+    {{ trans('labels.backend.lessons.fields.course') }}
+</label>
+                    <div class=" custom-select-wrapper">
+    <select name="course_id" id="course_id" class="form-control custom-select-box select2">
+        <option value="">{{ __('course_pages.admin_lessons_index.select_course') }}</option>
+        @foreach($courses as $id => $course)
+            <option value="{{ $id }}" 
+                @if(request('course_id') == $id || old('course_id') == $id) selected @endif>
+                {{ $course }}
+            </option>
+        @endforeach
+    </select>
+    <span class="custom-select-icon">
+        <i class="fa fa-chevron-down"></i>
+    </span>
+</div>
                 </div>
             </div>
-            <div class="col-12 col-lg-3 form-group mb-0">
-                <label for="status_filter" class="control-label">{{ __('Published Status') }}</label>
-                <div class="custom-select-wrapper">
-                    <select id="status_filter" class="form-control custom-select-box">
-                        <option value="">{{ __('All') }}</option>
-                        <option value="published" {{ request('status') === 'published' ? 'selected' : '' }}>{{ __('Published') }}</option>
-                        <option value="unpublished" {{ request('status') === 'unpublished' ? 'selected' : '' }}>{{ __('Unpublished') }}</option>
-                    </select>
-                    <span class="custom-select-icon"><i class="fa fa-chevron-down"></i></span>
-                </div>
+            <div class="d-block">
+                <ul class="list-inline">
+                    <li class="list-inline-item">
+                        <a href="{{ route('admin.lessons.index') }}"
+                           style="{{ request('show_deleted') == 1 ? '' : 'font-weight: 700' }}">{{trans('labels.general.all')}}</a>
+                    </li>
+                    |
+                    <li class="list-inline-item">
+                        <a href="{{trashUrl(request()) }}"
+                           style="{{ request('show_deleted') == 1 ? 'font-weight: 700' : '' }}">{{trans('labels.general.trash')}}</a>
+                    </li>
+                </ul>
             </div>
-            <div class="col-12 col-lg-2 form-group mb-0">
-                <a href="{{ route('admin.lessons.index') }}" class="btn btn-secondary btn-block">{{ __('Reset Filters') }}</a>
-            </div>
-        </div>
 
-        {{-- Trash Toggle --}}
-        <div class="d-block">
-            <ul class="list-inline">
-                <li class="list-inline-item">
-                    <a href="{{ route('admin.lessons.index') }}"
-                       style="{{ request('show_deleted') == 1 ? '' : 'font-weight: 700' }}">
-                        {{ trans('labels.general.all') }}
-                    </a>
-                </li>
-                |
-                <li class="list-inline-item">
-                    <a href="{{ trashUrl(request()) }}"
-                       style="{{ request('show_deleted') == 1 ? 'font-weight: 700' : '' }}">
-                        {{ trans('labels.general.trash') }}
-                    </a>
-                </li>
-            </ul>
-        </div>
+            <div class="table-responsive">
 
-        {{-- Table --}}
-        <div class="table-responsive">
-            <table id="myTable"
-                   class="table table-striped custom-teacher-table @can('lesson_delete') @if(request('show_deleted') != 1) dt-select @endif @endcan">
-                <thead>
+                <table id="myTable"
+                       class="table table-striped custom-teacher-table @can('lesson_delete') @if ( request('show_deleted') != 1 ) dt-select @endif @endcan">
+                    <thead>
                     <tr>
                         @can('lesson_delete')
-                            @if(request('show_deleted') != 1)
-                                <th style="text-align:center;"><input class="mass" type="checkbox" id="select-all"/></th>
-                            @endif
+                            @if ( request('show_deleted') != 1 )
+                                <th style="text-align:center;"><input class="mass" type="checkbox" id="select-all"/>
+                                </th>@endif
                         @endcan
-                        <th>@lang('labels.general.sr_no')</th>
+                            <th>@lang('labels.general.sr_no')</th>
+
+                            {{-- <th>@lang('labels.general.id')</th> --}}
                         <th>@lang('labels.backend.lessons.fields.title')</th>
-                        <th>Course</th>
-                        <th>@lang('Lesson Start Date')</th>
-                        <th>@lang('Duration [minutes]')</th>
-                        <th>@lang('Attendance [count]')</th>
+                        <th>@lang('labels.backend.lessons.fields.course')</th>
+                        <th>{{ __('course_pages.admin_lessons_index.lesson_start_date') }}</th>
+                        <th>{{ __('course_pages.admin_lessons_index.duration_minutes') }}</th>
+                        <th>{{ __('course_pages.admin_lessons_index.attendance_count') }}</th>
                         <th>@lang('labels.backend.courses.fields.qr_code')</th>
                         <th>@lang('labels.backend.lessons.fields.published')</th>
-                        <th style="text-align:center;">@lang('strings.backend.general.actions') &nbsp;</th>
+                        @if( request('show_deleted') == 1 )
+                            <th style="text-align:center;">@lang('strings.backend.general.actions') &nbsp;</th>
+                        @else
+                            <th style="text-align:center;">@lang('strings.backend.general.actions') &nbsp;</th>
+                        @endif
                     </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
 
+            </div>
+
+        </div>
     </div>
-</div>
 
 @stop
 
 @push('after-scripts')
-<script>
-    $(document).ready(function () {
-        @php
-            $show_deleted = request('show_deleted') == 1 ? 1 : 0;
-            $ajaxRoute = route('admin.lessons.get_data', [
-                'show_deleted' => $show_deleted,
-                'course_id'    => request('course_id', ''),
-                'status'       => request('status', ''),
-            ]);
-        @endphp
+    <script>
 
-        var ajaxRoute = '{{ $ajaxRoute }}'.replace(/&amp;/g, '&');
+        $(document).ready(function () {
+            var route = '{{route('admin.lessons.get_data')}}';
 
-        $('#myTable').DataTable({
-            processing: true,
-            serverSide: true,
-            iDisplayLength: 10,
-            retrieve: true,
-            dom: "<'table-controls'lfB>" +
-                 "<'table-responsive't>" +
-                 "<'d-flex justify-content-between align-items-center mt-3'ip><'actions'>",
-            buttons: [
-                {
-                    extend: 'collection',
-                    text: '<i class="fa fa-download icon-styles"></i>',
-                    className: '',
-                    buttons: [
-                        { extend: 'csv', text: 'CSV', exportOptions: { columns: [1, 2, 3, 4, 5] } },
-                        { extend: 'pdf', text: 'PDF', exportOptions: { columns: [1, 2, 3, 4, 5] } },
-                    ],
-                },
-                {
-                    extend: 'colvis',
-                    text: '<i class="fa fa-eye icon-styles" aria-hidden="true"></i>',
-                    className: '',
-                },
-            ],
-            ajax: ajaxRoute,
-            columns: [
-                @if(request('show_deleted') != 1)
-                {
-                    data: function (data) {
-                        return '<input type="checkbox" class="single" name="id[]" value="' + data.id + '" />';
+
+            @php
+                $show_deleted = (request('show_deleted') == 1) ? 1 : 0;
+                $course_id = (request('course_id') != "") ? request('course_id') : '';
+            $route = route('admin.lessons.get_data',['show_deleted' => $show_deleted,'course_id' => $course_id]);
+            @endphp
+
+            route = '{{$route}}';
+            route = route.replace(/&amp;/g, '&');
+
+            $('#myTable').DataTable({
+                processing: true,
+                serverSide: true,
+                iDisplayLength: 10,
+                retrieve: true,
+                dom: "<'table-controls'lfB>" +
+                     "<'table-responsive't>" +
+                     "<'d-flex justify-content-between align-items-center mt-3'ip><'actions'>",
+                             buttons: [
+    {
+        extend: 'collection',
+        text: '<i class="fa fa-download icon-styles"></i>',
+        className: '',
+        buttons: [
+            {
+                extend: 'csv',
+                text: '{{ trans("datatable.csv") }}',
+                exportOptions: {
+                    columns: [1, 2, 3, 4, 5]
+                }
+            },
+            {
+                extend: 'pdf',
+                text: '{{ trans("datatable.pdf") }}',
+                exportOptions: {
+                    columns: [1, 2, 3, 4, 5]
+                }
+            }
+        ]
+    },
+      {extend: 'colvis',
+    text: '<i class="fa fa-eye icon-styles" aria-hidden="true"></i>',
+    className: ''},
+],
+                // buttons: [
+                //     {
+                //         extend: 'csv',
+                //         exportOptions: {
+                //             columns: [ 1, 2, 3, 4]
+                //         }
+                //     },
+                //     {
+                //         extend: 'pdf',
+                //         exportOptions: {
+                //             columns: [ 1, 2, 3, 4]
+                //         }
+                //     },
+                //     'colvis'
+                // ],
+                ajax: route,
+                columns: [
+                        @if(request('show_deleted') != 1)
+                    {
+                        "data": function (data) {
+                            return '<input type="checkbox" class="single" name="id[]" value="' + data.id + '" />';
+                        }, "orderable": false, "searchable": false, "name": "id"
                     },
-                    orderable: false,
-                    searchable: false,
-                    name: 'id',
-                },
+                        @endif
+                    {data: "DT_RowIndex", name: 'DT_RowIndex', searchable: false, orderable:false},
+                    //{data: "id", name: 'id'},
+
+                    {data: "title", name: 'title'},
+                    {data: "course", name: 'course.title', defaultContent: 'N/A'},
+                    {data: "lesson_start_date", name: 'lesson_start_date'},
+                    {data: "duration", name: 'duration'},
+                    {data: "attendance", name: 'attendance'},
+                    {data: "qr_code" , name: "qr_code"},
+                    {data: "published", name: "published"},
+                    {data: "actions", name: "actions"}
+                ],
+                @if(request('show_deleted') != 1)
+                columnDefs: [
+                    {"width": "5%", "targets": 0},
+                    {"className": "text-center", "targets": [0]}
+                ],
                 @endif
-                { data: 'DT_RowIndex', name: 'DT_RowIndex', searchable: false, orderable: false },
-                { data: 'title', name: 'title' },
-                { data: 'course', name: 'course.title', defaultContent: 'N/A' },
-                { data: 'lesson_start_date', name: 'lesson_start_date' },
-                { data: 'duration', name: 'duration' },
-                { data: 'attendance', name: 'attendance' },
-                { data: 'qr_code', name: 'qr_code' },
-                { data: 'published', name: 'published' },
-                { data: 'actions', name: 'actions' },
-            ],
-            @if(request('show_deleted') != 1)
-            columnDefs: [
-                { width: '5%', targets: 0 },
-                { className: 'text-center', targets: [0] },
-            ],
-            @endif
-            initComplete: function () {
-                let $searchInput = $('#myTable_filter input[type="search"]');
-                $searchInput
-                    .addClass('custom-search')
-                    .wrap('<div class="search-wrapper position-relative d-inline-block"></div>')
-                    .after('<i class="fa fa-search search-icon"></i>');
+                initComplete: function () {
+                   let $searchInput = $('#myTable_filter input[type="search"]');
+    $searchInput
+        .addClass('custom-search')
+        .wrap('<div class="search-wrapper position-relative d-inline-block"></div>')
+        .after('<i class="fa fa-search search-icon"></i>');
 
-                $('#myTable_length select').addClass('form-select form-select-sm custom-entries');
-            },
-            createdRow: function (row, data) {
-                $(row).attr('data-entry-id', data.id);
-            },
-            language: {
-                url: '//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/{{ $locale_full_name }}.json',
-                buttons: {
-                    colvis: '{{ trans("datatable.colvis") }}',
-                    pdf: '{{ trans("datatable.pdf") }}',
-                    csv: '{{ trans("datatable.csv") }}',
+    $('#myTable_length select').addClass('form-select form-select-sm custom-entries');
                 },
-                search: '',
-            },
+              
+                createdRow: function (row, data, dataIndex) {
+                    $(row).attr('data-entry-id', data.id);
+                },
+                language:{
+                    url : "//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/{{$locale_full_name}}.json",
+                    buttons :{
+                        colvis : '{{trans("datatable.colvis")}}',
+                        pdf : '{{trans("datatable.pdf")}}',
+                        csv : '{{trans("datatable.csv")}}',
+                    }, 
+                    lengthMenu : '{{trans("datatable.length_menu")}}',
+                    search:"",
+           }
+            });
+
+            @can('lesson_delete')
+            @if(request('show_deleted') != 1)
+            $('.actions').html('<a href="' + '{{ route('admin.lessons.mass_destroy') }}' + '" class="btn btn-xs btn-danger js-delete-selected" style="margin-top:0.755em;margin-left: 20px;">{{ __('course_pages.admin_lessons_index.delete_selected') }}</a>');
+            @endif
+            @endcan
+
+
+            $(".js-example-placeholder-single").select2({
+                placeholder: "{{trans('labels.backend.lessons.select_course')}}",
+            });
+            $(document).on('change', '#course_id', function (e) {
+                var course_id = $(this).val();
+                if (course_id) {
+                    window.location.href = "{{ route('admin.lessons.index') }}" + "?course_id=" + course_id;
+                } else {
+                    window.location.href = "{{ route('admin.lessons.index') }}";
+                }
+            });
         });
 
-        @can('lesson_delete')
-        @if(request('show_deleted') != 1)
-        $('.actions').html(
-            '<a href="{{ route('admin.lessons.mass_destroy') }}" class="btn btn-xs btn-danger js-delete-selected" style="margin-top:0.755em;margin-left:20px;">Delete selected</a>'
-        );
-        @endif
-        @endcan
-
-        $('.js-example-placeholder-single').select2({
-            placeholder: '{{ trans("labels.backend.lessons.select_course") }}',
-        });
-
-        function applyFilters() {
-            var courseId = $('#course_id').val();
-            var status   = $('#status_filter').val();
-            var params   = [];
-
-            if (courseId) params.push('course_id=' + courseId);
-            if (status)   params.push('status=' + status);
-
-            window.location.href = '{{ route('admin.lessons.index') }}'
-                + (params.length ? '?' + params.join('&') : '');
-        }
-
-        $(document).on('change', '#course_id, #status_filter', applyFilters);
-    });
-</script>
+    </script>
 @endpush


### PR DESCRIPTION
📥 Pull Request Template

🔧 Description

This PR is a clean re-submission of the lesson bug fix from updated `main`, scoped strictly to Issue #407.

Included scope only:
- Fix lesson creation failure when `published` is null.
- Normalize and enforce `published` across request/controller/model/db layers.
- Add migration to backfill null values and enforce default/non-null for `lessons.published`.
- Fix lesson media upload/save consistency for downloadable/PDF/audio files.
- Fix lesson edit media visibility and delete behavior (instant row removal + API success/failure consistency).
- Keep lesson media URL fallback compatible with legacy local records.

Explicitly excluded:
- Any multilingual/i18n language-file changes.
- Any unrelated module or platform changes.

Fixes #407

✅ Type of Change

- Bug fix
- Backend data integrity hardening
- Admin lesson UI/UX fix

🚀 How Has This Been Tested?

- Manual verification for lesson create/edit flow
- Static diagnostics in edited files (no reported errors)
- Migration command used in prior validation: `php artisan migrate`

🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin.
2. Go to Course Management > Lessons.
3. Create a lesson with `Published` checked and unchecked.
4. Verify lesson saves without SQL errors.
5. Edit lesson and upload downloadable/PDF/audio files.
6. Save and reopen edit page.
7. Verify files are visible and removable; row disappears instantly on delete.

🔄 Checklist

- Followed the project's coding guidelines
- Verified no sensitive data is included
- Scope limited to ticket-specific files

🙏 Additional Notes

- This PR was intentionally rebuilt from current `main` to keep the diff clean for review.
- It supersedes the previous broader PR context for this bug.
