### PR TITLE
feat: Implement KPI management lifecycle (closes #411)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/KpiController.php
+++ b/app/Http/Controllers/Backend/Admin/KpiController.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Http\Controllers\Backend\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreKpiRequest;
+use App\Http\Requests\Admin\UpdateKpiRequest;
+use App\Models\Kpi;
+use App\Services\KpiCalculationService;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+class KpiController extends Controller
+{
+    protected $calculationService;
+
+    public function __construct(KpiCalculationService $calculationService)
+    {
+        $this->calculationService = $calculationService;
+    }
+
+    public function index(Request $request)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $query = Kpi::query();
+
+        if ($request->filled('search')) {
+            $search = trim($request->search);
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('code', 'like', "%{$search}%")
+                    ->orWhere('type', 'like', "%{$search}%");
+            });
+        }
+
+        $sorts = $this->normalizeSorts($request);
+        $allKpis = $query->get();
+        $totalActiveWeight = (float) Kpi::query()->where('is_active', true)->sum('weight');
+
+        $calculatedKpis = $allKpis->map(function ($kpi) use ($totalActiveWeight) {
+            $kpi->calculation = $this->calculationService->calculateForKpi($kpi, $totalActiveWeight);
+            return $kpi;
+        });
+
+        $sorted = $calculatedKpis->sort(function ($left, $right) use ($sorts) {
+            foreach ($sorts as $sort) {
+                $comparison = $this->compareKpisBySort($left, $right, $sort['by'], $sort['dir']);
+                if ($comparison !== 0) {
+                    return $comparison;
+                }
+            }
+
+            return 0;
+        })->values();
+
+        $currentPage = LengthAwarePaginator::resolveCurrentPage();
+        $perPage = 15;
+        $pageItems = $sorted->forPage($currentPage, $perPage)->values();
+
+        $kpis = new LengthAwarePaginator(
+            $pageItems,
+            $sorted->count(),
+            $perPage,
+            $currentPage,
+            ['path' => LengthAwarePaginator::resolveCurrentPath()]
+        );
+
+        $kpis->appends($request->query());
+
+        $kpiTypes = config('kpi.types', []);
+
+        if ($request->ajax()) {
+            return response()->json([
+                'html' => view('backend.kpis.partials.table', compact('kpis', 'kpiTypes'))->render(),
+                'totalActiveWeight' => number_format($totalActiveWeight, 2),
+            ]);
+        }
+
+        return view('backend.kpis.index', compact('kpis', 'kpiTypes', 'totalActiveWeight'));
+    }
+
+    protected function normalizeSorts(Request $request)
+    {
+        $sortBy = $request->input('sort_by', []);
+        $sortDir = $request->input('sort_dir', []);
+
+        if (!is_array($sortBy)) {
+            $sortBy = [$sortBy];
+        }
+
+        if (!is_array($sortDir)) {
+            $sortDir = [$sortDir];
+        }
+
+        $allowed = ['created_at', 'name', 'code', 'type', 'weight', 'is_active', 'current_value', 'weighted_score'];
+        $sorts = [];
+
+        foreach ($sortBy as $index => $column) {
+            if (!in_array($column, $allowed, true)) {
+                continue;
+            }
+
+            $direction = strtolower($sortDir[$index] ?? 'asc');
+            $sorts[] = [
+                'by' => $column,
+                'dir' => $direction === 'desc' ? 'desc' : 'asc',
+            ];
+        }
+
+        if (empty($sorts)) {
+            $sorts[] = ['by' => 'created_at', 'dir' => 'desc'];
+        }
+
+        return $sorts;
+    }
+
+    protected function compareKpisBySort($left, $right, $column, $direction)
+    {
+        $leftValue = $this->extractSortValue($left, $column);
+        $rightValue = $this->extractSortValue($right, $column);
+
+        if (in_array($column, ['current_value', 'weighted_score'], true)) {
+            $leftExcluded = (bool) ($left->calculation['excluded'] ?? false);
+            $rightExcluded = (bool) ($right->calculation['excluded'] ?? false);
+
+            if ($leftExcluded !== $rightExcluded) {
+                return $leftExcluded ? 1 : -1;
+            }
+        }
+
+        if ($leftValue === $rightValue) {
+            return 0;
+        }
+
+        if ($leftValue < $rightValue) {
+            return $direction === 'asc' ? -1 : 1;
+        }
+
+        return $direction === 'asc' ? 1 : -1;
+    }
+
+    protected function extractSortValue($kpi, $column)
+    {
+        switch ($column) {
+            case 'name':
+            case 'code':
+            case 'type':
+                return mb_strtolower((string) $kpi->{$column});
+            case 'weight':
+                return (float) $kpi->weight;
+            case 'is_active':
+                return (int) $kpi->is_active;
+            case 'current_value':
+                return (float) ($kpi->calculation['value'] ?? 0);
+            case 'weighted_score':
+                return (float) ($kpi->calculation['weighted_score'] ?? 0);
+            case 'created_at':
+            default:
+                return optional($kpi->created_at)->timestamp ?? 0;
+        }
+    }
+
+    public function create()
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $kpiTypes = config('kpi.types', []);
+        $maxWeight = config('kpi.max_weight', 100);
+        $defaultWeight = config('kpi.default_weight', 1);
+
+        return view('backend.kpis.create', compact('kpiTypes', 'maxWeight', 'defaultWeight'));
+    }
+
+    public function store(StoreKpiRequest $request)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        Kpi::create([
+            'name' => $request->name,
+            'code' => strtoupper(trim($request->code)),
+            'type' => $request->type,
+            'description' => $request->description,
+            'weight' => $request->weight,
+            'is_active' => true,
+            'created_by' => \Auth::id(),
+            'updated_by' => \Auth::id(),
+        ]);
+
+        $created = Kpi::query()->where('code', strtoupper(trim($request->code)))->first();
+        if ($created) {
+            $created->statusHistories()->create([
+                'action' => 'created',
+                'previous_is_active' => null,
+                'new_is_active' => true,
+                'changed_by' => \Auth::id(),
+                'meta' => [
+                    'type' => $created->type,
+                    'weight' => $created->weight,
+                ],
+            ]);
+        }
+
+        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI created successfully.');
+    }
+
+    public function edit($kpi)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $kpi = Kpi::findOrFail($kpi);
+
+        $kpiTypes = config('kpi.types', []);
+        $maxWeight = config('kpi.max_weight', 100);
+
+        return view('backend.kpis.edit', compact('kpi', 'kpiTypes', 'maxWeight'));
+    }
+
+    public function update(UpdateKpiRequest $request, $kpi)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $kpiModel = Kpi::findOrFail($kpi);
+        $oldType = $kpiModel->type;
+        $oldWeight = $kpiModel->weight;
+
+        $kpiModel->name = $request->name;
+        $kpiModel->code = strtoupper(trim($request->code));
+        $kpiModel->type = $request->type;
+        $kpiModel->description = $request->description;
+        $kpiModel->weight = $request->weight;
+        $kpiModel->updated_by = \Auth::id();
+        $kpiModel->save();
+
+        $typeChanged = $oldType !== $kpiModel->type;
+        $weightChanged = (float) $oldWeight !== (float) $kpiModel->weight;
+        if ($typeChanged || $weightChanged) {
+            $kpiModel->statusHistories()->create([
+                'action' => 'updated',
+                'previous_is_active' => $kpiModel->is_active,
+                'new_is_active' => $kpiModel->is_active,
+                'changed_by' => \Auth::id(),
+                'meta' => [
+                    'old_type' => $oldType,
+                    'new_type' => $kpiModel->type,
+                    'old_weight' => $oldWeight,
+                    'new_weight' => $kpiModel->weight,
+                ],
+            ]);
+        }
+
+        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI updated successfully.');
+    }
+
+    public function toggleStatus($kpi)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $kpiModel = Kpi::findOrFail($kpi);
+        $previousStatus = (bool) $kpiModel->is_active;
+        $kpiModel->is_active = !$kpiModel->is_active;
+        $kpiModel->updated_by = \Auth::id();
+        $kpiModel->save();
+
+        $kpiModel->statusHistories()->create([
+            'action' => $kpiModel->is_active ? 'activated' : 'deactivated',
+            'previous_is_active' => $previousStatus,
+            'new_is_active' => (bool) $kpiModel->is_active,
+            'changed_by' => \Auth::id(),
+            'meta' => null,
+        ]);
+
+        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI status updated successfully.');
+    }
+
+    public function destroy($kpi)
+    {
+        if (!Gate::allows('category_access')) {
+            return abort(401);
+        }
+
+        $kpiModel = Kpi::findOrFail($kpi);
+        $previousStatus = (bool) $kpiModel->is_active;
+        $kpiModel->updated_by = \Auth::id();
+        $kpiModel->save();
+        $kpiModel->delete();
+
+        $kpiModel->statusHistories()->create([
+            'action' => 'deleted',
+            'previous_is_active' => $previousStatus,
+            'new_is_active' => $previousStatus,
+            'changed_by' => \Auth::id(),
+            'meta' => ['soft_deleted' => true],
+        ]);
+
+        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI deleted successfully.');
+    }
+}

