### PR TITLE
feat(kpi): add incremental delta-based KPI cursor processing

### DIFF
--- a/app/Console/Commands/Kpi/ProcessIncrementalKpiCommand.php
+++ b/app/Console/Commands/Kpi/ProcessIncrementalKpiCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Console\Commands\Kpi;
+
+use App\Models\Kpi;
+use App\Services\Kpi\IncrementalKpiProcessingService;
+use Illuminate\Console\Command;
+
+/**
+ * ProcessIncrementalKpiCommand
+ *
+ * Artisan command that drives the cursor-based incremental KPI engine.
+ *
+ * Usage examples:
+ *   php artisan kpi:process-incremental
+ *   php artisan kpi:process-incremental --user=42
+ *   php artisan kpi:process-incremental --kpi=COURSE_COMPLETION_RATE
+ *   php artisan kpi:process-incremental --force-full
+ *   php artisan kpi:process-incremental --user=42 --kpi=ASSESSMENT_PASS_RATE --force-full
+ */
+class ProcessIncrementalKpiCommand extends Command
+{
+    protected $signature = 'kpi:process-incremental
+        {--user=    : Process only this user ID}
+        {--kpi=     : Process only the KPI with this code}
+        {--force-full : Force a full recalculation (ignores current cursor state)}';
+
+    protected $description = 'Process new KPI events incrementally using per-user cursors.';
+
+    protected IncrementalKpiProcessingService $service;
+
+    public function __construct(IncrementalKpiProcessingService $service)
+    {
+        parent::__construct();
+        $this->service = $service;
+    }
+
+    public function handle(): int
+    {
+        $userId    = $this->option('user')      ? (int) $this->option('user') : null;
+        $kpiCode   = $this->option('kpi')       ? (string) $this->option('kpi') : null;
+        $forceFull = (bool) $this->option('force-full');
+
+        $kpis = $this->resolveKpis($kpiCode);
+
+        if ($kpis->isEmpty()) {
+            $this->warn('No active KPIs found' . ($kpiCode ? " matching code [{$kpiCode}]" : '') . '.');
+            return 0;
+        }
+
+        $totalProcessed = 0;
+        $errors         = 0;
+
+        foreach ($kpis as $kpi) {
+            $userIds = $userId !== null ? collect([$userId]) : $this->resolveUserIds($kpi);
+
+            foreach ($userIds as $uid) {
+                try {
+                    $result = $forceFull
+                        ? $this->service->forceFullRecalculation((int) $uid, $kpi)
+                        : $this->service->processForUser((int) $uid, $kpi);
+
+                    $totalProcessed += $result['processed'] ?? 0;
+
+                    if ($this->getOutput()->isVerbose()) {
+                        $this->line(sprintf(
+                            '  user=%d kpi=%s events=%d value=%.2f dirty=%s',
+                            $uid,
+                            $kpi->code,
+                            $result['processed'],
+                            $result['value'],
+                            $result['was_dirty'] ? 'yes' : 'no'
+                        ));
+                    }
+                } catch (\Throwable $e) {
+                    $errors++;
+                    $this->error("  Failed user={$uid} kpi={$kpi->code}: " . $e->getMessage());
+                }
+            }
+        }
+
+        $this->info("Done. Total events processed: {$totalProcessed}. Errors: {$errors}.");
+
+        return $errors === 0 ? 0 : 1;
+    }
+
+    private function resolveKpis(?string $kpiCode)
+    {
+        $query = Kpi::where('is_active', true);
+
+        if ($kpiCode !== null) {
+            $query->where('code', $kpiCode);
+        }
+
+        return $query->get();
+    }
+
+    private function resolveUserIds(Kpi $kpi): \Illuminate\Support\Collection
+    {
+        // Find all users that have events relevant to this KPI type or have
+        // an existing cursor for it (including dirty ones awaiting recovery).
+        $relevantTypes = app(
+            \App\Services\Kpi\KpiEventIncrementalApplier::class
+        )->relevantEventTypes($kpi->type);
+
+        $fromEvents = \Illuminate\Support\Facades\DB::table('lms_kpi_events')
+            ->whereIn('event_type', $relevantTypes)
+            ->whereNotNull('user_id')
+            ->distinct()
+            ->pluck('user_id');
+
+        $fromCursors = \Illuminate\Support\Facades\DB::table('kpi_user_cursors')
+            ->where('kpi_id', $kpi->id)
+            ->pluck('user_id');
+
+        return $fromEvents->merge($fromCursors)->unique()->values();
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,6 +49,7 @@ class Kernel extends ConsoleKernel
         // RemoveUnwantedFiles::class,
         // UpdateAssesmentStatusAndScoreInSubscribeCourses::class
         \App\Console\Commands\UnpublishExpiredCourses::class,
+        \App\Console\Commands\Kpi\ProcessIncrementalKpiCommand::class,
     ];
 
     /**
@@ -68,6 +69,13 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('license:expiry-check')->everyMinute();
         $schedule->command('license:user-limit-check')->everyMinute();
+
+        // Incremental KPI processing: runs every 15 minutes to keep user KPI
+        // values fresh without expensive full-table scans.
+        $schedule->command('kpi:process-incremental')
+            ->everyFifteenMinutes()
+            ->withoutOverlapping()
+            ->runInBackground();
         //$schedule->command(FixOfflineCoursesDownloadButton::class)->daily()->withoutOverlapping();
         
         // Once for data fix

--- a/app/Jobs/Kpi/ProcessUserKpiJob.php
+++ b/app/Jobs/Kpi/ProcessUserKpiJob.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Jobs\Kpi;
+
+use App\Models\Kpi;
+use App\Services\Kpi\IncrementalKpiProcessingService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * ProcessUserKpiJob
+ *
+ * Queued job that runs incremental KPI processing for a single (user, KPI) pair.
+ * Designed to be dispatched from event listeners or scheduled commands when a
+ * new LMS event is recorded, enabling near-real-time KPI updates at scale.
+ *
+ * – Retries up to 3 times with exponential back-off.
+ * – On final failure the cursor is marked dirty so the next scheduled run
+ *   performs a full recalculation.
+ */
+class ProcessUserKpiJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries   = 3;
+    public $timeout = 120;
+
+    protected int $userId;
+    protected int $kpiId;
+    protected bool $forceFull;
+
+    public function __construct(int $userId, int $kpiId, bool $forceFull = false)
+    {
+        $this->userId    = $userId;
+        $this->kpiId     = $kpiId;
+        $this->forceFull = $forceFull;
+        $this->onQueue('kpi');
+    }
+
+    public function handle(IncrementalKpiProcessingService $service): void
+    {
+        $kpi = Kpi::find($this->kpiId);
+
+        if (!$kpi || !$kpi->is_active) {
+            // KPI deleted or deactivated – nothing to do.
+            return;
+        }
+
+        if ($this->forceFull) {
+            $service->forceFullRecalculation($this->userId, $kpi);
+        } else {
+            $service->processForUser($this->userId, $kpi);
+        }
+    }
+
+    /**
+     * Called when all retries are exhausted.
+     * Mark the cursor dirty so the scheduler can recover.
+     */
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('[ProcessUserKpiJob] All retries exhausted; marking cursor dirty.', [
+            'user_id' => $this->userId,
+            'kpi_id'  => $this->kpiId,
+            'error'   => $exception->getMessage(),
+        ]);
+
+        try {
+            app(IncrementalKpiProcessingService::class)
+                ->getOrCreateCursor($this->userId, Kpi::findOrFail($this->kpiId))
+                ->markDirty();
+        } catch (\Throwable $e) {
+            Log::error('[ProcessUserKpiJob] Failed to mark cursor dirty.', ['error' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Exponential back-off: 10 s, 60 s, 300 s.
+     *
+     * @return int[]
+     */
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+}

--- a/app/Models/KpiUserCursor.php
+++ b/app/Models/KpiUserCursor.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Auth\User;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * KpiUserCursor
+ *
+ * Stores the processing state for incremental KPI calculations on a per-user,
+ * per-KPI basis.  The cursor advances each time new lms_kpi_events are
+ * successfully incorporated into computed_value, preventing redundant
+ * full-table scans and enabling efficient, scalable KPI processing.
+ *
+ * @property int         $id
+ * @property int         $user_id
+ * @property int         $kpi_id
+ * @property int|null    $last_event_id     Last lms_kpi_events.id that is included in computed_value
+ * @property float|null  $computed_value    Pre-computed KPI percentage 0–100
+ * @property int         $event_count       Events contributing to computed_value
+ * @property array|null  $checkpoint_data   Type-specific running state
+ * @property bool        $is_dirty          True when a full recalculation is needed
+ * @property \Carbon\Carbon|null $last_processed_at
+ */
+class KpiUserCursor extends Model
+{
+    protected $table = 'kpi_user_cursors';
+
+    protected $fillable = [
+        'user_id',
+        'kpi_id',
+        'last_event_id',
+        'computed_value',
+        'event_count',
+        'checkpoint_data',
+        'is_dirty',
+        'last_processed_at',
+    ];
+
+    protected $casts = [
+        'computed_value'    => 'float',
+        'event_count'       => 'integer',
+        'checkpoint_data'   => 'array',
+        'is_dirty'          => 'boolean',
+        'last_processed_at' => 'datetime',
+        'last_event_id'     => 'integer',
+    ];
+
+    // ─── Relationships ────────────────────────────────────────────────────────
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function kpi()
+    {
+        return $this->belongsTo(Kpi::class, 'kpi_id');
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Return the computed value (defaulting to 0 when never calculated).
+     */
+    public function getEffectiveValue(): float
+    {
+        return $this->computed_value ?? 0.0;
+    }
+
+    /**
+     * Return the raw type-specific accumulator stored in checkpoint_data,
+     * or a default value when the key is absent.
+     */
+    public function getCheckpointKey(string $key, $default = 0.0)
+    {
+        $data = $this->checkpoint_data ?? [];
+        return $data[$key] ?? $default;
+    }
+
+    /**
+     * Mark this cursor as dirty so the next processing run performs a full
+     * recalculation rather than an incremental one.
+     */
+    public function markDirty(): void
+    {
+        $this->is_dirty = true;
+        $this->save();
+    }
+
+    /**
+     * Reset the cursor back to a clean, unprocessed state.
+     */
+    public function reset(): void
+    {
+        $this->last_event_id     = null;
+        $this->computed_value    = null;
+        $this->event_count       = 0;
+        $this->checkpoint_data   = null;
+        $this->is_dirty          = false;
+        $this->last_processed_at = null;
+        $this->save();
+    }
+
+    /**
+     * Advance the cursor after successfully processing a batch of events.
+     *
+     * @param  int        $newLastEventId
+     * @param  float      $newValue
+     * @param  int        $newEventCount
+     * @param  array|null $newCheckpointData
+     */
+    public function advance(int $newLastEventId, float $newValue, int $newEventCount, ?array $newCheckpointData = null): void
+    {
+        $this->last_event_id     = $newLastEventId;
+        $this->computed_value    = round($newValue, 4);
+        $this->event_count       = $newEventCount;
+        $this->checkpoint_data   = $newCheckpointData;
+        $this->is_dirty          = false;
+        $this->last_processed_at = now();
+        $this->save();
+    }
+
+    // ─── Scopes ───────────────────────────────────────────────────────────────
+
+    public function scopeDirty($query)
+    {
+        return $query->where('is_dirty', true);
+    }
+
+    public function scopeForKpi($query, int $kpiId)
+    {
+        return $query->where('kpi_id', $kpiId);
+    }
+
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+}

--- a/app/Services/Kpi/IncrementalKpiProcessingService.php
+++ b/app/Services/Kpi/IncrementalKpiProcessingService.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use App\Models\Kpi;
+use App\Models\KpiUserCursor;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+
+/**
+ * IncrementalKpiProcessingService
+ *
+ * Core engine for cursor-based incremental KPI calculations.
+ *
+ * Design principles:
+ *  – Cursors are stored per (user_id, kpi_id).
+ *  – Only events with id > cursor.last_event_id are fetched on each run.
+ *  – State updates are atomic: the cursor advances inside a DB transaction.
+ *  – Dirty cursors trigger a full event-stream recalculation before resuming
+ *    incremental processing.
+ *  – The service is idempotent: processing the same event set twice yields
+ *    the same result.
+ */
+class IncrementalKpiProcessingService
+{
+    protected KpiEventIncrementalApplier $applier;
+    protected ?LoggerInterface $logger;
+
+    /** Maximum events processed per cursor per call (prevents memory exhaustion). */
+    public const BATCH_SIZE = 1000;
+
+    public function __construct(KpiEventIncrementalApplier $applier, ?LoggerInterface $logger = null)
+    {
+        $this->applier = $applier;
+        $this->logger  = $logger;
+    }
+
+    // ─── Public API ──────────────────────────────────────────────────────────
+
+    /**
+     * Process new events for a single (user, KPI) pair.
+     *
+     * Returns an associative result array:
+     *   processed   int    Events processed in this run
+     *   value       float  Updated computed KPI value (0–100)
+     *   was_dirty   bool   Whether a full recalculation was required
+     *   cursor_id   int    ID of the cursor record
+     *
+     * @throws \Throwable on DB failure (cursor is marked dirty for recovery)
+     */
+    public function processForUser(int $userId, Kpi $kpi): array
+    {
+        $cursor = $this->getOrCreateCursor($userId, $kpi);
+
+        // Dirty cursors must be fully rebuilt before resuming incremental mode.
+        if ($cursor->is_dirty) {
+            return $this->fullRecalculationForUser($userId, $kpi, $cursor);
+        }
+
+        return $this->incrementalUpdateForUser($userId, $kpi, $cursor);
+    }
+
+    /**
+     * Process new events for all active KPIs and all users that have relevant
+     * events beyond their current cursor.
+     *
+     * Returns a summary array keyed by "user_id:kpi_id".
+     */
+    public function processAll(): array
+    {
+        $activeKpis = Kpi::where('is_active', true)->get();
+        $summary    = [];
+
+        foreach ($activeKpis as $kpi) {
+            $relevantTypes = $this->applier->relevantEventTypes($kpi->type);
+            if (empty($relevantTypes)) {
+                continue;
+            }
+
+            // Find all distinct user IDs that have any event beyond their cursor.
+            $userIds = $this->usersWithPendingEvents($kpi, $relevantTypes);
+
+            foreach ($userIds as $userId) {
+                $key = "{$userId}:{$kpi->id}";
+                try {
+                    $summary[$key] = $this->processForUser((int) $userId, $kpi);
+                } catch (\Throwable $e) {
+                    $this->log('error', 'processAll: failed for user/kpi', [
+                        'user_id' => $userId,
+                        'kpi_id'  => $kpi->id,
+                        'error'   => $e->getMessage(),
+                    ]);
+                    $summary[$key] = ['error' => $e->getMessage()];
+                }
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Force a full recalculation by scanning the entire event history for this
+     * user/KPI.  Resets the cursor to clean state afterwards.
+     *
+     * Use this when you need guaranteed accuracy (e.g. after a bulk data import
+     * that may have inserted events with occurred_at in the past).
+     */
+    public function forceFullRecalculation(int $userId, Kpi $kpi): array
+    {
+        $cursor = $this->getOrCreateCursor($userId, $kpi);
+        return $this->fullRecalculationForUser($userId, $kpi, $cursor);
+    }
+
+    /**
+     * Reset the cursor for a specific (user, KPI) pair.
+     * The next call to processForUser() will perform a full recalculation.
+     */
+    public function resetCursor(int $userId, int $kpiId): void
+    {
+        $cursor = KpiUserCursor::where('user_id', $userId)
+            ->where('kpi_id', $kpiId)
+            ->first();
+
+        if ($cursor) {
+            $cursor->reset();
+        }
+    }
+
+    /**
+     * Return the current computed value for a user/KPI without triggering any
+     * processing.  Returns null if no cursor exists yet.
+     */
+    public function getCachedValue(int $userId, int $kpiId): ?float
+    {
+        $cursor = KpiUserCursor::where('user_id', $userId)
+            ->where('kpi_id', $kpiId)
+            ->first();
+
+        return $cursor ? $cursor->computed_value : null;
+    }
+
+    /**
+     * Retrieve the cursor for (userId, kpi) or create a fresh one.
+     */
+    public function getOrCreateCursor(int $userId, Kpi $kpi): KpiUserCursor
+    {
+        return KpiUserCursor::firstOrCreate(
+            ['user_id' => $userId, 'kpi_id' => $kpi->id],
+            [
+                'last_event_id'     => null,
+                'computed_value'    => null,
+                'event_count'       => 0,
+                'checkpoint_data'   => null,
+                'is_dirty'          => false,
+                'last_processed_at' => null,
+            ]
+        );
+    }
+
+    // ─── Private: incremental update ─────────────────────────────────────────
+
+    private function incrementalUpdateForUser(int $userId, Kpi $kpi, KpiUserCursor $cursor): array
+    {
+        $relevantTypes = $this->applier->relevantEventTypes($kpi->type);
+        if (empty($relevantTypes)) {
+            return $this->noopResult($cursor);
+        }
+
+        $events = $this->fetchNewEvents($userId, $cursor->last_event_id, $relevantTypes);
+
+        if ($events->isEmpty()) {
+            return $this->noopResult($cursor);
+        }
+
+        $value      = $cursor->computed_value ?? 0.0;
+        $count      = $cursor->event_count;
+        $checkpoint = $cursor->checkpoint_data;
+        $maxEventId = $cursor->last_event_id ?? 0;
+
+        foreach ($events as $event) {
+            $payload = is_string($event->payload)
+                ? (json_decode($event->payload, true) ?? [])
+                : (array) ($event->payload ?? []);
+
+            $result     = $this->applier->apply($kpi->type, $event->event_type, $payload, $value, $count, $checkpoint);
+            $value      = $result['value'];
+            $count      = $result['count'];
+            $checkpoint = $result['checkpoint'];
+            $maxEventId = (int) $event->id;
+        }
+
+        try {
+            DB::transaction(function () use ($cursor, $maxEventId, $value, $count, $checkpoint) {
+                // Re-read inside transaction to detect concurrent writes.
+                $fresh = KpiUserCursor::lockForUpdate()->find($cursor->id);
+                if (!$fresh) {
+                    return;
+                }
+
+                // Idempotency guard: if another process already advanced the cursor
+                // past our batch, skip the update to avoid overwriting newer state.
+                if ($fresh->last_event_id !== null && $fresh->last_event_id >= $maxEventId) {
+                    return;
+                }
+
+                $fresh->advance($maxEventId, $value, $count, $checkpoint);
+            });
+        } catch (\Throwable $e) {
+            $cursor->markDirty();
+            $this->log('error', 'incrementalUpdate: transaction failed, cursor marked dirty', [
+                'cursor_id' => $cursor->id,
+                'user_id'   => $userId,
+                'kpi_id'    => $kpi->id,
+                'error'     => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        $cursor->refresh();
+
+        return [
+            'processed' => $events->count(),
+            'value'     => $cursor->getEffectiveValue(),
+            'was_dirty' => false,
+            'cursor_id' => $cursor->id,
+        ];
+    }
+
+    // ─── Private: full recalculation ─────────────────────────────────────────
+
+    private function fullRecalculationForUser(int $userId, Kpi $kpi, KpiUserCursor $cursor): array
+    {
+        $relevantTypes = $this->applier->relevantEventTypes($kpi->type);
+
+        $value      = 0.0;
+        $count      = 0;
+        $checkpoint = [];
+        $maxEventId = 0;
+        $processed  = 0;
+
+        // Stream events in chunks to avoid loading the entire table into memory.
+        DB::table('lms_kpi_events')
+            ->where('user_id', $userId)
+            ->whereIn('event_type', $relevantTypes)
+            ->orderBy('id')
+            ->chunkById(self::BATCH_SIZE, function ($chunk) use (
+                $kpi, &$value, &$count, &$checkpoint, &$maxEventId, &$processed
+            ) {
+                foreach ($chunk as $event) {
+                    $payload = is_string($event->payload)
+                        ? (json_decode($event->payload, true) ?? [])
+                        : (array) ($event->payload ?? []);
+
+                    $result     = $this->applier->apply($kpi->type, $event->event_type, $payload, $value, $count, $checkpoint);
+                    $value      = $result['value'];
+                    $count      = $result['count'];
+                    $checkpoint = $result['checkpoint'];
+                    $maxEventId = (int) $event->id;
+                    $processed++;
+                }
+            });
+
+        try {
+            DB::transaction(function () use ($cursor, $maxEventId, $value, $count, $checkpoint) {
+                $fresh = KpiUserCursor::lockForUpdate()->find($cursor->id);
+                if (!$fresh) {
+                    return;
+                }
+                $fresh->last_event_id   = $maxEventId > 0 ? $maxEventId : null;
+                $fresh->computed_value  = round($value, 4);
+                $fresh->event_count     = $count;
+                $fresh->checkpoint_data = $checkpoint ?: null;
+                $fresh->is_dirty        = false;
+                $fresh->last_processed_at = now();
+                $fresh->save();
+            });
+        } catch (\Throwable $e) {
+            // Do NOT mark dirty here – we are already in recovery mode.
+            $this->log('error', 'fullRecalculation: transaction failed', [
+                'cursor_id' => $cursor->id,
+                'user_id'   => $cursor->user_id,
+                'kpi_id'    => $cursor->kpi_id,
+                'error'     => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        $cursor->refresh();
+
+        return [
+            'processed' => $processed,
+            'value'     => $cursor->getEffectiveValue(),
+            'was_dirty' => true,
+            'cursor_id' => $cursor->id,
+        ];
+    }
+
+    // ─── Private: helpers ────────────────────────────────────────────────────
+
+    /**
+     * Fetch events for a user that have not yet been processed (id > lastEventId).
+     * Results are ordered by id ASC to guarantee monotonic cursor advancement.
+     */
+    private function fetchNewEvents(int $userId, ?int $lastEventId, array $relevantTypes)
+    {
+        return DB::table('lms_kpi_events')
+            ->where('user_id', $userId)
+            ->whereIn('event_type', $relevantTypes)
+            ->when($lastEventId !== null, fn ($q) => $q->where('id', '>', $lastEventId))
+            ->orderBy('id')
+            ->limit(self::BATCH_SIZE)
+            ->get();
+    }
+
+    /**
+     * Find all user IDs that have at least one event beyond their current cursor
+     * for the given KPI.
+     *
+     * @param  Kpi      $kpi
+     * @param  string[] $relevantTypes
+     * @return \Illuminate\Support\Collection
+     */
+    private function usersWithPendingEvents(Kpi $kpi, array $relevantTypes)
+    {
+        // Users with a cursor — only include those whose cursor lags behind the
+        // latest available event.
+        $withCursor = DB::table('lms_kpi_events as e')
+            ->join('kpi_user_cursors as c', function ($join) use ($kpi) {
+                $join->on('c.user_id', '=', 'e.user_id')
+                    ->where('c.kpi_id', '=', $kpi->id);
+            })
+            ->whereIn('e.event_type', $relevantTypes)
+            ->whereRaw('e.id > COALESCE(c.last_event_id, 0)')
+            ->whereNotNull('e.user_id')
+            ->distinct()
+            ->pluck('e.user_id');
+
+        // Users without any cursor (first time) who have relevant events.
+        $withoutCursor = DB::table('lms_kpi_events')
+            ->whereNotNull('user_id')
+            ->whereIn('event_type', $relevantTypes)
+            ->whereNotIn('user_id', function ($sub) use ($kpi) {
+                $sub->select('user_id')
+                    ->from('kpi_user_cursors')
+                    ->where('kpi_id', $kpi->id);
+            })
+            ->distinct()
+            ->pluck('user_id');
+
+        return $withCursor->merge($withoutCursor)->unique()->values();
+    }
+
+    private function noopResult(KpiUserCursor $cursor): array
+    {
+        return [
+            'processed' => 0,
+            'value'     => $cursor->getEffectiveValue(),
+            'was_dirty' => false,
+            'cursor_id' => $cursor->id,
+        ];
+    }
+
+    private function log(string $level, string $message, array $context = []): void
+    {
+        if ($this->logger) {
+            $this->logger->{$level}('[IncrementalKpi] ' . $message, $context);
+        }
+    }
+}

--- a/app/Services/Kpi/KpiEventIncrementalApplier.php
+++ b/app/Services/Kpi/KpiEventIncrementalApplier.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use App\Models\KpiUserCursor;
+
+/**
+ * KpiEventIncrementalApplier
+ *
+ * Stateless service responsible for applying a single LMS event to an
+ * in-progress cursor state and returning the updated state.  All arithmetic
+ * is deterministic and idempotent for a given (event, prior_state) pair.
+ *
+ * Each KPI type maps to a subset of event types and uses a specific
+ * aggregation strategy:
+ *
+ *   completion → course_completed   (running average of completion_percentage)
+ *   score      → quiz_attempt + assignment_completed[graded|approved]
+ *                (running average of score)
+ *   activity   → all engagement events (accumulated points, max 100)
+ *   time       → assignment_completed (running average of time_to_complete_seconds,
+ *                normalized: avg_seconds / 3600 * 100, capped at 100)
+ */
+class KpiEventIncrementalApplier
+{
+    /**
+     * Which lms_kpi_events.event_type values are relevant for each KPI type.
+     */
+    public const EVENT_TYPE_MAP = [
+        'completion' => ['course_completed'],
+        'score'      => ['quiz_attempt', 'assignment_completed'],
+        'activity'   => ['user_login', 'lesson_completed', 'course_completed', 'quiz_attempt', 'assignment_completed'],
+        'time'       => ['assignment_completed'],
+    ];
+
+    /**
+     * Activity points awarded per event type.
+     */
+    public const ACTIVITY_POINTS = [
+        'user_login'            => 5,
+        'lesson_completed'      => 10,
+        'quiz_attempt'          => 15,
+        'assignment_completed'  => 20,
+        'course_completed'      => 25,
+    ];
+
+    /**
+     * Seconds considered a "full" time KPI score (100 %).
+     * Anything >= this value is capped at 100.
+     */
+    public const TIME_BASELINE_SECONDS = 3600;
+
+    /**
+     * Assignment statuses that count toward the score KPI.
+     */
+    public const SCORED_ASSIGNMENT_STATUSES = ['graded', 'approved'];
+
+    // ─── Public API ──────────────────────────────────────────────────────────
+
+    /**
+     * Return all event types that should be fetched for a given KPI type.
+     *
+     * @param  string $kpiType
+     * @return string[]
+     */
+    public function relevantEventTypes(string $kpiType): array
+    {
+        return self::EVENT_TYPE_MAP[$kpiType] ?? [];
+    }
+
+    /**
+     * Apply a single event to the current cursor state and return the new
+     * (value, count, checkpointData) triple.
+     *
+     * If the event is not relevant for this KPI type, or the payload does
+     * not supply the fields needed, the cursor state is returned unchanged.
+     *
+     * @param  string     $kpiType       One of: completion, score, activity, time
+     * @param  string     $eventType     The event_type from lms_kpi_events
+     * @param  array      $payload       Decoded JSON payload of the event
+     * @param  float      $currentValue  Current computed_value (0–100)
+     * @param  int        $eventCount    Current event_count
+     * @param  array|null $checkpointData Current checkpoint_data
+     * @return array{value: float, count: int, checkpoint: array}
+     */
+    public function apply(
+        string $kpiType,
+        string $eventType,
+        array $payload,
+        float $currentValue,
+        int $eventCount,
+        ?array $checkpointData
+    ): array {
+        $checkpoint = $checkpointData ?? [];
+
+        switch ($kpiType) {
+            case 'completion':
+                return $this->applyCompletion($eventType, $payload, $currentValue, $eventCount, $checkpoint);
+
+            case 'score':
+                return $this->applyScore($eventType, $payload, $currentValue, $eventCount, $checkpoint);
+
+            case 'activity':
+                return $this->applyActivity($eventType, $currentValue, $eventCount, $checkpoint);
+
+            case 'time':
+                return $this->applyTime($eventType, $payload, $currentValue, $eventCount, $checkpoint);
+
+            default:
+                // Unknown KPI type – pass through unchanged.
+                return ['value' => $currentValue, 'count' => $eventCount, 'checkpoint' => $checkpoint];
+        }
+    }
+
+    /**
+     * Apply an entire batch of events sequentially and return the final state.
+     *
+     * @param  string     $kpiType
+     * @param  iterable   $events        Each item: ['event_type' => …, 'payload' => array|null]
+     * @param  float      $currentValue
+     * @param  int        $eventCount
+     * @param  array|null $checkpointData
+     * @return array{value: float, count: int, checkpoint: array}
+     */
+    public function applyBatch(
+        string $kpiType,
+        iterable $events,
+        float $currentValue,
+        int $eventCount,
+        ?array $checkpointData
+    ): array {
+        $value      = $currentValue;
+        $count      = $eventCount;
+        $checkpoint = $checkpointData ?? [];
+
+        foreach ($events as $event) {
+            $eventType = (string) ($event['event_type'] ?? '');
+            $payload   = is_array($event['payload']) ? $event['payload'] : [];
+
+            $result     = $this->apply($kpiType, $eventType, $payload, $value, $count, $checkpoint);
+            $value      = $result['value'];
+            $count      = $result['count'];
+            $checkpoint = $result['checkpoint'];
+        }
+
+        return ['value' => $value, 'count' => $count, 'checkpoint' => $checkpoint];
+    }
+
+    // ─── Per-type strategies ─────────────────────────────────────────────────
+
+    protected function applyCompletion(
+        string $eventType,
+        array $payload,
+        float $currentValue,
+        int $count,
+        array $checkpoint
+    ): array {
+        if ($eventType !== 'course_completed') {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $pct = isset($payload['completion_percentage']) ? (float) $payload['completion_percentage'] : null;
+        if ($pct === null) {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $pct       = min(100.0, max(0.0, $pct));
+        $rawSum    = (float) ($checkpoint['raw_sum'] ?? ($currentValue * $count));
+        $rawSum   += $pct;
+        $newCount  = $count + 1;
+        $newValue  = $newCount > 0 ? $rawSum / $newCount : 0.0;
+
+        return [
+            'value'      => round(min(100.0, max(0.0, $newValue)), 4),
+            'count'      => $newCount,
+            'checkpoint' => ['raw_sum' => round($rawSum, 6)],
+        ];
+    }
+
+    protected function applyScore(
+        string $eventType,
+        array $payload,
+        float $currentValue,
+        int $count,
+        array $checkpoint
+    ): array {
+        if (!in_array($eventType, ['quiz_attempt', 'assignment_completed'], true)) {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        // For assignments, only count graded/approved submissions.
+        if ($eventType === 'assignment_completed') {
+            $status = (string) ($payload['status'] ?? '');
+            if (!in_array($status, self::SCORED_ASSIGNMENT_STATUSES, true)) {
+                return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+            }
+        }
+
+        $score = isset($payload['score']) ? (float) $payload['score'] : null;
+        if ($score === null) {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $score    = min(100.0, max(0.0, $score));
+        $rawSum   = (float) ($checkpoint['raw_sum'] ?? ($currentValue * $count));
+        $rawSum  += $score;
+        $newCount = $count + 1;
+        $newValue = $newCount > 0 ? $rawSum / $newCount : 0.0;
+
+        return [
+            'value'      => round(min(100.0, max(0.0, $newValue)), 4),
+            'count'      => $newCount,
+            'checkpoint' => ['raw_sum' => round($rawSum, 6)],
+        ];
+    }
+
+    protected function applyActivity(
+        string $eventType,
+        float $currentValue,
+        int $count,
+        array $checkpoint
+    ): array {
+        $points = self::ACTIVITY_POINTS[$eventType] ?? null;
+        if ($points === null) {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $accumulated    = (float) ($checkpoint['accumulated_points'] ?? $currentValue);
+        $accumulated   += $points;
+        $newValue       = min(100.0, $accumulated);
+        $newCount       = $count + 1;
+
+        return [
+            'value'      => round($newValue, 4),
+            'count'      => $newCount,
+            'checkpoint' => ['accumulated_points' => round($accumulated, 6)],
+        ];
+    }
+
+    protected function applyTime(
+        string $eventType,
+        array $payload,
+        float $currentValue,
+        int $count,
+        array $checkpoint
+    ): array {
+        if ($eventType !== 'assignment_completed') {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $seconds = isset($payload['time_to_complete_seconds'])
+            ? (float) $payload['time_to_complete_seconds']
+            : null;
+
+        if ($seconds === null || $seconds < 0) {
+            return ['value' => $currentValue, 'count' => $count, 'checkpoint' => $checkpoint];
+        }
+
+        $rawSumSeconds = (float) ($checkpoint['raw_sum_seconds'] ?? 0.0);
+
+        // Reconstruct running sum when checkpoint is missing (first event after
+        // a state reset that preserved computed_value but lost checkpoint).
+        if (!isset($checkpoint['raw_sum_seconds']) && $count > 0) {
+            // Reverse-engineer from the stored normalized value.
+            $rawSumSeconds = ($currentValue / 100.0) * self::TIME_BASELINE_SECONDS * $count;
+        }
+
+        $rawSumSeconds += $seconds;
+        $newCount       = $count + 1;
+        $avgSeconds     = $rawSumSeconds / $newCount;
+        $newValue       = ($avgSeconds / self::TIME_BASELINE_SECONDS) * 100.0;
+
+        return [
+            'value'      => round(min(100.0, max(0.0, $newValue)), 4),
+            'count'      => $newCount,
+            'checkpoint' => ['raw_sum_seconds' => round($rawSumSeconds, 6)],
+        ];
+    }
+}

--- a/database/migrations/2026_04_12_000001_create_kpi_user_cursors_table.php
+++ b/database/migrations/2026_04_12_000001_create_kpi_user_cursors_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateKpiUserCursorsTable extends Migration
+{
+    public function up()
+    {
+        if (Schema::hasTable('kpi_user_cursors')) {
+            return;
+        }
+
+        Schema::create('kpi_user_cursors', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            // The user whose KPI progress this cursor tracks.
+            $table->unsignedInteger('user_id');
+
+            // The KPI definition this cursor belongs to.
+            $table->unsignedBigInteger('kpi_id');
+
+            // The last lms_kpi_events.id that has been fully incorporated into
+            // computed_value. NULL means no events have been processed yet.
+            $table->unsignedBigInteger('last_event_id')->nullable()->default(null);
+
+            // Pre-computed KPI percentage (0.00 – 100.00) for this user/KPI pair.
+            // NULL means the value has never been computed.
+            $table->decimal('computed_value', 8, 4)->nullable()->default(null);
+
+            // Number of events that contributed to computed_value.
+            // Used as the denominator for accurate running-average calculations.
+            $table->unsignedInteger('event_count')->default(0);
+
+            // Arbitrary type-specific state needed for accurate incremental updates
+            // (e.g. running sums that cannot be reconstructed from computed_value alone).
+            $table->json('checkpoint_data')->nullable()->default(null);
+
+            // When true the cursor is considered corrupt or stale and the next
+            // call to processIncrementalForUser() will fall back to a full
+            // recalculation before clearing this flag.
+            $table->boolean('is_dirty')->default(false);
+
+            // Timestamp of the last successful processing run.
+            $table->timestamp('last_processed_at')->nullable()->default(null);
+
+            $table->timestamps();
+
+            // One cursor per (user, KPI).
+            $table->unique(['user_id', 'kpi_id'], 'kpi_user_cursors_user_kpi_unique');
+
+            $table->index('kpi_id', 'kpi_user_cursors_kpi_id_idx');
+            $table->index('is_dirty', 'kpi_user_cursors_is_dirty_idx');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+
+            $table->foreign('kpi_id')
+                ->references('id')
+                ->on('kpis')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('kpi_user_cursors');
+    }
+}

--- a/tests/Unit/Services/Kpi/IncrementalKpiProcessingServiceTest.php
+++ b/tests/Unit/Services/Kpi/IncrementalKpiProcessingServiceTest.php
@@ -1,0 +1,687 @@
+<?php
+
+namespace Tests\Unit\Services\Kpi;
+
+use App\Models\Kpi;
+use App\Models\KpiUserCursor;
+use App\Services\Kpi\IncrementalKpiProcessingService;
+use App\Services\Kpi\KpiEventIncrementalApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Deep integration tests for IncrementalKpiProcessingService.
+ *
+ * Uses an in-memory SQLite database (sqlite_testing connection) with
+ * RefreshDatabase so every test starts with a pristine schema.
+ *
+ * Covered scenarios:
+ *  - Cursor creation on first call
+ *  - Incremental advancement (only new events processed)
+ *  - Idempotency (same run = same result)
+ *  - Duplicate event prevention
+ *  - Dirty-cursor full recalculation
+ *  - Partial failure recovery (cursor flagged dirty on exception)
+ *  - Missing / delayed events (out-of-order occurred_at)
+ *  - processAll processes multiple users / KPIs
+ *  - forceFullRecalculation rebuilds from scratch
+ *  - resetCursor reverts to unprocessed state
+ *  - getCachedValue returns persisted value
+ *  - BATCH_SIZE chunking
+ */
+class IncrementalKpiProcessingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private IncrementalKpiProcessingService $service;
+    private Kpi $kpiCompletion;
+    private Kpi $kpiScore;
+    private Kpi $kpiActivity;
+    private Kpi $kpiTime;
+
+    // ─── Schema bootstrap ─────────────────────────────────────────────────────
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(IncrementalKpiProcessingService::class);
+        $this->bootstrapSchema();
+        $this->kpiCompletion = $this->createKpi('COMP', 'completion');
+        $this->kpiScore      = $this->createKpi('SCORE', 'score');
+        $this->kpiActivity   = $this->createKpi('ACT', 'activity');
+        $this->kpiTime       = $this->createKpi('TIME', 'time');
+    }
+
+    /**
+     * Create the minimal tables that the service queries.
+     * (The real migrations run in the full test suite; here we inline them
+     *  so that unit tests remain self-contained.)
+     */
+    private function bootstrapSchema(): void
+    {
+        // kpis
+        if (!DB::getSchemaBuilder()->hasTable('kpis')) {
+            DB::getSchemaBuilder()->create('kpis', function ($t) {
+                $t->bigIncrements('id');
+                $t->string('name');
+                $t->string('code', 64)->unique();
+                $t->string('type', 100);
+                $t->text('description')->default('');
+                $t->decimal('weight', 8, 2)->default(1);
+                $t->boolean('is_active')->default(true);
+                $t->unsignedInteger('created_by')->nullable();
+                $t->unsignedInteger('updated_by')->nullable();
+                $t->timestamps();
+                $t->softDeletes();
+            });
+        }
+
+        // lms_kpi_events
+        if (!DB::getSchemaBuilder()->hasTable('lms_kpi_events')) {
+            DB::getSchemaBuilder()->create('lms_kpi_events', function ($t) {
+                $t->bigIncrements('id');
+                $t->unsignedInteger('user_id')->nullable();
+                $t->string('event_type', 80);
+                $t->timestamp('occurred_at')->useCurrent();
+                $t->json('payload')->nullable();
+                $t->timestamp('created_at')->useCurrent();
+            });
+        }
+
+        // kpi_user_cursors
+        if (!DB::getSchemaBuilder()->hasTable('kpi_user_cursors')) {
+            DB::getSchemaBuilder()->create('kpi_user_cursors', function ($t) {
+                $t->bigIncrements('id');
+                $t->unsignedInteger('user_id');
+                $t->unsignedBigInteger('kpi_id');
+                $t->unsignedBigInteger('last_event_id')->nullable()->default(null);
+                $t->decimal('computed_value', 8, 4)->nullable()->default(null);
+                $t->unsignedInteger('event_count')->default(0);
+                $t->json('checkpoint_data')->nullable()->default(null);
+                $t->boolean('is_dirty')->default(false);
+                $t->timestamp('last_processed_at')->nullable()->default(null);
+                $t->timestamps();
+                $t->unique(['user_id', 'kpi_id']);
+            });
+        }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private function createUser(int $id): void
+    {
+        DB::table('users')->insertOrIgnore([
+            'id'          => $id,
+            'uuid'        => \Illuminate\Support\Str::uuid()->toString(),
+            'first_name'  => "User",
+            'last_name'   => (string) $id,
+            'email'       => "user{$id}@test.test",
+            'password'    => bcrypt('secret'),
+            'active'      => 1,
+            'confirmed'   => true,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+    }
+
+    private function createKpi(string $code, string $type): Kpi
+    {
+        return Kpi::create([
+            'name'        => $code,
+            'code'        => $code,
+            'type'        => $type,
+            'description' => "Test KPI {$code}",
+            'weight'      => 1,
+            'is_active'   => true,
+        ]);
+    }
+
+    private function insertEvent(int $userId, string $eventType, array $payload = [], ?string $occurredAt = null): int
+    {
+        return DB::table('lms_kpi_events')->insertGetId([
+            'user_id'    => $userId,
+            'event_type' => $eventType,
+            'occurred_at'=> $occurredAt ?? now()->toDateTimeString(),
+            'payload'    => json_encode($payload),
+            'created_at' => now()->toDateTimeString(),
+        ]);
+    }
+
+    private function getCursor(int $userId, Kpi $kpi): ?KpiUserCursor
+    {
+        return KpiUserCursor::where('user_id', $userId)->where('kpi_id', $kpi->id)->first();
+    }
+
+    // ─── Cursor lifecycle ─────────────────────────────────────────────────────
+
+    #[Test]
+    public function get_or_create_cursor_creates_new_cursor_on_first_call(): void
+    {
+        $this->createUser(1);
+        $cursor = $this->service->getOrCreateCursor(1, $this->kpiCompletion);
+
+        $this->assertInstanceOf(KpiUserCursor::class, $cursor);
+        $this->assertSame(1, $cursor->user_id);
+        $this->assertSame((int) $this->kpiCompletion->id, (int) $cursor->kpi_id);
+        $this->assertNull($cursor->last_event_id);
+        $this->assertNull($cursor->computed_value);
+        $this->assertFalse($cursor->is_dirty);
+        $this->assertSame(0, $cursor->event_count);
+    }
+
+    #[Test]
+    public function get_or_create_cursor_returns_existing_cursor(): void
+    {
+        $this->createUser(1);
+        $c1 = $this->service->getOrCreateCursor(1, $this->kpiCompletion);
+        $c2 = $this->service->getOrCreateCursor(1, $this->kpiCompletion);
+
+        $this->assertSame((int) $c1->id, (int) $c2->id);
+        $this->assertSame(1, KpiUserCursor::count());
+    }
+
+    // ─── processForUser: incremental ─────────────────────────────────────────
+
+    #[Test]
+    public function process_for_user_returns_zero_events_when_no_events_exist(): void
+    {
+        $this->createUser(1);
+        $result = $this->service->processForUser(1, $this->kpiCompletion);
+
+        $this->assertSame(0, $result['processed']);
+        $this->assertSame(0.0, $result['value']);
+        $this->assertFalse($result['was_dirty']);
+    }
+
+    #[Test]
+    public function process_for_user_processes_first_batch_of_events(): void
+    {
+        $this->createUser(10);
+        $this->insertEvent(10, 'course_completed', ['completion_percentage' => 80.0]);
+        $this->insertEvent(10, 'course_completed', ['completion_percentage' => 60.0]);
+
+        $result = $this->service->processForUser(10, $this->kpiCompletion);
+
+        $this->assertSame(2, $result['processed']);
+        $this->assertSame(70.0, round($result['value'], 2));
+
+        $cursor = $this->getCursor(10, $this->kpiCompletion);
+        $this->assertNotNull($cursor->last_event_id);
+        $this->assertSame(70.0, round($cursor->computed_value, 2));
+        $this->assertSame(2, $cursor->event_count);
+    }
+
+    #[Test]
+    public function process_for_user_only_processes_new_events_on_second_call(): void
+    {
+        $this->createUser(20);
+
+        // First batch
+        $this->insertEvent(20, 'course_completed', ['completion_percentage' => 80.0]);
+        $result1 = $this->service->processForUser(20, $this->kpiCompletion);
+        $this->assertSame(1, $result1['processed']);
+
+        // Second batch – one new event
+        $this->insertEvent(20, 'course_completed', ['completion_percentage' => 60.0]);
+        $result2 = $this->service->processForUser(20, $this->kpiCompletion);
+
+        $this->assertSame(1, $result2['processed'], 'Second call should process only the new event');
+        $this->assertSame(70.0, round($result2['value'], 2));
+    }
+
+    #[Test]
+    public function process_for_user_returns_cached_value_when_no_new_events(): void
+    {
+        $this->createUser(30);
+        $this->insertEvent(30, 'course_completed', ['completion_percentage' => 90.0]);
+        $this->service->processForUser(30, $this->kpiCompletion);
+
+        // Call again – no new events.
+        $result = $this->service->processForUser(30, $this->kpiCompletion);
+
+        $this->assertSame(0, $result['processed']);
+        $this->assertSame(90.0, round($result['value'], 2));
+    }
+
+    // ─── Idempotency / duplicate prevention ──────────────────────────────────
+
+    #[Test]
+    public function processing_same_events_twice_does_not_double_count(): void
+    {
+        $this->createUser(40);
+        $this->insertEvent(40, 'quiz_attempt', ['score' => 80.0]);
+        $this->insertEvent(40, 'quiz_attempt', ['score' => 60.0]);
+
+        $r1 = $this->service->processForUser(40, $this->kpiScore);
+        // Re-process: cursor is up-to-date, no new events.
+        $r2 = $this->service->processForUser(40, $this->kpiScore);
+
+        $this->assertSame(70.0, round($r1['value'], 2));
+        $this->assertSame(0, $r2['processed']);
+        $this->assertSame($r1['value'], $r2['value'], 'Value must not change when no new events exist');
+    }
+
+    #[Test]
+    public function cursor_does_not_advance_when_event_batch_is_empty(): void
+    {
+        $this->createUser(50);
+        $cursor = $this->service->getOrCreateCursor(50, $this->kpiCompletion);
+        $this->assertNull($cursor->last_event_id);
+
+        $this->service->processForUser(50, $this->kpiCompletion);
+
+        $cursor->refresh();
+        $this->assertNull($cursor->last_event_id, 'Cursor should not advance when there are no events');
+    }
+
+    // ─── Score KPI specifics ──────────────────────────────────────────────────
+
+    #[Test]
+    public function score_kpi_ignores_unscored_assignment_submissions(): void
+    {
+        $this->createUser(60);
+        $this->insertEvent(60, 'assignment_completed', ['score' => 95.0, 'status' => 'submitted']);
+        $this->insertEvent(60, 'quiz_attempt',         ['score' => 70.0]);
+
+        $result = $this->service->processForUser(60, $this->kpiScore);
+
+        // Only quiz_attempt counts → value = 70
+        $this->assertSame(70.0, round($result['value'], 2));
+        $this->assertSame(1, $this->getCursor(60, $this->kpiScore)->event_count);
+    }
+
+    // ─── Activity KPI specifics ───────────────────────────────────────────────
+
+    #[Test]
+    public function activity_kpi_accumulates_points_across_multiple_event_types(): void
+    {
+        $this->createUser(70);
+        $this->insertEvent(70, 'user_login',           []);   // +5
+        $this->insertEvent(70, 'lesson_completed',     []);   // +10
+        $this->insertEvent(70, 'quiz_attempt',         []);   // +15
+        $this->insertEvent(70, 'assignment_completed', ['status' => 'graded']); // +20
+        $this->insertEvent(70, 'course_completed',     ['completion_percentage' => 100]); // +25
+
+        $result = $this->service->processForUser(70, $this->kpiActivity);
+
+        $this->assertSame(75.0, round($result['value'], 2)); // 5+10+15+20+25 = 75
+        $this->assertSame(5, $result['processed']);
+    }
+
+    #[Test]
+    public function activity_kpi_caps_at_100_regardless_of_event_count(): void
+    {
+        $this->createUser(71);
+        // 5 × course_completed = 5 × 25 = 125 pts → capped at 100
+        for ($i = 0; $i < 5; $i++) {
+            $this->insertEvent(71, 'course_completed', []);
+        }
+
+        $result = $this->service->processForUser(71, $this->kpiActivity);
+
+        $this->assertSame(100.0, $result['value']);
+    }
+
+    // ─── Time KPI specifics ───────────────────────────────────────────────────
+
+    #[Test]
+    public function time_kpi_computes_normalized_average_seconds(): void
+    {
+        $this->createUser(80);
+        // 1800s → 50 %, 3600s → 100 % → avg 2700s → 75 %
+        $this->insertEvent(80, 'assignment_completed', ['time_to_complete_seconds' => 1800, 'status' => 'graded']);
+        $this->insertEvent(80, 'assignment_completed', ['time_to_complete_seconds' => 3600, 'status' => 'graded']);
+
+        $result = $this->service->processForUser(80, $this->kpiTime);
+
+        $this->assertSame(75.0, round($result['value'], 2));
+    }
+
+    // ─── Dirty cursor / full recalculation ───────────────────────────────────
+
+    #[Test]
+    public function process_for_user_performs_full_recalculation_when_cursor_is_dirty(): void
+    {
+        $this->createUser(90);
+        $this->insertEvent(90, 'course_completed', ['completion_percentage' => 100.0]);
+        $this->insertEvent(90, 'course_completed', ['completion_percentage' => 80.0]);
+
+        // Seed a cursor with wrong state and mark it dirty.
+        $cursor = $this->service->getOrCreateCursor(90, $this->kpiCompletion);
+        $cursor->update(['computed_value' => 0.0, 'event_count' => 0, 'is_dirty' => true]);
+
+        $result = $this->service->processForUser(90, $this->kpiCompletion);
+
+        $this->assertTrue($result['was_dirty']);
+        $this->assertSame(90.0, round($result['value'], 2));   // (100+80)/2
+        $this->assertFalse($this->getCursor(90, $this->kpiCompletion)->is_dirty);
+    }
+
+    // ─── Missing / delayed events (late arrivals) ─────────────────────────────
+
+    #[Test]
+    public function late_arriving_event_with_past_occurred_at_is_processed_in_insertion_order(): void
+    {
+        $this->createUser(100);
+
+        // Two events processed first.
+        $this->insertEvent(100, 'course_completed', ['completion_percentage' => 80.0], '2025-01-01 10:00:00');
+        $this->insertEvent(100, 'course_completed', ['completion_percentage' => 60.0], '2025-01-02 10:00:00');
+        $this->service->processForUser(100, $this->kpiCompletion);
+
+        // A late event with occurred_at in the past arrives later (higher id).
+        $this->insertEvent(100, 'course_completed', ['completion_percentage' => 100.0], '2025-01-01 09:00:00');
+
+        // Should pick up the new event (id > cursor) regardless of occurred_at order.
+        $result = $this->service->processForUser(100, $this->kpiCompletion);
+
+        $this->assertSame(1, $result['processed'], 'Late-arriving event must be processed on next run');
+        $this->assertSame(80.0, round($result['value'], 2)); // (80+60+100)/3 = 80
+    }
+
+    // ─── forceFullRecalculation ───────────────────────────────────────────────
+
+    #[Test]
+    public function force_full_recalculation_rebuilds_value_from_entire_event_history(): void
+    {
+        $this->createUser(110);
+        $this->insertEvent(110, 'quiz_attempt', ['score' => 50.0]);
+        $this->insertEvent(110, 'quiz_attempt', ['score' => 90.0]);
+
+        // Process once to set cursor.
+        $this->service->processForUser(110, $this->kpiScore);
+
+        // Corrupt the stored value.
+        KpiUserCursor::where('user_id', 110)->where('kpi_id', $this->kpiScore->id)
+            ->update(['computed_value' => 0.0, 'event_count' => 0, 'checkpoint_data' => null]);
+
+        $result = $this->service->forceFullRecalculation(110, $this->kpiScore);
+
+        $this->assertTrue($result['was_dirty']);
+        $this->assertSame(70.0, round($result['value'], 2));  // (50+90)/2
+        $this->assertSame(2, $result['processed']);
+    }
+
+    #[Test]
+    public function force_full_recalculation_with_no_events_returns_zero(): void
+    {
+        $this->createUser(111);
+        $result = $this->service->forceFullRecalculation(111, $this->kpiScore);
+
+        $this->assertSame(0.0, $result['value']);
+        $this->assertSame(0, $result['processed']);
+    }
+
+    // ─── resetCursor ─────────────────────────────────────────────────────────
+
+    #[Test]
+    public function reset_cursor_clears_all_state(): void
+    {
+        $this->createUser(120);
+        $this->insertEvent(120, 'course_completed', ['completion_percentage' => 75.0]);
+        $this->service->processForUser(120, $this->kpiCompletion);
+
+        $this->service->resetCursor(120, $this->kpiCompletion->id);
+
+        $cursor = $this->getCursor(120, $this->kpiCompletion);
+        $this->assertNull($cursor->last_event_id);
+        $this->assertNull($cursor->computed_value);
+        $this->assertSame(0, $cursor->event_count);
+        $this->assertFalse($cursor->is_dirty);
+    }
+
+    #[Test]
+    public function reset_cursor_for_nonexistent_cursor_does_not_throw(): void
+    {
+        $this->createUser(121);
+        // Should not throw when no cursor exists.
+        $this->service->resetCursor(121, $this->kpiCompletion->id);
+        $this->assertTrue(true);
+    }
+
+    // ─── getCachedValue ───────────────────────────────────────────────────────
+
+    #[Test]
+    public function get_cached_value_returns_null_before_first_processing(): void
+    {
+        $this->createUser(130);
+        $this->assertNull($this->service->getCachedValue(130, $this->kpiCompletion->id));
+    }
+
+    #[Test]
+    public function get_cached_value_returns_last_computed_value(): void
+    {
+        $this->createUser(131);
+        $this->insertEvent(131, 'course_completed', ['completion_percentage' => 55.0]);
+        $this->service->processForUser(131, $this->kpiCompletion);
+
+        $this->assertSame(55.0, round($this->service->getCachedValue(131, $this->kpiCompletion->id), 2));
+    }
+
+    // ─── processAll ──────────────────────────────────────────────────────────
+
+    #[Test]
+    public function process_all_processes_multiple_users_and_kpis(): void
+    {
+        $this->createUser(200);
+        $this->createUser(201);
+
+        $this->insertEvent(200, 'course_completed', ['completion_percentage' => 60.0]);
+        $this->insertEvent(201, 'quiz_attempt',     ['score' => 85.0]);
+
+        $summary = $this->service->processAll();
+
+        $this->assertArrayHasKey("200:{$this->kpiCompletion->id}", $summary);
+        $this->assertArrayHasKey("201:{$this->kpiScore->id}", $summary);
+
+        $this->assertSame(1, $summary["200:{$this->kpiCompletion->id}"]['processed']);
+        $this->assertSame(1, $summary["201:{$this->kpiScore->id}"]['processed']);
+    }
+
+    #[Test]
+    public function process_all_skips_inactive_kpis(): void
+    {
+        $this->createUser(210);
+
+        $inactiveKpi = $this->createKpi('INACTIVE', 'completion');
+        $inactiveKpi->update(['is_active' => false]);
+
+        $this->insertEvent(210, 'course_completed', ['completion_percentage' => 80.0]);
+
+        $summary = $this->service->processAll();
+
+        $this->assertArrayNotHasKey("210:{$inactiveKpi->id}", $summary);
+    }
+
+    // ─── Cursor isolation between KPI types ──────────────────────────────────
+
+    #[Test]
+    public function cursors_are_isolated_per_kpi(): void
+    {
+        $this->createUser(220);
+
+        $this->insertEvent(220, 'course_completed', ['completion_percentage' => 80.0]);
+        $this->insertEvent(220, 'quiz_attempt',     ['score' => 70.0]);
+
+        $rComp  = $this->service->processForUser(220, $this->kpiCompletion);
+        $rScore = $this->service->processForUser(220, $this->kpiScore);
+
+        // Completion KPI should only have processed course_completed events.
+        $this->assertSame(1, $rComp['processed']);
+        $this->assertSame(80.0, round($rComp['value'], 2));
+
+        // Score KPI should only have processed quiz_attempt events.
+        $this->assertSame(1, $rScore['processed']);
+        $this->assertSame(70.0, round($rScore['value'], 2));
+
+        // Two separate cursors exist.
+        $this->assertSame(2, KpiUserCursor::where('user_id', 220)->count());
+    }
+
+    // ─── Cursor isolation between users ──────────────────────────────────────
+
+    #[Test]
+    public function cursors_are_isolated_per_user(): void
+    {
+        $this->createUser(230);
+        $this->createUser(231);
+
+        $this->insertEvent(230, 'course_completed', ['completion_percentage' => 100.0]);
+        $this->insertEvent(231, 'course_completed', ['completion_percentage' => 40.0]);
+
+        $r230 = $this->service->processForUser(230, $this->kpiCompletion);
+        $r231 = $this->service->processForUser(231, $this->kpiCompletion);
+
+        $this->assertSame(100.0, round($r230['value'], 2));
+        $this->assertSame(40.0,  round($r231['value'], 2));
+    }
+
+    // ─── BATCH_SIZE chunking ──────────────────────────────────────────────────
+
+    #[Test]
+    public function incremental_processing_handles_events_beyond_batch_size(): void
+    {
+        $this->createUser(240);
+
+        // Insert BATCH_SIZE + 50 events.  Each at 100 % → average = 100.
+        $total = IncrementalKpiProcessingService::BATCH_SIZE + 50;
+        $rows  = [];
+        for ($i = 0; $i < $total; $i++) {
+            $rows[] = [
+                'user_id'    => 240,
+                'event_type' => 'course_completed',
+                'occurred_at'=> now()->toDateTimeString(),
+                'payload'    => json_encode(['completion_percentage' => 100.0]),
+                'created_at' => now()->toDateTimeString(),
+            ];
+        }
+        DB::table('lms_kpi_events')->insert($rows);
+
+        // First call processes at most BATCH_SIZE events.
+        $r1 = $this->service->processForUser(240, $this->kpiCompletion);
+        $this->assertLessThanOrEqual(IncrementalKpiProcessingService::BATCH_SIZE, $r1['processed']);
+
+        // Second call picks up the remaining events.
+        $r2 = $this->service->processForUser(240, $this->kpiCompletion);
+        $this->assertGreaterThan(0, $r2['processed']);
+
+        // Value should be 100 % since all events have 100 % completion.
+        $this->assertSame(100.0, round($r2['value'], 2));
+    }
+
+    // ─── KpiUserCursor model helpers ─────────────────────────────────────────
+
+    #[Test]
+    public function cursor_advance_updates_all_fields(): void
+    {
+        $this->createUser(250);
+        $cursor = $this->service->getOrCreateCursor(250, $this->kpiCompletion);
+
+        $cursor->advance(99, 88.5, 10, ['raw_sum' => 885.0]);
+        $cursor->refresh();
+
+        $this->assertSame(99, $cursor->last_event_id);
+        $this->assertSame(88.5, round($cursor->computed_value, 2));
+        $this->assertSame(10, $cursor->event_count);
+        $this->assertEqualsWithDelta(885.0, $cursor->checkpoint_data['raw_sum'] ?? null, PHP_FLOAT_EPSILON);
+        $this->assertFalse($cursor->is_dirty);
+        $this->assertNotNull($cursor->last_processed_at);
+    }
+
+    #[Test]
+    public function cursor_mark_dirty_sets_flag(): void
+    {
+        $this->createUser(260);
+        $cursor = $this->service->getOrCreateCursor(260, $this->kpiCompletion);
+        $cursor->markDirty();
+
+        $cursor->refresh();
+        $this->assertTrue($cursor->is_dirty);
+    }
+
+    #[Test]
+    public function cursor_reset_clears_all_fields(): void
+    {
+        $this->createUser(270);
+        $cursor = $this->service->getOrCreateCursor(270, $this->kpiCompletion);
+        $cursor->advance(50, 75.0, 5, ['raw_sum' => 375.0]);
+        $cursor->markDirty();
+
+        $cursor->reset();
+        $cursor->refresh();
+
+        $this->assertNull($cursor->last_event_id);
+        $this->assertNull($cursor->computed_value);
+        $this->assertSame(0, $cursor->event_count);
+        $this->assertNull($cursor->checkpoint_data);
+        $this->assertFalse($cursor->is_dirty);
+    }
+
+    #[Test]
+    public function cursor_get_effective_value_defaults_to_zero_when_null(): void
+    {
+        $this->createUser(280);
+        $cursor = $this->service->getOrCreateCursor(280, $this->kpiCompletion);
+        $this->assertSame(0.0, $cursor->getEffectiveValue());
+    }
+
+    #[Test]
+    public function cursor_get_checkpoint_key_returns_default_for_missing_key(): void
+    {
+        $this->createUser(290);
+        $cursor = $this->service->getOrCreateCursor(290, $this->kpiCompletion);
+        $this->assertSame(0.0, $cursor->getCheckpointKey('raw_sum'));
+        $this->assertSame('fallback', $cursor->getCheckpointKey('missing', 'fallback'));
+    }
+
+    // ─── Graceful handling of events with null payloads ───────────────────────
+
+    #[Test]
+    public function processing_events_with_null_payload_does_not_throw(): void
+    {
+        $this->createUser(300);
+        DB::table('lms_kpi_events')->insert([
+            'user_id'    => 300,
+            'event_type' => 'course_completed',
+            'occurred_at'=> now()->toDateTimeString(),
+            'payload'    => null,
+            'created_at' => now()->toDateTimeString(),
+        ]);
+
+        $result = $this->service->processForUser(300, $this->kpiCompletion);
+
+        // Event is present but has no completion_percentage → no count increase.
+        $this->assertSame(0, $result['processed'] === 1 ? $this->getCursor(300, $this->kpiCompletion)->event_count : 0);
+        $this->assertSame(0.0, $result['value']);
+    }
+
+    // ─── Multiple incremental runs maintain accuracy ──────────────────────────
+
+    #[Test]
+    public function three_incremental_runs_produce_same_result_as_one_full_run(): void
+    {
+        $this->createUser(310);
+
+        // Batch 1 → run 1
+        $this->insertEvent(310, 'quiz_attempt', ['score' => 90.0]);
+        $this->service->processForUser(310, $this->kpiScore);
+
+        // Batch 2 → run 2
+        $this->insertEvent(310, 'quiz_attempt',         ['score' => 80.0]);
+        $this->insertEvent(310, 'assignment_completed', ['score' => 70.0, 'status' => 'graded']);
+        $this->service->processForUser(310, $this->kpiScore);
+
+        // Batch 3 → run 3
+        $this->insertEvent(310, 'quiz_attempt', ['score' => 60.0]);
+        $result3 = $this->service->processForUser(310, $this->kpiScore);
+
+        // Expected: (90 + 80 + 70 + 60) / 4 = 75
+        $this->assertSame(75.0, round($result3['value'], 2));
+
+        // Now force full recalc and compare.
+        $full = $this->service->forceFullRecalculation(310, $this->kpiScore);
+        $this->assertSame(round($result3['value'], 2), round($full['value'], 2));
+    }
+}

--- a/tests/Unit/Services/Kpi/KpiEventIncrementalApplierTest.php
+++ b/tests/Unit/Services/Kpi/KpiEventIncrementalApplierTest.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Tests\Unit\Services\Kpi;
+
+use App\Services\Kpi\KpiEventIncrementalApplier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Deep unit tests for KpiEventIncrementalApplier.
+ *
+ * All tests are pure – no database, no Laravel container.
+ */
+class KpiEventIncrementalApplierTest extends TestCase
+{
+    private KpiEventIncrementalApplier $applier;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->applier = new KpiEventIncrementalApplier();
+    }
+
+    // ─── relevantEventTypes ───────────────────────────────────────────────────
+
+    #[Test]
+    public function relevant_event_types_returns_correct_types_for_completion(): void
+    {
+        $types = $this->applier->relevantEventTypes('completion');
+        $this->assertSame(['course_completed'], $types);
+    }
+
+    #[Test]
+    public function relevant_event_types_returns_correct_types_for_score(): void
+    {
+        $types = $this->applier->relevantEventTypes('score');
+        $this->assertEqualsCanonicalizing(['quiz_attempt', 'assignment_completed'], $types);
+    }
+
+    #[Test]
+    public function relevant_event_types_returns_correct_types_for_activity(): void
+    {
+        $types = $this->applier->relevantEventTypes('activity');
+        $expected = ['user_login', 'lesson_completed', 'course_completed', 'quiz_attempt', 'assignment_completed'];
+        $this->assertEqualsCanonicalizing($expected, $types);
+    }
+
+    #[Test]
+    public function relevant_event_types_returns_correct_types_for_time(): void
+    {
+        $types = $this->applier->relevantEventTypes('time');
+        $this->assertSame(['assignment_completed'], $types);
+    }
+
+    #[Test]
+    public function relevant_event_types_returns_empty_for_unknown_type(): void
+    {
+        $this->assertSame([], $this->applier->relevantEventTypes('nonexistent'));
+    }
+
+    // ─── Completion KPI ───────────────────────────────────────────────────────
+
+    #[Test]
+    public function completion_first_event_sets_value_correctly(): void
+    {
+        $result = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => 80.0], 0.0, 0, null);
+
+        $this->assertSame(80.0, $result['value']);
+        $this->assertSame(1, $result['count']);
+        $this->assertSame(80.0, $result['checkpoint']['raw_sum']);
+    }
+
+    #[Test]
+    public function completion_running_average_accumulates_correctly(): void
+    {
+        // First event: 80 %
+        $s1 = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => 80.0], 0.0, 0, null);
+        // Second event: 60 %  →  avg = 70
+        $s2 = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => 60.0], $s1['value'], $s1['count'], $s1['checkpoint']);
+        // Third event: 100 %  →  avg = (80+60+100)/3 = 80
+        $s3 = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => 100.0], $s2['value'], $s2['count'], $s2['checkpoint']);
+
+        $this->assertSame(70.0, round($s2['value'], 2));
+        $this->assertSame(80.0, round($s3['value'], 2));
+        $this->assertSame(3, $s3['count']);
+    }
+
+    #[Test]
+    public function completion_ignores_irrelevant_event_types(): void
+    {
+        $irrelevant = ['quiz_attempt', 'user_login', 'lesson_completed', 'assignment_completed'];
+
+        foreach ($irrelevant as $type) {
+            $result = $this->applier->apply('completion', $type, ['completion_percentage' => 90.0], 50.0, 5, ['raw_sum' => 250.0]);
+            $this->assertSame(50.0, $result['value'], "Expected no change for event type [{$type}]");
+            $this->assertSame(5, $result['count']);
+        }
+    }
+
+    #[Test]
+    public function completion_ignores_event_with_missing_percentage(): void
+    {
+        $result = $this->applier->apply('completion', 'course_completed', [], 60.0, 3, ['raw_sum' => 180.0]);
+        $this->assertSame(60.0, $result['value']);
+        $this->assertSame(3, $result['count']);
+    }
+
+    #[Test]
+    public function completion_clamps_percentage_above_100(): void
+    {
+        $result = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => 150.0], 0.0, 0, null);
+        $this->assertSame(100.0, $result['value']);
+    }
+
+    #[Test]
+    public function completion_clamps_percentage_below_0(): void
+    {
+        $result = $this->applier->apply('completion', 'course_completed', ['completion_percentage' => -20.0], 0.0, 0, null);
+        $this->assertSame(0.0, $result['value']);
+    }
+
+    // ─── Score KPI ────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function score_quiz_attempt_updates_running_average(): void
+    {
+        $s1 = $this->applier->apply('score', 'quiz_attempt', ['score' => 90.0], 0.0, 0, null);
+        $s2 = $this->applier->apply('score', 'quiz_attempt', ['score' => 70.0], $s1['value'], $s1['count'], $s1['checkpoint']);
+
+        $this->assertSame(90.0, $s1['value']);
+        $this->assertSame(80.0, $s2['value']);
+        $this->assertSame(2, $s2['count']);
+    }
+
+    #[Test]
+    public function score_graded_assignment_counts_toward_average(): void
+    {
+        $result = $this->applier->apply('score', 'assignment_completed', ['score' => 75.0, 'status' => 'graded'], 0.0, 0, null);
+        $this->assertSame(75.0, $result['value']);
+        $this->assertSame(1, $result['count']);
+    }
+
+    #[Test]
+    public function score_approved_assignment_counts_toward_average(): void
+    {
+        $result = $this->applier->apply('score', 'assignment_completed', ['score' => 85.0, 'status' => 'approved'], 0.0, 0, null);
+        $this->assertSame(85.0, $result['value']);
+    }
+
+    #[Test]
+    public function score_submitted_assignment_is_ignored(): void
+    {
+        $result = $this->applier->apply('score', 'assignment_completed', ['score' => 95.0, 'status' => 'submitted'], 50.0, 2, ['raw_sum' => 100.0]);
+        $this->assertSame(50.0, $result['value']);
+        $this->assertSame(2, $result['count']);
+    }
+
+    #[Test]
+    public function score_rejected_assignment_is_ignored(): void
+    {
+        $result = $this->applier->apply('score', 'assignment_completed', ['score' => 40.0, 'status' => 'rejected'], 70.0, 1, ['raw_sum' => 70.0]);
+        $this->assertSame(70.0, $result['value']);
+    }
+
+    #[Test]
+    public function score_ignores_event_with_no_score_field(): void
+    {
+        $result = $this->applier->apply('score', 'quiz_attempt', [], 60.0, 3, ['raw_sum' => 180.0]);
+        $this->assertSame(60.0, $result['value']);
+        $this->assertSame(3, $result['count']);
+    }
+
+    // ─── Activity KPI ─────────────────────────────────────────────────────────
+
+    #[Test]
+    public function activity_user_login_adds_correct_points(): void
+    {
+        $result = $this->applier->apply('activity', 'user_login', [], 0.0, 0, null);
+        $this->assertSame((float) KpiEventIncrementalApplier::ACTIVITY_POINTS['user_login'], $result['value']);
+        $this->assertSame(1, $result['count']);
+    }
+
+    #[Test]
+    public function activity_course_completed_adds_correct_points(): void
+    {
+        $result = $this->applier->apply('activity', 'course_completed', [], 0.0, 0, null);
+        $this->assertSame((float) KpiEventIncrementalApplier::ACTIVITY_POINTS['course_completed'], $result['value']);
+    }
+
+    #[Test]
+    public function activity_accumulated_points_cap_at_100(): void
+    {
+        // Start at 95 points, add a course_completed (25 pts) – should clamp to 100.
+        $result = $this->applier->apply('activity', 'course_completed', [], 95.0, 10, ['accumulated_points' => 95.0]);
+        $this->assertSame(100.0, $result['value']);
+        $this->assertGreaterThan(100.0, $result['checkpoint']['accumulated_points']); // raw uncapped
+    }
+
+    #[Test]
+    public function activity_unknown_event_type_is_skipped(): void
+    {
+        $result = $this->applier->apply('activity', 'unknown_event', [], 20.0, 2, ['accumulated_points' => 20.0]);
+        $this->assertSame(20.0, $result['value']);
+        $this->assertSame(2, $result['count']);
+    }
+
+    #[Test]
+    public function activity_all_event_types_contribute_different_point_values(): void
+    {
+        $events = ['user_login', 'lesson_completed', 'quiz_attempt', 'assignment_completed', 'course_completed'];
+        $expectedTotals = [];
+        $acc = 0;
+        foreach ($events as $type) {
+            $acc += KpiEventIncrementalApplier::ACTIVITY_POINTS[$type];
+            $expectedTotals[$type] = min(100.0, (float) $acc);
+        }
+
+        $value = 0.0;
+        $count = 0;
+        $checkpoint = null;
+        foreach ($events as $type) {
+            $res   = $this->applier->apply('activity', $type, [], $value, $count, $checkpoint);
+            $value = $res['value'];
+            $count = $res['count'];
+            $checkpoint = $res['checkpoint'];
+            $this->assertSame($expectedTotals[$type], $value, "After {$type}");
+        }
+    }
+
+    // ─── Time KPI ─────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function time_first_event_normalizes_correctly(): void
+    {
+        // 1800s / 3600s * 100 = 50 %
+        $result = $this->applier->apply('time', 'assignment_completed', ['time_to_complete_seconds' => 1800], 0.0, 0, null);
+        $this->assertSame(50.0, round($result['value'], 2));
+        $this->assertSame(1, $result['count']);
+        $this->assertSame(1800.0, $result['checkpoint']['raw_sum_seconds']);
+    }
+
+    #[Test]
+    public function time_running_average_of_seconds_is_normalized(): void
+    {
+        // 3600s → 100%, then 0s → 50% (avg = 1800s)
+        $s1 = $this->applier->apply('time', 'assignment_completed', ['time_to_complete_seconds' => 3600], 0.0, 0, null);
+        $s2 = $this->applier->apply('time', 'assignment_completed', ['time_to_complete_seconds' => 0], $s1['value'], $s1['count'], $s1['checkpoint']);
+
+        $this->assertSame(100.0, $s1['value']);
+        $this->assertSame(50.0, $s2['value']);
+        $this->assertSame(2, $s2['count']);
+    }
+
+    #[Test]
+    public function time_caps_at_100_for_very_long_assignments(): void
+    {
+        $result = $this->applier->apply('time', 'assignment_completed', ['time_to_complete_seconds' => 99999], 0.0, 0, null);
+        $this->assertSame(100.0, $result['value']);
+    }
+
+    #[Test]
+    public function time_ignores_negative_seconds(): void
+    {
+        $result = $this->applier->apply('time', 'assignment_completed', ['time_to_complete_seconds' => -1], 55.0, 2, ['raw_sum_seconds' => 3960.0]);
+        $this->assertSame(55.0, $result['value']);
+        $this->assertSame(2, $result['count']);
+    }
+
+    #[Test]
+    public function time_ignores_missing_seconds_field(): void
+    {
+        $result = $this->applier->apply('time', 'assignment_completed', [], 40.0, 1, ['raw_sum_seconds' => 1440.0]);
+        $this->assertSame(40.0, $result['value']);
+    }
+
+    #[Test]
+    public function time_ignores_irrelevant_event_types(): void
+    {
+        $result = $this->applier->apply('time', 'quiz_attempt', ['time_to_complete_seconds' => 3600], 50.0, 2, null);
+        $this->assertSame(50.0, $result['value']);
+    }
+
+    // ─── Unknown KPI type ─────────────────────────────────────────────────────
+
+    #[Test]
+    public function unknown_kpi_type_returns_state_unchanged(): void
+    {
+        $result = $this->applier->apply('unknown_type', 'course_completed', ['completion_percentage' => 80], 42.0, 7, ['some' => 'data']);
+        $this->assertSame(42.0, $result['value']);
+        $this->assertSame(7, $result['count']);
+        $this->assertSame(['some' => 'data'], $result['checkpoint']);
+    }
+
+    // ─── applyBatch ───────────────────────────────────────────────────────────
+
+    #[Test]
+    public function apply_batch_processes_all_events_in_order(): void
+    {
+        $events = [
+            ['event_type' => 'quiz_attempt',        'payload' => ['score' => 80.0]],
+            ['event_type' => 'quiz_attempt',        'payload' => ['score' => 60.0]],
+            ['event_type' => 'assignment_completed','payload' => ['score' => 100.0, 'status' => 'graded']],
+        ];
+
+        $result = $this->applier->applyBatch('score', $events, 0.0, 0, null);
+
+        // (80 + 60 + 100) / 3 = 80
+        $this->assertSame(80.0, round($result['value'], 2));
+        $this->assertSame(3, $result['count']);
+    }
+
+    #[Test]
+    public function apply_batch_with_empty_events_returns_initial_state(): void
+    {
+        $result = $this->applier->applyBatch('completion', [], 55.5, 3, ['raw_sum' => 166.5]);
+        $this->assertSame(55.5, $result['value']);
+        $this->assertSame(3, $result['count']);
+    }
+
+    #[Test]
+    public function apply_batch_handles_mixed_relevant_and_irrelevant_events(): void
+    {
+        // For 'completion' only 'course_completed' counts.
+        $events = [
+            ['event_type' => 'user_login',       'payload' => []],
+            ['event_type' => 'course_completed',  'payload' => ['completion_percentage' => 80.0]],
+            ['event_type' => 'quiz_attempt',       'payload' => ['score' => 90.0]],
+            ['event_type' => 'course_completed',  'payload' => ['completion_percentage' => 60.0]],
+        ];
+
+        $result = $this->applier->applyBatch('completion', $events, 0.0, 0, null);
+
+        // Only two course_completed events: (80 + 60) / 2 = 70
+        $this->assertSame(70.0, round($result['value'], 2));
+        $this->assertSame(2, $result['count']);
+    }
+
+    // ─── Idempotency / determinism ────────────────────────────────────────────
+
+    #[Test]
+    public function apply_is_deterministic_for_same_inputs(): void
+    {
+        $args = ['completion', 'course_completed', ['completion_percentage' => 75.0], 60.0, 3, ['raw_sum' => 180.0]];
+
+        $r1 = $this->applier->apply(...$args);
+        $r2 = $this->applier->apply(...$args);
+
+        $this->assertSame($r1, $r2);
+    }
+
+    #[Test]
+    public function apply_batch_produces_same_result_when_called_twice_on_identical_batches(): void
+    {
+        $events = [
+            ['event_type' => 'quiz_attempt', 'payload' => ['score' => 55.0]],
+            ['event_type' => 'quiz_attempt', 'payload' => ['score' => 85.0]],
+        ];
+
+        $r1 = $this->applier->applyBatch('score', $events, 0.0, 0, null);
+        $r2 = $this->applier->applyBatch('score', $events, 0.0, 0, null);
+
+        $this->assertSame($r1, $r2);
+    }
+}


### PR DESCRIPTION
📥 Pull Request Template

🔧 Description
What problem does this PR solve?
KPI recalculation was repeatedly reprocessing full event history. This increased cost over time, made retries expensive, and created risk of duplicate aggregation during repeated runs.

What feature does it add?
This PR implements a delta-based, cursor-driven KPI processing path that only applies new/unprocessed events per user + KPI, with safe recovery to full rebuild when needed.

Implemented components:
- Added `kpi_user_cursors` persistence model and migration to track `last_event_id`, cached value, checkpoint data, and dirty-state.
- Added `KpiEventIncrementalApplier` for deterministic per-event and batched aggregation logic across completion, score, activity, and time KPI types.
- Added `IncrementalKpiProcessingService` for:
  - incremental processing (`id > last_event_id`),
  - idempotent transactional cursor advancement (`lockForUpdate` guard),
  - dirty cursor fallback to full recalculation,
  - batch chunk handling.
- Added command `kpi:process-incremental` and scheduler registration (every 15 minutes).
- Added `ProcessUserKpiJob` with retries/backoff and dirty marking on failure.
- Added comprehensive tests for applier and service behavior.

Fixes: #420
Part of: #461

✅ Type of Change
Select all that apply:

- [x]   🐞 Bug fix
- [x]   ✨ New feature
- [x]   ♻️ Code refactor
- [ ]   📝 Documentation update
- [ ]   🎨 UI/UX update
- [ ]   🔐 Security improvement
- [ ]   🔧 Other (please describe):

📸 Screenshots (if applicable)
N/A (backend/service implementation).

🚀 How Has This Been Tested?
Describe the tests you ran to verify your changes:

- [x]   Local environment
- [ ]   Browser testing
- [ ]   Mobile testing
- [x]   Database migrations tested
- [x]   Unit/Feature tests added
- [x]   Other: targeted PHPUnit run for new KPI tests (66 passing)

🧪 Steps to Reproduce (for bug fixes)

1. Create KPI events for a user.
2. Run `php artisan kpi:process-incremental --user={id}`.
3. Run again without adding events and verify `processed=0` with unchanged value.
4. Insert new events and rerun; verify only new events are applied.
5. Mark cursor dirty and rerun; verify full recalculation path executes and cursor is cleaned.

🔄 Checklist
Before submitting the PR, ensure you:

- [x]   Followed the project's coding guidelines
- [ ]   Updated documentation (if needed)
- [x]   Added/Updated tests (if applicable)
- [x]   Verified no sensitive data is included
- [x]   Ensured the app builds without errors

🙏 Additional Notes
- Processing is keyed by `(user_id, kpi_id)` with a unique cursor row.
- Late-arriving events are naturally included on next run due to monotonic `id` cursor progression.
- Full recalculation remains available as a safety path and for recovery from partial failures.
