### PR TITLE
feat: add download button for base English language file

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ConfigController.php
+++ b/app/Http/Controllers/Backend/Admin/ConfigController.php
@@ -535,4 +535,30 @@ class ConfigController extends Controller
 
         return back()->withFlashSuccess(__('alerts.backend.general.updated'));
     }
+
+    public function downloadBaseLanguageFile()
+    {
+        if (!auth()->user()->isAdmin()) {
+            return abort(403);
+        }
+
+        $langPath = resource_path('lang/en');
+        $merged = [];
+
+        foreach (File::files($langPath) as $file) {
+            if ($file->getExtension() === 'php') {
+                $keys = require $file->getPathname();
+                if (is_array($keys)) {
+                    $merged[$file->getFilenameWithoutExtension()] = $keys;
+                }
+            }
+        }
+
+        $json = json_encode($merged, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        return response($json, 200, [
+            'Content-Type'        => 'application/json',
+            'Content-Disposition' => 'attachment; filename="en.json"',
+        ]);
+    }
 }

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -615,6 +615,7 @@ return array(
         'right_to_left' => 'Right to Left',
         'left_to_right' => 'Left to right',
         'display_type' => 'Display Type',
+        'download_base_language_file' => 'Download Base Language File',
       ),
       'user_registration_settings' =>
       array(

--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -462,6 +462,14 @@
         <div class="col">
 
             <div class="form-group row">
+                <div class="col-md-12 mb-3">
+                    <a href="{{ route('admin.settings.language.download-base') }}" class="btn btn-secondary">
+                        <i class="fa fa-download mr-1"></i> {{ __('labels.backend.general_settings.language_settings.download_base_language_file') }}
+                    </a>
+                </div>
+            </div>
+
+            <div class="form-group row">
                 <label class="col-md-2 form-control-label" for="default_language">
                     {{ __('labels.backend.general_settings.language_settings.default_language') }}
                 </label>

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -143,6 +143,8 @@ Route::group(['middleware' => 'permission:trainer_access'], function () {
 
     Route::post('settings/general', ['uses' => 'Admin\ConfigController@saveGeneralSettings'])->name('general-settings');
 
+    Route::get('settings/language/download-base', ['uses' => 'Admin\ConfigController@downloadBaseLanguageFile', 'as' => 'settings.language.download-base']);
+
     
     Route::post('settings/landing-general-setting', ['uses' => 'Admin\ConfigController@saveLandingPageGeneralSettings'])->name('landing-general-settings');
 


### PR DESCRIPTION
## Summary

Closes #453

Adds a **Download Base Language File** button on the Language Settings tab
(Settings → General) that exports a dynamically generated `en.json` file
with all English translation keys from all modules merged into a single JSON.

## Changes

- `ConfigController`: new `downloadBaseLanguageFile()` method — reads all PHP
  files under `resources/lang/en/`, merges them into a keyed object
  (`{filename: {key: value}}`) and returns it as a JSON download.
- `routes/backend/admin.php`: new GET route `admin.settings.language.download-base`
- `general.blade.php`: download button added at the top of the Language Settings tab
- `labels.php`: added `download_base_language_file` translation key

## Type of change

- [x] New feature (non-breaking)

## How to test

1. Log in as admin
2. Go to Settings → General → Language Settings tab
3. Click **Download Base Language File**
4. Verify `en.json` downloads and contains all 20 module keys with their translations