--- a/app/Http/Requests/Admin/StoreKpiRequest.php
+++ b/app/Http/Requests/Admin/StoreKpiRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreKpiRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'code' => ['required', 'string', 'max:64', 'regex:/^[A-Z][A-Z0-9_]*$/', 'unique:kpis,code'],
+            'type' => ['required', Rule::in(array_keys(config('kpi.types', [])))],
+            'weight' => 'required|numeric|min:0|max:' . config('kpi.max_weight', 100),
+            'description' => 'required|string|max:5000',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'code.regex' => 'KPI code must start with an uppercase letter and use only uppercase letters, numbers, and underscores.',
+            'type.in' => 'Selected KPI type is not supported.',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateKpiRequest.php
+++ b/app/Http/Requests/Admin/UpdateKpiRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateKpiRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $kpiId = $this->route('kpi');
+
+        return [
+            'name' => 'required|string|max:255',
+            'code' => [
+                'required',
+                'string',
+                'max:64',
+                'regex:/^[A-Z][A-Z0-9_]*$/',
+                Rule::unique('kpis', 'code')->ignore($kpiId),
+            ],
+            'type' => ['required', Rule::in(array_keys(config('kpi.types', [])))],
+            'weight' => 'required|numeric|min:0|max:' . config('kpi.max_weight', 100),
+            'description' => 'required|string|max:5000',
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $kpiId = $this->route('kpi');
+            if (!$kpiId) {
+                return;
+            }
+
+            $kpi = \App\Models\Kpi::find($kpiId);
+            if (!$kpi) {
+                return;
+            }
+
+            $typeChanged = $kpi->type !== $this->input('type');
+            if ($typeChanged && $kpi->is_active && (float) $this->input('weight', 0) <= 0) {
+                $validator->errors()->add('weight', 'Weight must be greater than 0 when changing KPI type for an active KPI.');
+            }
+        });
+    }
+
+    public function messages()
+    {
+        return [
+            'code.regex' => 'KPI code must start with an uppercase letter and use only uppercase letters, numbers, and underscores.',
+            'type.in' => 'Selected KPI type is not supported.',
+        ];
+    }
+}

