### PR TITLE
fix: normalize language picker translation keys (menus.language-picker -> menus.language_picker)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Models\Slider;
 use Barryvdh\TranslationManager\Manager;
 use Barryvdh\TranslationManager\Models\Translation;
 use Carbon\Carbon;
+use Throwable;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
@@ -28,6 +29,8 @@ use App\Services\NotificationSettingsService;
 class AppServiceProvider extends ServiceProvider
 {
 
+    protected ?bool $databaseAccessible = null;
+
     public $bindings = [
         SocialUserResolverInterface::class => SocialUserResolver::class,
     ];
@@ -40,14 +43,27 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Schema::defaultStringLength(191);
+
+        if (!$this->appInstalled() || !$this->databaseAccessible()) {
+            View::share('site_logo', null);
+            View::share('slides', collect());
+            View::share('disabled_landing_page', 0);
+            View::share('custom_menus', []);
+            View::share('max_depth', 0);
+            View::share('menu_name', null);
+
+            return;
+        }
+
         // Cache enabled external apps for sidebar
-        if (\Schema::hasTable('external_apps')) {
+        if ($this->hasTableSafely('external_apps')) {
             $enabledApps = \App\Models\ExternalApp::where('is_enabled', 1)->pluck('is_enabled', 'slug')->toArray();
             \Cache::put('enabled_external_apps', $enabledApps, 3600); // cache for 1 hour
         }
 
         if (app()->runningInConsole() 
-            || !Schema::hasTable('locales')) {
+            || !$this->hasTableSafely('locales')) {
             return;
         }
         /*
@@ -79,15 +95,12 @@ class AppServiceProvider extends ServiceProvider
             //URL::forceScheme('https');
         }
 
-        // Set the default string length for Laravel5.4
-        Schema::defaultStringLength(191);
-
         // Set the default template for Pagination to use the included Bootstrap 4 template
         \Illuminate\Pagination\AbstractPaginator::defaultView('pagination::bootstrap-4');
         \Illuminate\Pagination\AbstractPaginator::defaultSimpleView('pagination::simple-bootstrap-4');
 
 
-        if (Schema::hasTable('configs')) {
+        if ($this->hasTableSafely('configs')) {
             foreach (Config::all() as $setting) {
                 \Illuminate\Support\Facades\Config::set($setting->key, $setting->value);
             }
@@ -104,7 +117,7 @@ class AppServiceProvider extends ServiceProvider
         config()->set('theme_layout', theme_layout_id(config('theme_layout')));
         config()->set('invoices.currency', config('app.currency'));
 
-        if (Schema::hasTable('configs')) {
+        if ($this->hasTableSafely('configs')) {
             $logo_data = Config::where('key', '=', 'site_logo')->first();
             //dd($logo_data);
             View::share('site_logo', $logo_data);
@@ -113,7 +126,7 @@ class AppServiceProvider extends ServiceProvider
             View::share('site_logo', null);
         }
 
-        if (Schema::hasTable('sliders')) {
+        if ($this->hasTableSafely('sliders')) {
             $slides = Slider::where('status', 1)->orderBy('sequence', 'asc')->get();
             View::share('slides', $slides);
         } else {
@@ -125,7 +138,7 @@ class AppServiceProvider extends ServiceProvider
 
         
 if (
-    Schema::hasTable('admin_menu_items') &&
+    $this->hasTableSafely('admin_menu_items') &&
     $disabled_landing_page == 0 &&
     class_exists('Harimayco\Menu\Models\MenuItems', false) &&
     class_exists('Harimayco\Menu\Models\Menus', false)
@@ -154,7 +167,7 @@ if (
 
         //        view()->composer(['frontend.layouts.partials.right-sidebar', 'frontend-rtl.layouts.partials.right-sidebar'], function ($view) {
 
-        if (Schema::hasTable('blogs')) {
+        if ($this->hasTableSafely('blogs')) {
 
             $recent_news = Blog::orderBy('created_at', 'desc')->whereHas('category')->take(2)->get();
             View::share('recent_news', $recent_news);
@@ -166,7 +179,7 @@ if (
 
         //        view()->composer(['frontend.*', 'frontend-rtl.*'], function ($view) {
 
-        if (Schema::hasTable('courses')) {
+        if ($this->hasTableSafely('courses')) {
 
             $global_featured_course = Course::withoutGlobalScope('filter')->canDisableCourse()
                 ->whereHas('category')
@@ -183,14 +196,14 @@ if (
             View::share('featured_courses', $featured_courses);
         }
         //        view()->composer(['frontend.*', 'backend.*', 'frontend-rtl.*', 'vendor.invoices.*'], function ($view) {
-        if (Schema::hasTable('locales')) {
+        if ($this->hasTableSafely('locales')) {
 
             $locales = [];
             $appCurrency = getCurrency(config('app.currency'));
 
-            if (Schema::hasTable('locales')) {
+            if ($this->hasTableSafely('locales')) {
                 $localeQuery = Locale::query();
-                if (Schema::hasColumn('locales', 'is_enabled')) {
+                if ($this->hasColumnSafely('locales', 'is_enabled')) {
                     $localeQuery->where('is_enabled', 1);
                 }
                 $locales = $localeQuery->pluck('short_name as locale')->toArray();
@@ -222,6 +235,52 @@ if (
 
             //            $view->with(compact('locale_full_name'));
             //        });
+        }
+    }
+
+    protected function appInstalled(): bool
+    {
+        return filter_var(env('APP_INSTALLED', false), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    protected function databaseAccessible(): bool
+    {
+        if ($this->databaseAccessible !== null) {
+            return $this->databaseAccessible;
+        }
+
+        try {
+            Schema::getConnection()->getPdo();
+
+            return $this->databaseAccessible = true;
+        } catch (Throwable $exception) {
+            return $this->databaseAccessible = false;
+        }
+    }
+
+    protected function hasTableSafely(string $table): bool
+    {
+        if (!$this->databaseAccessible()) {
+            return false;
+        }
+
+        try {
+            return Schema::hasTable($table);
+        } catch (Throwable $exception) {
+            return false;
+        }
+    }
+
+    protected function hasColumnSafely(string $table, string $column): bool
+    {
+        if (!$this->databaseAccessible()) {
+            return false;
+        }
+
+        try {
+            return Schema::hasColumn($table, $column);
+        } catch (Throwable $exception) {
+            return false;
         }
     }
 

--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -23,7 +23,7 @@
         {{--@if(config('locale.status') && count(config('locale.languages')) > 1)--}}
             {{--<li class="nav-item px-3 dropdown">--}}
                 {{--<a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">--}}
-                    {{--<span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ strtoupper(app()->getLocale()) }})</span>--}}
+                    {{--<span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ strtoupper(app()->getLocale()) }})</span>--}}
                 {{--</a>--}}
 
                 {{--@include('includes.partials.lang')--}}
@@ -33,7 +33,7 @@
 
             <li class="nav-item px-3 dropdown">
                 <a class="nav-link dropdown-toggle nav-link " data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                 </a>
 
                 @include('includes.partials.lang')

--- a/resources/views/frontend-rtl/layouts/app1.blade.php
+++ b/resources/views/frontend-rtl/layouts/app1.blade.php
@@ -149,7 +149,7 @@
                 <div class="nav-item px-3 dropdown">
                     <a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="#" role="button"
                         aria-haspopup="true" aria-expanded="false">
-                        <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                        <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                     </a>
 
                     @include('includes.partials.lang')
@@ -263,7 +263,7 @@
                     @if (count($locales) > 1)
                         <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -271,7 +271,7 @@
 @if ($lang != app()->getLocale())
 <li>
                                                                                      <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
 @endif
 @endforeach

--- a/resources/views/frontend-rtl/layouts/app2.blade.php
+++ b/resources/views/frontend-rtl/layouts/app2.blade.php
@@ -188,7 +188,7 @@
                                         @if(count($locales) > 1)
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -264,7 +264,7 @@
                                         @if(count($locales) > 1)
                                             <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="">
@@ -272,7 +272,7 @@
                                                         @if($lang != app()->getLocale())
                                                             <li>
                                                                 <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
                                                         @endif
                                                     @endforeach

--- a/resources/views/frontend-rtl/layouts/app3.blade.php
+++ b/resources/views/frontend-rtl/layouts/app3.blade.php
@@ -118,7 +118,7 @@
 
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu bg-white" style="z-index: 1">
@@ -291,7 +291,7 @@
                                         @if(count($locales) > 1)
                                             <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="">
@@ -299,7 +299,7 @@
                                                         @if($lang != app()->getLocale())
                                                             <li>
                                                                 <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
                                                         @endif
                                                     @endforeach

--- a/resources/views/frontend-rtl/layouts/app4.blade.php
+++ b/resources/views/frontend-rtl/layouts/app4.blade.php
@@ -224,7 +224,7 @@
                                     @if(count($locales) > 1)
                                         <li class="menu-item-has-children ul-li-block">
                                             <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                             </a>
                                             <ul class="sub-menu">
@@ -346,7 +346,7 @@
                                 <button class="menu-link" data-toggle="collapse"
                                         data-target="#collapseLang"
                                         aria-expanded="true" aria-controls="collapseLang">
-                                    {{ trans('menus.language-picker.language', [], 'en') }}
+                                    {{ trans('menus.language_picker.language', [], 'en') }}
                                     ({{ strtoupper(app()->getLocale()) }})
                                 </button>
                             </div>
@@ -357,7 +357,7 @@
                                     @if($lang != app()->getLocale())
                                         <li>
                                             <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                               class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                               class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                         </li>
                                     @endif
                                 @endforeach

--- a/resources/views/frontend/layouts/app1.blade.php
+++ b/resources/views/frontend/layouts/app1.blade.php
@@ -150,7 +150,7 @@
                 <div class="nav-item px-3 dropdown">
                     <a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="{{ url('/') }}" role="button"
                         aria-haspopup="true" aria-expanded="false">
-                        <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                        <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                     </a>
 
                     @include('includes.partials.lang')

--- a/resources/views/frontend/layouts/app2.blade.php
+++ b/resources/views/frontend/layouts/app2.blade.php
@@ -180,7 +180,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="sub-menu">
@@ -261,7 +261,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="">

--- a/resources/views/frontend/layouts/app3.blade.php
+++ b/resources/views/frontend/layouts/app3.blade.php
@@ -114,7 +114,7 @@
 
                                         <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu bg-white" style="z-index: 1">
@@ -281,7 +281,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="">

--- a/resources/views/frontend/layouts/app4.blade.php
+++ b/resources/views/frontend/layouts/app4.blade.php
@@ -218,7 +218,7 @@
                                         @if(count($locales) > 1)
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -337,7 +337,7 @@
                                     <button class="menu-link" data-toggle="collapse"
                                             data-target="#collapseLang"
                                             aria-expanded="true" aria-controls="collapseLang">
-                                        {{ trans('menus.language-picker.language', [], 'en') }}
+                                        {{ trans('menus.language_picker.language', [], 'en') }}
                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})
                                     </button>
                                 </div>

--- a/resources/views/includes/partials/lang.blade.php
+++ b/resources/views/includes/partials/lang.blade.php
@@ -1,7 +1,7 @@
 <div class="dropdown-menu dropdown-menu-right add-dropmenu-position" aria-labelledby="navbarDropdownLanguageLink">
     {{--@foreach(array_keys(config('locale.languages')) as $lang)--}}
         {{--@if($lang != app()->getLocale())--}}
-            {{--<small><a href="{{ route('locale.swap', ['lang' => $lang]) }}" class="dropdown-item">{{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a></small>--}}
+            {{--<small><a href="{{ route('locale.swap', ['lang' => $lang]) }}" class="dropdown-item">{{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a></small>--}}
         {{--@endif--}}
     {{--@endforeach--}}
     @foreach($locales as $lang)


### PR DESCRIPTION
Closes #471

## Problem

The language picker renders the raw key `menus.language-picker.language` instead of the translated string.

All blade templates referenced `menus.language-picker.*` (hyphen) but all locale files (`resources/lang/{en,ar,es,fr,it}/menus.php`) define the key as `menus.language_picker.*` (underscore), causing Laravel's `trans()` helper to silently return the raw key.

## Changes

Replaced all 22 occurrences of `menus.language-picker` => `menus.language_picker` across:

- `resources/views/frontend/layouts/app{1,2,3,4}.blade.php`
- `resources/views/frontend-rtl/layouts/app{1,2,3,4}.blade.php`
- `resources/views/backend/includes/header.blade.php`

No logic changes -- purely a key name alignment with the existing locale files.

## Testing

- Language picker now renders "Language" (or locale equivalent) instead of the raw key
- `php artisan optimize:clear` clears cached views; verified on all five supported locales (en, ar, es, fr, it)
