### PR TITLE
fix: make certificates dashboard widget clickable (#404)

### DIFF
--- a/resources/views/backend/dashboard.blade.php
+++ b/resources/views/backend/dashboard.blade.php
@@ -256,7 +256,7 @@ $show_dashboard_widget_tabs = auth()->user()->hasRole('administrator')
 
 
         </div>
-        <div class="col-lg-2 dash-card mb-3 ml-3 leftBorder4">
+        <a href="{{ route('admin.certificates.manage.index') }}" class="col-lg-2 dash-card mb-3 ml-3 leftBorder4" style="text-decoration: none; color: inherit;">
             <div class="d-flex justify-content-center">
                 <h5>
                     {{ $total_certificate_issued }}
@@ -276,7 +276,7 @@ $show_dashboard_widget_tabs = auth()->user()->hasRole('administrator')
             </div>
 
 
-        </div>
+        </a>
     </div>
 
 </div>


### PR DESCRIPTION
## Summary

Fixes #404

The certificates issued widget on the Admin Dashboard was static with no interaction. This change wraps the widget in an `<a>` tag that navigates to the certificates management page when clicked.

## Type of change

- [x] Bug fix / UI improvement (non-breaking change)

## Changes made

- Replaced the `<div class="col-lg-2 dash-card ...">` wrapper with an `<a>` tag pointing to `route('admin.certificates.manage.index')`
- Added `text-decoration: none` and `color: inherit` to preserve the original visual appearance
- No logic, controller, or style changes required

## How to test

1. Log in as admin
2. Go to the Admin Dashboard
3. Click on the "Certificates Issued" widget
4. Verify it navigates to `/admin/certificates/manage`