--- a/app/Models/Kpi.php
+++ b/app/Models/Kpi.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Auth\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Kpi extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'code',
+        'type',
+        'description',
+        'weight',
+        'is_active',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'weight' => 'float',
+    ];
+
+    protected $attributes = [
+        'weight' => 1,
+    ];
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updater()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    public function statusHistories()
+    {
+        return $this->hasMany(KpiStatusHistory::class);
+    }
+
+    public function getTypeLabelAttribute()
+    {
+        return config('kpi.types.' . $this->type . '.label', ucfirst($this->type));
+    }
+}

--- a/app/Models/KpiStatusHistory.php
+++ b/app/Models/KpiStatusHistory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Auth\User;
+use Illuminate\Database\Eloquent\Model;
+
+class KpiStatusHistory extends Model
+{
+    protected $fillable = [
+        'kpi_id',
+        'action',
+        'previous_is_active',
+        'new_is_active',
+        'changed_by',
+        'meta',
+    ];
+
+    protected $casts = [
+        'previous_is_active' => 'boolean',
+        'new_is_active' => 'boolean',
+        'meta' => 'array',
+    ];
+
+    public function kpi()
+    {
+        return $this->belongsTo(Kpi::class);
+    }
+
+    public function changer()
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/app/Services/KpiCalculationService.php
+++ b/app/Services/KpiCalculationService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class KpiCalculationService
+{
+    protected $typeValueCache = [];
+
+    public function getSupportedTypeKeys()
+    {
+        return array_keys(config('kpi.types', []));
+    }
+
+    public function calculateForKpi($kpi, $totalActiveWeight)
+    {
+        if (!$kpi->is_active) {
+            return [
+                'excluded' => true,
+                'value' => null,
+                'weighted_score' => null,
+            ];
+        }
+
+        $value = $this->calculateTypeValue($kpi->type);
+        $weight = (float) $kpi->weight;
+        $totalWeight = (float) $totalActiveWeight;
+
+        $weightedScore = 0.0;
+        if ($totalWeight > 0 && $weight >= 0) {
+            $weightedScore = ($value * $weight) / $totalWeight;
+        }
+
+        return [
+            'excluded' => false,
+            'value' => round($value, 2),
+            'weighted_score' => round($weightedScore, 2),
+        ];
+    }
+
+    public function calculateTypeValue($type)
+    {
+        if (array_key_exists($type, $this->typeValueCache)) {
+            return $this->typeValueCache[$type];
+        }
+
+        $value = 0.0;
+        switch ($type) {
+            case 'completion':
+                $value = $this->calculateCompletionValue();
+                break;
+            case 'score':
+                $value = $this->calculateScoreValue();
+                break;
+            case 'activity':
+                $value = $this->calculateActivityValue();
+                break;
+            case 'time':
+                $value = $this->calculateTimeValue();
+                break;
+            default:
+                $value = 0.0;
+        }
+
+        $this->typeValueCache[$type] = $value;
+
+        return $value;
+    }
+
+    protected function calculateCompletionValue()
+    {
+        if (Schema::hasTable('employee_course_progress') && Schema::hasColumn('employee_course_progress', 'progress')) {
+            $avg = DB::table('employee_course_progress')->whereNotNull('progress')->avg('progress');
+            return $this->normalizePercent($avg);
+        }
+
+        if (Schema::hasTable('subscribe_courses') && Schema::hasColumn('subscribe_courses', 'progress_percent')) {
+            $avg = DB::table('subscribe_courses')->whereNotNull('progress_percent')->avg('progress_percent');
+            return $this->normalizePercent($avg);
+        }
+
+        return 0.0;
+    }
+
+    protected function calculateScoreValue()
+    {
+        if (Schema::hasTable('tests_results') && Schema::hasColumn('tests_results', 'test_result')) {
+            $avg = DB::table('tests_results')->whereNotNull('test_result')->avg('test_result');
+            return $this->normalizePercent($avg);
+        }
+
+        if (Schema::hasTable('subscribe_courses') && Schema::hasColumn('subscribe_courses', 'assignment_score')) {
+            $avg = DB::table('subscribe_courses')->whereNotNull('assignment_score')->avg('assignment_score');
+            return $this->normalizePercent($avg);
+        }
+
+        return 0.0;
+    }
+
+    protected function calculateActivityValue()
+    {
+        $videoScore = 0.0;
+        $attendanceScore = 0.0;
+
+        if (Schema::hasTable('video_progresses')) {
+            if (Schema::hasColumn('video_progresses', 'progress')) {
+                $videoScore = $this->normalizePercent(DB::table('video_progresses')->whereNotNull('progress')->avg('progress'));
+            } else {
+                $count = (int) DB::table('video_progresses')->count();
+                $videoScore = min(100.0, $count * 2.0);
+            }
+        }
+
+        if (Schema::hasTable('live_session_attendances')) {
+            $attendanceCount = (int) DB::table('live_session_attendances')->count();
+            $attendanceScore = min(100.0, $attendanceCount * 2.0);
+        }
+
+        return round(($videoScore * 0.6) + ($attendanceScore * 0.4), 2);
+    }
+
+    protected function calculateTimeValue()
+    {
+        if (Schema::hasTable('assignments') && Schema::hasColumn('assignments', 'duration')) {
+            $avgMinutes = DB::table('assignments')->whereNotNull('duration')->avg('duration');
+            if ($avgMinutes === null) {
+                return 0.0;
+            }
+
+            // 60 minutes = full score baseline for normalized time KPI.
+            $normalized = ((float) $avgMinutes / 60) * 100;
+            return round(min(100.0, max(0.0, $normalized)), 2);
+        }
+
+        return 0.0;
+    }
+
+    protected function normalizePercent($value)
+    {
+        if ($value === null) {
+            return 0.0;
+        }
+
+        return round(min(100.0, max(0.0, (float) $value)), 2);
+    }
+}

--- a/config/kpi.php
+++ b/config/kpi.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'default_weight' => 1,
+    'max_weight' => 100,
+
+    // Centralized KPI type registry. Admin can only select these keys.
+    'types' => [
+        'completion' => [
+            'label' => 'Completion',
+            'description' => 'Measures completion progress as a percentage.',
+        ],
+        'score' => [
+            'label' => 'Score',
+            'description' => 'Measures result quality based on score outcomes.',
+        ],
+        'activity' => [
+            'label' => 'Activity',
+            'description' => 'Measures engagement/activity from platform interactions.',
+        ],
+        'time' => [
+            'label' => 'Time',
+            'description' => 'Measures time-based performance against expected duration.',
+        ],
+    ],
+];

--- a/database/migrations/2026_04_02_120000_create_kpis_table.php
+++ b/database/migrations/2026_04_02_120000_create_kpis_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateKpisTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('kpis', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('code', 64)->unique();
+            $table->string('type', 100);
+            $table->text('description');
+            $table->boolean('is_active')->default(true);
+            $table->unsignedInteger('created_by')->nullable();
+            $table->unsignedInteger('updated_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('kpis');
+    }
+}

--- a/database/migrations/2026_04_02_130000_add_weight_to_kpis_table.php
+++ b/database/migrations/2026_04_02_130000_add_weight_to_kpis_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWeightToKpisTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('kpis', function (Blueprint $table) {
+            $table->decimal('weight', 8, 2)->default(1)->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('kpis', function (Blueprint $table) {
+            $table->dropColumn('weight');
+        });
+    }
+}

--- a/database/migrations/2026_04_02_130100_create_kpi_status_histories_table.php
+++ b/database/migrations/2026_04_02_130100_create_kpi_status_histories_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateKpiStatusHistoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('kpi_status_histories', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('kpi_id');
+            $table->string('action', 50);
+            $table->boolean('previous_is_active')->nullable();
+            $table->boolean('new_is_active')->nullable();
+            $table->unsignedInteger('changed_by')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->foreign('kpi_id')->references('id')->on('kpis')->onDelete('cascade');
+            $table->foreign('changed_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('kpi_status_histories');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -35,6 +35,8 @@ class DatabaseSeeder extends Seeder
         $this->call(CommissionRateSeeder::class);
         $this->call(EventsSeeder::class);
         $this->call(NewsSeeder::class);
+        $this->call(KpiSeeder::class);
+        $this->call(KpiLifecycleSeeder::class);
         //Artisan::call('translations:import');
         //Artisan::call('storage:link');
         Model::reguard();

--- a/database/seeders/DummyDataSeeder.php
+++ b/database/seeders/DummyDataSeeder.php
@@ -21,6 +21,8 @@ class DummyDataSeeder extends Seeder
         $this->call(FaqSeeder::class);
         $this->call(ReasonSeeder::class);
         $this->call(ChatterTableSeeder::class);
+        $this->call(KpiSeeder::class);
+        $this->call(KpiLifecycleSeeder::class);
 
     }
 }

--- a/database/seeders/KpiLifecycleSeeder.php
+++ b/database/seeders/KpiLifecycleSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Auth\User;
+use App\Models\Kpi;
+use Illuminate\Database\Seeder;
+
+class KpiLifecycleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $seedUserId = User::query()->value('id');
+
+        $legacy = Kpi::withTrashed()->updateOrCreate(
+            ['code' => 'LEGACY_SUPPORT_RESPONSE_TIME'],
+            [
+                'name' => 'Legacy Support Response Time',
+                'type' => 'time',
+                'description' => 'Legacy KPI kept for historical reporting validation in tests.',
+                'weight' => 1,
+                'is_active' => false,
+                'created_by' => $seedUserId,
+                'updated_by' => $seedUserId,
+            ]
+        );
+
+        if (!$legacy->trashed()) {
+            $legacy->delete();
+        }
+
+        $inactive = Kpi::query()->where('code', 'TRAINING_ATTENDANCE_RATE')->first();
+        if ($inactive) {
+            $inactive->is_active = false;
+            $inactive->updated_by = $seedUserId;
+            $inactive->save();
+        }
+    }
+}

--- a/database/seeders/KpiSeeder.php
+++ b/database/seeders/KpiSeeder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Auth\User;
+use App\Models\Kpi;
+use Illuminate\Database\Seeder;
+
+class KpiSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $seedUserId = User::query()->value('id');
+
+        $kpis = [
+            [
+                'name' => 'Course Completion Rate',
+                'code' => 'COURSE_COMPLETION_RATE',
+                'type' => 'completion',
+                'description' => 'Percentage of enrolled users who completed assigned courses within the reporting period.',
+                'weight' => 30,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Assessment Pass Rate',
+                'code' => 'ASSESSMENT_PASS_RATE',
+                'type' => 'score',
+                'description' => 'Percentage of users who achieved the minimum passing score in assessments.',
+                'weight' => 25,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Average Assessment Score',
+                'code' => 'AVG_ASSESSMENT_SCORE',
+                'type' => 'score',
+                'description' => 'Average score achieved by users across all completed assessments.',
+                'weight' => 20,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Training Attendance Rate',
+                'code' => 'TRAINING_ATTENDANCE_RATE',
+                'type' => 'activity',
+                'description' => 'Attendance percentage for scheduled training sessions and live classes.',
+                'weight' => 10,
+                'is_active' => false,
+            ],
+            [
+                'name' => 'Assignment Submission Timeliness',
+                'code' => 'ASSIGNMENT_SUBMISSION_TIMELINESS',
+                'type' => 'time',
+                'description' => 'Percentage of assignments submitted on or before due date.',
+                'weight' => 15,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Learner Engagement Index',
+                'code' => 'LEARNER_ENGAGEMENT_INDEX',
+                'type' => 'activity',
+                'description' => 'Composite KPI from logins, lesson progress, and assessment activity.',
+                'weight' => 5,
+                'is_active' => false,
+            ],
+        ];
+
+        foreach ($kpis as $kpiData) {
+            $kpi = Kpi::withTrashed()->firstOrNew(['code' => $kpiData['code']]);
+            $kpi->fill(array_merge($kpiData, [
+                'created_by' => $kpi->exists ? $kpi->created_by : $seedUserId,
+                'updated_by' => $seedUserId,
+            ]));
+            $kpi->save();
+
+            if ($kpi->trashed()) {
+                $kpi->restore();
+            }
+        }
+    }
+}

--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -172,6 +172,15 @@
                     <span class="title">@lang('menus.backend.sidebar.position')</span>
                 </a>
             </li>
+            @if($logged_in_user->isAdmin())
+            <li class="nav-item ">
+                <a class="nav-link {{ $request->segment(2) == 'kpis' ? 'active' : '' }}"
+                    href="{{ route('admin.kpis.index') }}">
+                    <i class="nav-icon fa fa-bullseye"></i>
+                    <span class="title">KPI Management</span>
+                </a>
+            </li>
+            @endif
             @endif
             @if (null == Session::get('setvaluesession') ||
             (null !== Session::get('setvaluesession') && in_array(Session::get('setvaluesession'), [1,2,3])))

--- a/resources/views/backend/kpis/create.blade.php
+++ b/resources/views/backend/kpis/create.blade.php
@@ -1,0 +1,90 @@
+@extends('backend.layouts.app')
+
+@section('title', 'Create KPI | ' . app_name())
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center pb-3">
+        <h4 class="mb-0">Create KPI</h4>
+        <a href="{{ route('admin.kpis.index') }}" class="btn btn-primary">View KPIs</a>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="POST" action="{{ route('admin.kpis.store') }}">
+                @csrf
+
+                <div class="row">
+                    <div class="col-md-6 form-group">
+                        <label for="name">KPI Name *</label>
+                        <input type="text" id="name" name="name" class="form-control" value="{{ old('name') }}" required>
+                    </div>
+
+                    <div class="col-md-6 form-group">
+                        <label for="code">KPI Code *</label>
+                        <input
+                            type="text"
+                            id="code"
+                            name="code"
+                            class="form-control"
+                            value="{{ old('code') }}"
+                            placeholder="Example: COURSE_COMPLETION_RATE"
+                            required
+                        >
+                        <small class="form-text text-muted">Use uppercase letters, numbers, and underscores only.</small>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 form-group">
+                        <label for="type">KPI Type *</label>
+                        <select id="type" name="type" class="form-control" required>
+                            <option value="">Select a KPI type</option>
+                            @foreach($kpiTypes as $typeKey => $typeConfig)
+                                <option value="{{ $typeKey }}" {{ old('type') === $typeKey ? 'selected' : '' }}>
+                                    {{ $typeConfig['label'] }}
+                                </option>
+                            @endforeach
+                        </select>
+                        <small class="form-text text-muted">Formulas are system-managed. Admin selects only supported KPI types.</small>
+                    </div>
+
+                    <div class="col-md-6 form-group">
+                        <label for="weight">Weight *</label>
+                        <input
+                            type="number"
+                            id="weight"
+                            name="weight"
+                            class="form-control"
+                            min="0"
+                            max="{{ $maxWeight }}"
+                            step="0.01"
+                            value="{{ old('weight', $defaultWeight) }}"
+                            required
+                        >
+                        <small class="form-text text-muted">Set relative importance. Allowed range: 0 to {{ $maxWeight }}.</small>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12 form-group">
+                        <label for="description">Description *</label>
+                        <textarea id="description" name="description" rows="4" class="form-control" required>{{ old('description') }}</textarea>
+                    </div>
+                </div>
+
+                <div class="text-right">
+                    <button type="submit" class="add-btn">Save KPI</button>
+                </div>
+            </form>
+
+            <div class="mt-3">
+                <h6 class="mb-2">KPI Type Guide</h6>
+                <ul class="mb-0 pl-3">
+                    @foreach($kpiTypes as $typeConfig)
+                        <li><strong>{{ $typeConfig['label'] }}:</strong> {{ $typeConfig['description'] }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/backend/kpis/edit.blade.php
+++ b/resources/views/backend/kpis/edit.blade.php
@@ -1,0 +1,91 @@
+@extends('backend.layouts.app')
+
+@section('title', 'Edit KPI | ' . app_name())
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center pb-3">
+        <h4 class="mb-0">Edit KPI</h4>
+        <a href="{{ route('admin.kpis.index') }}" class="btn btn-primary">View KPIs</a>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="POST" action="{{ route('admin.kpis.update', $kpi->id) }}">
+                @csrf
+                @method('PUT')
+
+                <div class="row">
+                    <div class="col-md-6 form-group">
+                        <label for="name">KPI Name *</label>
+                        <input type="text" id="name" name="name" class="form-control" value="{{ old('name', $kpi->name) }}" required>
+                    </div>
+
+                    <div class="col-md-6 form-group">
+                        <label for="code">KPI Code *</label>
+                        <input
+                            type="text"
+                            id="code"
+                            name="code"
+                            class="form-control"
+                            value="{{ old('code', $kpi->code) }}"
+                            placeholder="Example: COURSE_COMPLETION_RATE"
+                            required
+                        >
+                        <small class="form-text text-muted">Use uppercase letters, numbers, and underscores only.</small>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 form-group">
+                        <label for="type">KPI Type *</label>
+                        <select id="type" name="type" class="form-control" required>
+                            <option value="">Select a KPI type</option>
+                            @foreach($kpiTypes as $typeKey => $typeConfig)
+                                <option value="{{ $typeKey }}" {{ old('type', $kpi->type) === $typeKey ? 'selected' : '' }}>
+                                    {{ $typeConfig['label'] }}
+                                </option>
+                            @endforeach
+                        </select>
+                        <small class="form-text text-muted">Changing KPI type triggers validation before save.</small>
+                    </div>
+
+                    <div class="col-md-6 form-group">
+                        <label for="weight">Weight *</label>
+                        <input
+                            type="number"
+                            id="weight"
+                            name="weight"
+                            class="form-control"
+                            min="0"
+                            max="{{ $maxWeight }}"
+                            step="0.01"
+                            value="{{ old('weight', $kpi->weight) }}"
+                            required
+                        >
+                        <small class="form-text text-muted">Allowed range: 0 to {{ $maxWeight }}.</small>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12 form-group">
+                        <label for="description">Description *</label>
+                        <textarea id="description" name="description" rows="4" class="form-control" required>{{ old('description', $kpi->description) }}</textarea>
+                    </div>
+                </div>
+
+                <div class="text-right">
+                    <button type="submit" class="add-btn">Update KPI</button>
+                </div>
+            </form>
+
+            <div class="mt-3">
+                <h6 class="mb-2">KPI Type Guide</h6>
+                <ul class="mb-0 pl-3">
+                    @foreach($kpiTypes as $typeConfig)
+                        <li><strong>{{ $typeConfig['label'] }}:</strong> {{ $typeConfig['description'] }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/backend/kpis/index.blade.php
+++ b/resources/views/backend/kpis/index.blade.php
@@ -1,0 +1,180 @@
+@extends('backend.layouts.app')
+
+@section('title', 'KPI Management | ' . app_name())
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center pb-3">
+        <h4 class="mb-0">KPI Management</h4>
+        <a href="{{ route('admin.kpis.create') }}" class="add-btn">Add KPI</a>
+    </div>
+
+    <div class="alert alert-info">
+        Active KPI total weight: <strong id="kpi-active-total-weight">{{ number_format($totalActiveWeight, 2) }}</strong>
+    </div>
+
+    <p class="text-muted small">Click a sortable header to cycle through ascending, descending, and off. Multiple active sorts are applied automatically.</p>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="GET" action="{{ route('admin.kpis.index') }}" class="mb-3">
+                <div class="row">
+                    <div class="col-md-6">
+                        <input
+                            type="text"
+                            id="kpi-search"
+                            name="search"
+                            class="form-control"
+                            placeholder="Search by name, code, or type"
+                            value="{{ request('search') }}"
+                            autocomplete="off"
+                        >
+                        <small class="form-text text-muted">Instant search enabled</small>
+                    </div>
+                </div>
+            </form>
+
+            <div id="kpi-results">
+                @include('backend.kpis.partials.table', ['kpis' => $kpis, 'kpiTypes' => $kpiTypes])
+            </div>
+        </div>
+    </div>
+
+    <script>
+        (function () {
+            var form = document.querySelector('form[action="{{ route('admin.kpis.index') }}"]');
+            var searchInput = document.getElementById('kpi-search');
+            var resultsContainer = document.getElementById('kpi-results');
+            var totalWeightEl = document.getElementById('kpi-active-total-weight');
+            var timer = null;
+            var activeRequest = null;
+            var sorts = [];
+
+            if (!form || !searchInput || !resultsContainer) {
+                return;
+            }
+
+            function readSortsFromUrl() {
+                var url = new URL(window.location.href);
+                var by = url.searchParams.getAll('sort_by[]');
+                var dir = url.searchParams.getAll('sort_dir[]');
+
+                sorts = by.map(function (column, index) {
+                    return {
+                        by: column,
+                        dir: (dir[index] || 'asc') === 'desc' ? 'desc' : 'asc'
+                    };
+                });
+            }
+
+            readSortsFromUrl();
+
+            function requestAndRender(url) {
+                if (activeRequest) {
+                    activeRequest.abort();
+                }
+
+                activeRequest = new XMLHttpRequest();
+                activeRequest.open('GET', url, true);
+                activeRequest.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+                activeRequest.onreadystatechange = function () {
+                    if (activeRequest.readyState !== 4) {
+                        return;
+                    }
+
+                    if (activeRequest.status < 200 || activeRequest.status >= 300) {
+                        return;
+                    }
+
+                    var response = JSON.parse(activeRequest.responseText);
+                    resultsContainer.innerHTML = response.html;
+                    if (totalWeightEl && response.totalActiveWeight) {
+                        totalWeightEl.textContent = response.totalActiveWeight;
+                    }
+
+                    if (window.history && window.history.replaceState) {
+                        window.history.replaceState({}, '', url);
+                    }
+                };
+                activeRequest.send();
+            }
+
+            function buildUrl(pageUrl) {
+                if (pageUrl) {
+                    var parsed = new URL(pageUrl, window.location.origin);
+                    var currentSearch = searchInput.value.trim();
+                    if (currentSearch.length > 0) {
+                        parsed.searchParams.set('search', currentSearch);
+                    } else {
+                        parsed.searchParams.delete('search');
+                    }
+                    parsed.searchParams.delete('sort_by[]');
+                    parsed.searchParams.delete('sort_dir[]');
+                    sorts.forEach(function (sort) {
+                        parsed.searchParams.append('sort_by[]', sort.by);
+                        parsed.searchParams.append('sort_dir[]', sort.dir);
+                    });
+                    return parsed.toString();
+                }
+
+                var url = new URL(form.action, window.location.origin);
+                var value = searchInput.value.trim();
+                if (value.length > 0) {
+                    url.searchParams.set('search', value);
+                }
+                sorts.forEach(function (sort) {
+                    url.searchParams.append('sort_by[]', sort.by);
+                    url.searchParams.append('sort_dir[]', sort.dir);
+                });
+                return url.toString();
+            }
+
+            function updateSortState(column) {
+                var existingIndex = sorts.findIndex(function (sort) {
+                    return sort.by === column;
+                });
+
+                if (existingIndex === -1) {
+                    sorts.push({ by: column, dir: 'asc' });
+                    return;
+                }
+
+                if (sorts[existingIndex].dir === 'asc') {
+                    sorts[existingIndex].dir = 'desc';
+                    return;
+                }
+
+                sorts.splice(existingIndex, 1);
+            }
+
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                requestAndRender(buildUrl());
+            });
+
+            searchInput.addEventListener('input', function () {
+                clearTimeout(timer);
+                timer = setTimeout(function () {
+                    requestAndRender(buildUrl());
+                }, 300);
+            });
+
+            document.addEventListener('click', function (e) {
+                var link = e.target.closest('#kpi-results .pagination a');
+                if (!link) {
+                    var sortButton = e.target.closest('#kpi-results .js-kpi-sort');
+                    if (!sortButton) {
+                        return;
+                    }
+
+                    e.preventDefault();
+                    updateSortState(sortButton.getAttribute('data-sort-column'));
+                    requestAndRender(buildUrl());
+                    return;
+                }
+
+                e.preventDefault();
+                requestAndRender(buildUrl(link.getAttribute('href')));
+            });
+        })();
+    </script>
+@endsection

--- a/resources/views/backend/kpis/partials/table.blade.php
+++ b/resources/views/backend/kpis/partials/table.blade.php
@@ -1,0 +1,138 @@
+@php
+    $currentSortBy = request()->input('sort_by', []);
+    $currentSortDir = request()->input('sort_dir', []);
+
+    if (!is_array($currentSortBy)) {
+        $currentSortBy = [$currentSortBy];
+    }
+
+    if (!is_array($currentSortDir)) {
+        $currentSortDir = [$currentSortDir];
+    }
+
+    $sortMetaFor = function ($column) use ($currentSortBy, $currentSortDir) {
+        $index = array_search($column, $currentSortBy, true);
+        if ($index === false) {
+            return [
+                'icon' => '<i class="fa fa-sort text-muted ml-1" aria-hidden="true"></i>',
+                'priority' => null,
+                'next_dir' => 'asc',
+            ];
+        }
+
+        $dir = strtolower($currentSortDir[$index] ?? 'asc') === 'desc' ? 'desc' : 'asc';
+
+        return [
+            'icon' => $dir === 'asc'
+                ? '<i class="fa fa-sort-amount-up ml-1" aria-hidden="true"></i>'
+                : '<i class="fa fa-sort-amount-down ml-1" aria-hidden="true"></i>',
+            'priority' => $index + 1,
+            'next_dir' => $dir === 'asc' ? 'desc' : 'asc',
+        ];
+    };
+
+    $typeSort = $sortMetaFor('type');
+    $weightSort = $sortMetaFor('weight');
+    $statusSort = $sortMetaFor('is_active');
+    $currentValueSort = $sortMetaFor('current_value');
+    $weightedScoreSort = $sortMetaFor('weighted_score');
+@endphp
+
+<div class="table-responsive">
+    <table class="table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Code</th>
+                <th>
+                    <button type="button" class="btn btn-link btn-sm p-0 text-dark js-kpi-sort" data-sort-column="type">
+                        Type {!! $typeSort['icon'] !!}
+                    </button>
+                    <i class="fa fa-question-circle text-muted ml-1" title="KPI category that maps to a predefined system calculation logic."></i>
+                </th>
+                <th>
+                    <button type="button" class="btn btn-link btn-sm p-0 text-dark js-kpi-sort" data-sort-column="weight">
+                        Weight {!! $weightSort['icon'] !!}
+                    </button>
+                    <i class="fa fa-question-circle text-muted ml-1" title="Relative importance of this KPI in weighted scoring."></i>
+                </th>
+                <th>
+                    <button type="button" class="btn btn-link btn-sm p-0 text-dark js-kpi-sort" data-sort-column="is_active">
+                        Status {!! $statusSort['icon'] !!}
+                    </button>
+                    <i class="fa fa-question-circle text-muted ml-1" title="Active KPIs are included in calculations; inactive KPIs are excluded."></i>
+                </th>
+                <th>
+                    <button type="button" class="btn btn-link btn-sm p-0 text-dark js-kpi-sort" data-sort-column="current_value">
+                        Current Value {!! $currentValueSort['icon'] !!}
+                    </button>
+                    <i class="fa fa-question-circle text-muted ml-1" title="Latest computed KPI value produced by the mapped KPI type logic."></i>
+                </th>
+                <th>
+                    <button type="button" class="btn btn-link btn-sm p-0 text-dark js-kpi-sort" data-sort-column="weighted_score">
+                        Weighted Score {!! $weightedScoreSort['icon'] !!}
+                    </button>
+                    <i class="fa fa-question-circle text-muted ml-1" title="KPI contribution after applying its weight relative to total active weight."></i>
+                </th>
+                <th>Updated</th>
+                <th class="text-center">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($kpis as $kpi)
+                <tr>
+                    <td>{{ $kpi->id }}</td>
+                    <td>{{ $kpi->name }}</td>
+                    <td><code>{{ $kpi->code }}</code></td>
+                    <td title="{{ $kpiTypes[$kpi->type]['description'] ?? '' }}">{{ $kpiTypes[$kpi->type]['label'] ?? ucfirst($kpi->type) }}</td>
+                    <td>{{ number_format((float) $kpi->weight, 2) }}</td>
+                    <td>
+                        @if($kpi->is_active)
+                            <span class="badge badge-success">Active</span>
+                        @else
+                            <span class="badge badge-secondary">Inactive</span>
+                        @endif
+                    </td>
+                    <td>
+                        @if($kpi->calculation['excluded'])
+                            <span class="text-muted">Excluded</span>
+                        @else
+                            {{ number_format((float) $kpi->calculation['value'], 2) }}
+                        @endif
+                    </td>
+                    <td>
+                        @if($kpi->calculation['excluded'])
+                            <span class="text-muted">Excluded</span>
+                        @else
+                            {{ number_format((float) $kpi->calculation['weighted_score'], 2) }}
+                        @endif
+                    </td>
+                    <td>{{ optional($kpi->updated_at)->diffForHumans() }}</td>
+                    <td class="text-center">
+                        <a href="{{ route('admin.kpis.edit', $kpi->id) }}" class="btn btn-sm btn-info">Edit</a>
+
+                        <form method="POST" action="{{ route('admin.kpis.toggle-status', $kpi->id) }}" class="d-inline-block">
+                            @csrf
+                            <button type="submit" class="btn btn-sm btn-warning">
+                                {{ $kpi->is_active ? 'Deactivate' : 'Activate' }}
+                            </button>
+                        </form>
+
+                        <form method="POST" action="{{ route('admin.kpis.destroy', $kpi->id) }}" class="d-inline-block" onsubmit="return confirm('Delete this KPI? It will be soft-deleted and historical records stay intact.');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="10" class="text-center">No KPIs found.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+
+{{ $kpis->links() }}

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -30,6 +30,8 @@ Route::get('setvaluesession/{type}', [DashboardController::class, 'setvaluesessi
 
 Route::group(['middleware' => ['role:administrator']], function () {
     Route::resource('roles', 'Admin\RolesController');
+    Route::resource('kpis', 'Admin\KpiController')->except(['show']);
+    Route::post('kpis/{kpi}/toggle-status', 'Admin\KpiController@toggleStatus')->name('kpis.toggle-status');
 });
 
 Route::group(['middleware' => 'role:teacher|administrator'], function () {


### PR DESCRIPTION
📥 Pull Request Template
🔧 Description

This PR implements the full KPI management module for admin, including controlled KPI types, weights, lifecycle controls (activate/deactivate/soft delete), real-time search/sorting UI, and seeders for a testable environment.

Fixes: #411

- New admin KPI domain model, migrations, and lifecycle audit history.
- Controlled type-mapping configuration and weighted scoring service.

📸 Screenshots (if applicable)

<img width="1522" height="659" alt="Schermata del 2026-04-03 10-33-09" src="https://github.com/user-attachments/assets/a6d869f9-786e-43f8-a20d-0f82d5a5deab" />

<img width="1522" height="659" alt="Schermata del 2026-04-03 10-33-41" src="https://github.com/user-attachments/assets/d4a50f3a-8968-4d93-9a72-acabd8060322" />


🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- Local environment
- Browser testing
- Database migrations tested

- Ran KPI seeders and verified dataset consistency.
- Verified inactive KPIs are excluded from weighted calculations.
- Ran PHP lint checks on all new/updated KPI files.

🧪 Steps to Reproduce (for bug fixes)

N/A (feature implementation)

🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [x] Updated documentation (if needed)
- [x] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

🙏 Additional Notes

- This PR is intentionally based on upstream  and contains only KPI-related changes.
- It supersedes the previous branch/PR that accidentally included unrelated installer history.