### PR TITLE
feat(i18n): remove hardcoded UI text and normalize locale keys

### DIFF
--- a/app/Models/NotificationSetting.php
+++ b/app/Models/NotificationSetting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class NotificationSetting extends Model
 {
@@ -28,128 +29,144 @@ class NotificationSetting extends Model
     {
         return [
             'users' => [
-                'label' => __('admin_pages.notification_settings.modules.users'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.users'),
                 'icon' => 'fas fa-users',
                 'events' => [
                     'user_created' => [
-                        'label' => __('admin_pages.notification_settings.events.user_created'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.user_created'),
                         'channels' => ['email'],
                     ],
                     'user_updated' => [
-                        'label' => __('admin_pages.notification_settings.events.user_updated'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.user_updated'),
                         'channels' => ['email'],
                     ],
                     'user_activated' => [
-                        'label' => __('admin_pages.notification_settings.events.user_activated'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.user_activated'),
                         'channels' => ['email'],
                     ],
                     'role_assigned' => [
-                        'label' => __('admin_pages.notification_settings.events.role_assigned'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.role_assigned'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'courses' => [
-                'label' => __('admin_pages.notification_settings.modules.courses'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.courses'),
                 'icon' => 'fas fa-graduation-cap',
                 'events' => [
                     'course_created' => [
-                        'label' => __('admin_pages.notification_settings.events.course_created'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.course_created'),
                         'channels' => ['email'],
                     ],
                     'course_published' => [
-                        'label' => __('admin_pages.notification_settings.events.course_published'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.course_published'),
                         'channels' => ['email'],
                     ],
                     'course_expired' => [
-                        'label' => __('admin_pages.notification_settings.events.course_expired'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.course_expired'),
                         'channels' => ['email'],
                     ],
                     'course_enrollment' => [
-                        'label' => __('admin_pages.notification_settings.events.course_enrollment'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.course_enrollment'),
                         'channels' => ['email'],
                     ],
                     'course_due_reminder' => [
-                        'label' => __('admin_pages.notification_settings.events.course_due_reminder'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.course_due_reminder'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'lessons' => [
-                'label' => __('admin_pages.notification_settings.modules.lessons'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.lessons'),
                 'icon' => 'fas fa-file-alt',
                 'events' => [
                     'lesson_added' => [
-                        'label' => __('admin_pages.notification_settings.events.lesson_added'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.lesson_added'),
                         'channels' => ['email'],
                     ],
                     'lesson_updated' => [
-                        'label' => __('admin_pages.notification_settings.events.lesson_updated'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.lesson_updated'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'assessments' => [
-                'label' => __('admin_pages.notification_settings.modules.assessments'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.assessments'),
                 'icon' => 'fas fa-clipboard-check',
                 'events' => [
                     'test_assigned' => [
-                        'label' => __('admin_pages.notification_settings.events.test_assigned'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.test_assigned'),
                         'channels' => ['email'],
                     ],
                     'test_completed' => [
-                        'label' => __('admin_pages.notification_settings.events.test_completed'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.test_completed'),
                         'channels' => ['email'],
                     ],
                     'test_results_published' => [
-                        'label' => __('admin_pages.notification_settings.events.test_results_published'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.test_results_published'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'trainees' => [
-                'label' => __('admin_pages.notification_settings.modules.trainees'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.trainees'),
                 'icon' => 'fas fa-user-graduate',
                 'events' => [
                     'trainee_enrolled' => [
-                        'label' => __('admin_pages.notification_settings.events.trainee_enrolled'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.trainee_enrolled'),
                         'channels' => ['email'],
                     ],
                     'trainee_completed_course' => [
-                        'label' => __('admin_pages.notification_settings.events.trainee_completed_course'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.trainee_completed_course'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'trainers' => [
-                'label' => __('admin_pages.notification_settings.modules.trainers'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.trainers'),
                 'icon' => 'fas fa-chalkboard-user',
                 'events' => [
                     'trainer_assigned' => [
-                        'label' => __('admin_pages.notification_settings.events.trainer_assigned'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.trainer_assigned'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
             'system' => [
-                'label' => __('admin_pages.notification_settings.modules.system'),
+                'label' => self::translateLabel('admin_pages.notification_settings.modules.system'),
                 'icon' => 'fas fa-shield-alt',
                 'events' => [
                     'login_alerts' => [
-                        'label' => __('admin_pages.notification_settings.events.login_alerts'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.login_alerts'),
                         'channels' => ['email'],
                     ],
                     'password_reset' => [
-                        'label' => __('admin_pages.notification_settings.events.password_reset'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.password_reset'),
                         'channels' => ['email'],
                     ],
                     'failed_login' => [
-                        'label' => __('admin_pages.notification_settings.events.failed_login'),
+                        'label' => self::translateLabel('admin_pages.notification_settings.events.failed_login'),
                         'channels' => ['email'],
                     ],
                 ],
             ],
         ];
+    }
+
+    protected static function translateLabel(string $key): string
+    {
+        $translated = __($key);
+        if ($translated !== $key) {
+            return $translated;
+        }
+
+        $fallbackLocale = (string) config('app.fallback_locale', 'en');
+        $fallback = trans($key, [], $fallbackLocale);
+        if ($fallback !== $key) {
+            return $fallback;
+        }
+
+        return Str::headline((string) last(explode('.', $key)));
     }
 
     /**

--- a/resources/lang/ar/admin_pages.php
+++ b/resources/lang/ar/admin_pages.php
@@ -1,6 +1,13 @@
 <?php
 
 return array(
+  'manual_assessment' => array(
+    'user_assessment_answers' => 'إجابات تقييم المستخدم',
+    'marks_obtained' => 'الدرجات المحصلة',
+    'correct_answer' => 'الإجابة الصحيحة',
+    'user_answer' => 'إجابة المستخدم',
+    'not_available' => 'غير متاح',
+  ),
   'pathway_assignments' => array(
     'title' => 'تعيينات مسارات التعلم',
     'make_new_assignment' => 'إنشاء تعيين جديد',

--- a/resources/lang/ar/course_pages.php
+++ b/resources/lang/ar/course_pages.php
@@ -41,6 +41,7 @@ return array(
     'open_quiz' => 'افتح اختبار الدرس',
     'course_title' => 'الدورة:',
     'complete_pass_quiz_unlock_next' => 'أكمل واجتز اختبار الدرس لفتح الدرس التالي',
+    'assessment_failed_no_certificate' => 'عذرا! لم تنجح في التقييم، لذلك لا يمكن إصدار الشهادة.',
   ),
   'certificate' => array(
     'course_name' => 'اسم المسار',

--- a/resources/lang/ar/labels.php
+++ b/resources/lang/ar/labels.php
@@ -496,6 +496,8 @@ return array(
         'mail_port' => 'ميناء البريد',
         'mail_username' => 'البريد اسم المستخدم',
         'mail_username_note' => 'أضف معرف بريدك الإلكتروني الذي تريد تكوينه لإرسال رسائل البريد الإلكتروني',
+        'site_logo' => 'شعار الموقع',
+        'save_settings' => 'حفظ الإعدادات',
         'note' => '<b> ملاحظة مهمة </b>: إذا كنت تستخدم <b> GMAIL </b> لتكوين البريد ، فتأكد من إكمال العملية التالية قبل التحديث:
   <UL>
 <li> انتقل إلى <a target="_blank" href="https://myaccount.google.com/security"> حسابي </a> من حسابك في Google الذي تريد تكوينه وتسجيل الدخول </li>
@@ -540,6 +542,7 @@ return array(
       'language_settings' => array(
         'default_language' => 'اللغة الافتراضية',
         'display_type' => 'نوع العرض',
+        'download_base_language_file' => 'تنزيل ملف اللغة الأساسي',
         'left_to_right' => 'من اليسار إلى اليمين',
         'right_to_left' => 'من اليمين الى اليسار',
         'title' => 'اعدادات اللغة',
@@ -561,6 +564,8 @@ return array(
       'mail_port' => 'ميناء البريد',
       'mail_username' => 'البريد اسم المستخدم',
       'management' => 'الإعدادات العامة',
+      'site_logo' => 'شعار الموقع',
+      'save_settings' => 'حفظ الإعدادات',
       'newsletter' => array(
         'api_key' => 'مفتاح API',
         'api_key_note' => 'أنشئ <b> مفتاح API </b> من <a target="_blank" href="https://mailchimp.com/"> <b> حساب Mailchimp </b> </a> والصقه أعلاه مربع النوع.',
@@ -1275,6 +1280,14 @@ return array(
       'view_license' => 'مراجعة الترخيص',
       'remove_license_title' => 'إزالة الترخيص',
       'removing' => 'جارٍ الإزالة...',
+      'toggle_key_visibility' => 'إظهار/إخفاء',
+      'standard' => 'قياسي',
+      'syncing' => 'جارٍ مزامنة المستخدمين...',
+      'sync_failed' => 'فشلت مزامنة المستخدمين',
+      'total' => 'الإجمالي',
+      'created' => 'تم الإنشاء',
+      'attached' => 'تم الربط',
+      'failed' => 'فشل',
     ),
     'smtp_settings' => array(
       'title' => 'إعدادات البريد الإلكتروني (SMTP)',
@@ -1331,8 +1344,10 @@ return array(
     'sr_no' => 'الرقم المتسلسل',
     'show' => 'تبين',
     'read_more' => 'قراءة المزيد',
+    'view_all' => 'عرض الكل',
     'none' => 'لا شيء',
     'no_data_available' => 'لا تتوافر بيانات',
+    'not_available' => 'غير متاح',
     'no' => 'لا',
     'more' => 'أكثر من',
     'actions' => 'أفعال',
@@ -1374,8 +1389,8 @@ return array(
       'featured_course' => 'ظهرت <span> الدورة التدريبية. </span>',
       'login_to_post_comment' => 'تسجيل الدخول لنشر تعليق',
       'no_comments_yet' => 'لا تعليقات حتى الآن ، كن أول من يعلق.',
+      'post_comments' => 'نشر <span>التعليقات.</span>',
       'popular_tags' => '<span> العلامات الشائعة. </span>',
-      'post_comments' => 'نشر <span> تعليقات. </span>',
       'related_news' => '<span> ذات صلة </span> الأخبار',
       'search_blog' => 'ابحث عن مدونة',
       'share_this_news' => 'شارك هذا الخبر',
@@ -1574,6 +1589,11 @@ return array(
       'title' => 'الصفحة الرئيسية',
       'what_they_say_about_us' => 'ماذا يقولون عنا',
       'no_data_available' => 'لا تتوافر بيانات',
+      'our_category' => 'فئاتنا',
+      'category_1' => 'الفئة 1',
+      'category_2' => 'الفئة 2',
+      'category_3' => 'الفئة 3',
+      'category_4' => 'الفئة 4',
     ),
     'layouts' => array(
       'partials' => array(

--- a/resources/lang/ar/language_marketplace_pages.php
+++ b/resources/lang/ar/language_marketplace_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+return array(
+  'contribute' => array(
+    'page_title' => 'المساهمة اللغوية',
+    'title' => 'المساهمة اللغوية',
+    'subtitle' => 'أرسل حزمة JSON المترجمة للغة :locale.',
+    'invitation_details' => 'تفاصيل الدعوة',
+    'contributor' => 'المساهم',
+    'default_contributor' => 'المساهم',
+    'email' => 'البريد الإلكتروني',
+    'status' => 'الحالة',
+    'expires' => 'تنتهي في',
+    'no_expiry' => 'لا يوجد انتهاء',
+    'source_package' => 'حزمة المصدر (:locale)',
+    'source_package_help' => 'قم بتنزيل حزمة المصدر الحالية، ثم ترجمها، ثم ارفع ملف JSON المترجم أدناه.',
+    'download_source_package' => 'تنزيل حزمة المصدر',
+    'auto_detected_title' => 'عناصر غير مترجمة تم اكتشافها تلقائيًا',
+    'auto_detected_desc' => 'تم اكتشاف :count عنصرًا غير مترجم بمقارنة المصدر :source مع الهدف :target. املأ الحقول أدناه ثم أرسل مباشرة.',
+    'no_source_modules' => 'لم يتم العثور على وحدات مصدر للغة المصدر المحددة. انشر حزمة مصدر صالحة أولاً أو استخدم EN كمصدر.',
+    'module' => 'الوحدة',
+    'source' => 'المصدر',
+    'current' => 'الحالي',
+    'insert_translation' => 'أدخل الترجمة',
+    'no_untranslated_labels' => 'لم يتم اكتشاف عناصر غير مترجمة لهذا الزوج اللغوي.',
+    'upload_translated_json_file' => 'ارفع ملف JSON المترجم',
+    'or_paste_translated_json' => 'أو ألصق JSON المترجم',
+    'message_to_reviewer' => 'رسالة إلى المراجع',
+    'optional_note' => 'ملاحظة اختيارية لمراجع الإدارة',
+    'submit_translation' => 'إرسال الترجمة',
+  ),
+);

--- a/resources/lang/ar/license-en.php
+++ b/resources/lang/ar/license-en.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-ar.php';

--- a/resources/lang/ar/license.php
+++ b/resources/lang/ar/license.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-ar.php';

--- a/resources/lang/en/admin_pages.php
+++ b/resources/lang/en/admin_pages.php
@@ -1,6 +1,13 @@
 <?php
 
 return array(
+  'manual_assessment' => array(
+    'user_assessment_answers' => 'User Assessment Answers',
+    'marks_obtained' => 'Marks obtained',
+    'correct_answer' => 'Correct Answer',
+    'user_answer' => 'User\'s Answer',
+    'not_available' => 'N/A',
+  ),
   'pathway_assignments' => array(
     'title' => 'Learning Pathway Assignments',
     'make_new_assignment' => 'Make New Assignment',

--- a/resources/lang/en/course_pages.php
+++ b/resources/lang/en/course_pages.php
@@ -41,6 +41,7 @@ return array(
     'open_quiz' => 'Open Lesson Quiz',
     'course_title' => 'Course:',
     'complete_pass_quiz_unlock_next' => 'Complete and pass the lesson quiz to unlock the next lesson',
+    'assessment_failed_no_certificate' => 'Sorry! You did not qualify the assignment, so the certificate could not be issued.',
   ),
   'certificate' => array(
     'course_name' => 'Course Name',

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -475,6 +475,8 @@ return array(
         'mail_password_note' => 'Add your email password you want to configure for sending emails',
         'mail_encryption' => 'Mail Encryption',
         'mail_encryption_note' => 'Use <b>tls</b> if your site uses <b>HTTP</b> protocol and <b>ssl</b> if you site uses <b>HTTPS</b> protocol',
+        'site_logo' => 'Site Logo',
+        'save_settings' => 'Save Settings',
         'note' => '<b>Important Note</b> : IF you are using <b>GMAIL</b> for Mail configuration, make sure you have completed following process before updating:
       <ul>
       <li>Go to <a target="_blank" href="https://myaccount.google.com/security">My Account</a> from your Google Account you want to configure and Login</li>
@@ -1372,6 +1374,14 @@ return array(
       'view_license' => 'Review License',
       'remove_license_title'=> 'Remove License',
       'removing'=>'Removing...',
+      'toggle_key_visibility' => 'Show/Hide',
+      'standard' => 'Standard',
+      'syncing' => 'Syncing...',
+      'sync_failed' => 'Failed to sync users',
+      'total' => 'Total',
+      'created' => 'Created',
+      'attached' => 'Attached',
+      'failed' => 'Failed',
     ],
     'smtp_settings' => array(
       'title' => 'Email Settings (SMTP)',
@@ -1437,6 +1447,7 @@ return array(
     'trash' => 'Trash',
     'delete' => 'Delete',
     'no_data_available' => 'No data available',
+    'not_available' => 'N/A',
     'edit' => 'Edit',
     'copyright' => 'Copyright',
     'delete_selected' => 'Delete Selected',
@@ -1447,6 +1458,7 @@ return array(
     'toggle_navigation' => 'Toggle Navigation',
     'sr_no' => 'Sr No.',
     'read_more' => 'Read More',
+    'view_all' => 'View All',
   ),
   'frontend' =>
   array(
@@ -1678,6 +1690,11 @@ return array(
       'all_teachers' => 'All Trainers',
       'what_they_say_about_us' => 'What they say about us',
       'no_data_available' => 'No data available',
+      'our_category' => 'Our Category',
+      'category_1' => 'Category 1',
+      'category_2' => 'Category 2',
+      'category_3' => 'Category 3',
+      'category_4' => 'Category 4',
     ),
     'layouts' =>
     array(

--- a/resources/lang/en/language_marketplace_pages.php
+++ b/resources/lang/en/language_marketplace_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+return array(
+  'contribute' => array(
+    'page_title' => 'Language Contribution',
+    'title' => 'Language Contribution',
+    'subtitle' => 'Submit your translated JSON package for :locale.',
+    'invitation_details' => 'Invitation Details',
+    'contributor' => 'Contributor',
+    'default_contributor' => 'Contributor',
+    'email' => 'Email',
+    'status' => 'Status',
+    'expires' => 'Expires',
+    'no_expiry' => 'No expiry',
+    'source_package' => 'Source Package (:locale)',
+    'source_package_help' => 'Download the current source package, translate it, then upload the translated JSON below.',
+    'download_source_package' => 'Download source package',
+    'auto_detected_title' => 'Auto-detected untranslated labels',
+    'auto_detected_desc' => 'We detected :count untranslated labels by comparing source :source with target :target. Fill any fields below and submit directly.',
+    'no_source_modules' => 'No source modules were found for the selected source locale. Publish a valid source package first, or use EN source.',
+    'module' => 'Module',
+    'source' => 'Source',
+    'current' => 'Current',
+    'insert_translation' => 'Insert translation',
+    'no_untranslated_labels' => 'No untranslated labels detected for this language pair.',
+    'upload_translated_json_file' => 'Upload translated JSON file',
+    'or_paste_translated_json' => 'Or paste translated JSON',
+    'message_to_reviewer' => 'Message to reviewer',
+    'optional_note' => 'Optional note for the admin reviewer',
+    'submit_translation' => 'Submit translation',
+  ),
+);

--- a/resources/lang/en/license-ar.php
+++ b/resources/lang/en/license-ar.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/en/license.php
+++ b/resources/lang/en/license.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/es/admin_pages.php
+++ b/resources/lang/es/admin_pages.php
@@ -1,6 +1,13 @@
 <?php
 
 return array(
+  'manual_assessment' => array(
+    'user_assessment_answers' => 'Respuestas de evaluacion del usuario',
+    'marks_obtained' => 'Puntuacion obtenida',
+    'correct_answer' => 'Respuesta correcta',
+    'user_answer' => 'Respuesta del usuario',
+    'not_available' => 'N/A',
+  ),
   'pathway_assignments' => array(
     'title' => 'Asignaciones de rutas de aprendizaje',
     'make_new_assignment' => 'Crear nueva asignacion',

--- a/resources/lang/es/course_pages.php
+++ b/resources/lang/es/course_pages.php
@@ -41,6 +41,7 @@ return array(
     'open_quiz' => 'Abrir cuestionario de la lección',
     'course_title' => 'Curso:',
     'complete_pass_quiz_unlock_next' => 'Completa y aprueba el cuestionario de la lección para desbloquear la siguiente lección',
+    'assessment_failed_no_certificate' => 'Lo sentimos, no calificaste en la evaluación, por lo que no se pudo emitir el certificado.',
   ),
   'certificate' => array(
     'course_name' => 'Nombre del curso',

--- a/resources/lang/es/labels.php
+++ b/resources/lang/es/labels.php
@@ -23,10 +23,12 @@ return array(
     'toolbar_btn_groups' => 'Barra de herramientas con grupos de botones',
     'sr_no' => 'No Señor.',
     'read_more' => 'Lee mas',
+      'view_all' => 'Ver todo',
     'no_data_available' => 'Datos no disponibles',
     'more' => 'Más',
     'edit' => 'Editar',
     'delete_selected' => 'Eliminar seleccionado',
+      'not_available' => 'N/D',
     'delete' => 'Borrar',
     'create_new' => 'Crear nuevo',
     'back' => 'Espalda',
@@ -445,6 +447,8 @@ return array(
         'mail_port' => 'Correo PORT',
         'mail_username' => 'Nombre de usuario del correo',
         'mail_username_note' => 'Agregue su ID de correo electrónico que desea configurar para enviar correos electrónicos',
+        'site_logo' => 'Logo del sitio',
+        'save_settings' => 'Guardar ajustes',
         'note' => '<b> Nota importante </b>: si está utilizando <b> GMAIL </b> para la configuración de correo, asegúrese de haber completado el siguiente proceso antes de actualizar:
   <ul>
 <li> Vaya a <a target="_blank" href="https://myaccount.google.com/security"> Mi cuenta </a> desde la cuenta de Google que desea configurar e iniciar sesión </li>
@@ -499,6 +503,8 @@ return array(
       'mail_port' => 'Puerto de correo',
       'mail_username' => 'Nombre de usuario del correo',
       'management' => 'Configuración general',
+      'site_logo' => 'Logo del sitio',
+      'save_settings' => 'Guardar ajustes',
       'newsletter' => array(
         'api_key' => 'Clave API',
         'api_key_note' => 'Genere <b> clave de API </b> a partir de su <a target="_blank" href="https://mailchimp.com/"> <b> cuenta de Mailchimp </b> </a> y péguela arriba. caja de texto.',
@@ -590,6 +596,7 @@ return array(
       'language_settings' => array(
         'default_language' => 'Idioma predeterminado',
         'display_type' => 'Tipo de visualización',
+        'download_base_language_file' => 'Descargar archivo de idioma base',
         'left_to_right' => 'De izquierda a derecha',
         'right_to_left' => 'De derecha a izquierda',
         'title' => 'Configuraciones de idioma',
@@ -1313,6 +1320,14 @@ return array(
       'view_license' => 'Revisar licencia',
       'remove_license_title' => 'Quitar licencia',
       'removing' => 'Eliminando...',
+      'toggle_key_visibility' => 'Mostrar/Ocultar',
+      'standard' => 'Estándar',
+      'syncing' => 'Sincronizando usuarios...',
+      'sync_failed' => 'No se pudieron sincronizar los usuarios',
+      'total' => 'Total',
+      'created' => 'Creados',
+      'attached' => 'Vinculados',
+      'failed' => 'Fallidos',
     ),
     'smtp_settings' => array(
       'title' => 'Configuración de correo electrónico (SMTP)',
@@ -1618,6 +1633,11 @@ return array(
       'title' => 'Home',
       'what_they_say_about_us' => 'Que dicen de nosotros',
       'no_data_available' => 'Datos no disponibles',
+      'our_category' => 'Nuestras categorias',
+      'category_1' => 'Categoria 1',
+      'category_2' => 'Categoria 2',
+      'category_3' => 'Categoria 3',
+      'category_4' => 'Categoria 4',
     ),
     'layouts' => array(
       'partials' => array(

--- a/resources/lang/es/language_marketplace_pages.php
+++ b/resources/lang/es/language_marketplace_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+return array(
+  'contribute' => array(
+    'page_title' => 'Contribucion de idioma',
+    'title' => 'Contribucion de idioma',
+    'subtitle' => 'Envia tu paquete JSON traducido para :locale.',
+    'invitation_details' => 'Detalles de la invitacion',
+    'contributor' => 'Colaborador',
+    'default_contributor' => 'Colaborador',
+    'email' => 'Correo electronico',
+    'status' => 'Estado',
+    'expires' => 'Expira',
+    'no_expiry' => 'Sin vencimiento',
+    'source_package' => 'Paquete fuente (:locale)',
+    'source_package_help' => 'Descarga el paquete fuente actual, traducelo y luego sube el JSON traducido abajo.',
+    'download_source_package' => 'Descargar paquete fuente',
+    'auto_detected_title' => 'Etiquetas sin traducir detectadas automaticamente',
+    'auto_detected_desc' => 'Detectamos :count etiquetas sin traducir comparando origen :source con destino :target. Completa los campos y envia directamente.',
+    'no_source_modules' => 'No se encontraron modulos fuente para el idioma origen seleccionado. Publica primero un paquete fuente valido o usa EN como fuente.',
+    'module' => 'Modulo',
+    'source' => 'Origen',
+    'current' => 'Actual',
+    'insert_translation' => 'Insertar traduccion',
+    'no_untranslated_labels' => 'No se detectaron etiquetas sin traducir para este par de idiomas.',
+    'upload_translated_json_file' => 'Subir archivo JSON traducido',
+    'or_paste_translated_json' => 'O pega el JSON traducido',
+    'message_to_reviewer' => 'Mensaje para el revisor',
+    'optional_note' => 'Nota opcional para el revisor administrador',
+    'submit_translation' => 'Enviar traduccion',
+  ),
+);

--- a/resources/lang/es/license-ar.php
+++ b/resources/lang/es/license-ar.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/es/license.php
+++ b/resources/lang/es/license.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/fr/admin_pages.php
+++ b/resources/lang/fr/admin_pages.php
@@ -1,6 +1,13 @@
 <?php
 
 return array(
+  'manual_assessment' => array(
+    'user_assessment_answers' => 'Reponses d\'evaluation utilisateur',
+    'marks_obtained' => 'Points obtenus',
+    'correct_answer' => 'Reponse correcte',
+    'user_answer' => 'Reponse utilisateur',
+    'not_available' => 'N/A',
+  ),
   'pathway_assignments' => array(
     'title' => 'Affectations de parcours d\'apprentissage',
     'make_new_assignment' => 'Créer une nouvelle affectation',

--- a/resources/lang/fr/course_pages.php
+++ b/resources/lang/fr/course_pages.php
@@ -41,6 +41,7 @@ return array(
     'open_quiz' => 'Ouvrir le quiz de la leçon',
     'course_title' => 'Cours :',
     'complete_pass_quiz_unlock_next' => 'Terminez et réussissez le quiz de la leçon pour déverrouiller la leçon suivante',
+    'assessment_failed_no_certificate' => 'Desole, vous n\'avez pas reussi l\'evaluation, le certificat ne peut donc pas etre delivre.',
   ),
   'certificate' => array(
     'course_name' => 'Nom du cours',

--- a/resources/lang/fr/labels.php
+++ b/resources/lang/fr/labels.php
@@ -22,7 +22,9 @@ return array(
     'toolbar_btn_groups' => 'Barre d\'outils avec des groupes de boutons',
     'sr_no' => 'Sr Non.',
     'read_more' => 'Lire la suite',
+    'view_all' => 'Voir tout',
     'no_data_available' => 'Pas de données disponibles',
+    'not_available' => 'N/D',
     'more' => 'Plus',
     'edit' => 'modifier',
     'delete_selected' => 'Supprimer sélectionnée',
@@ -445,6 +447,8 @@ return array(
         'mail_port' => 'PORT de courrier',
         'mail_username' => 'Mail Nom d\'utilisateur',
         'mail_username_note' => 'Ajoutez votre identifiant de messagerie que vous souhaitez configurer pour l\'envoi d\'emails',
+        'site_logo' => 'Logo du site',
+        'save_settings' => 'Enregistrer les paramètres',
         'note' => '<b> Remarque importante </b>: SI vous utilisez <b> GMAIL </b> pour la configuration du courrier, assurez-vous d\'avoir terminé le processus suivant avant la mise à jour:
   <ul>
 <li> Accédez à <a target="_blank" href="https://myaccount.google.com/security"> Mon compte </a> à partir de votre compte Google que vous souhaitez configurer et vous connecter </li>.
@@ -499,6 +503,8 @@ return array(
       'mail_port' => 'Port de messagerie',
       'mail_username' => 'Mail Nom d\'utilisateur',
       'management' => 'réglages généraux',
+      'site_logo' => 'Logo du site',
+      'save_settings' => 'Enregistrer les paramètres',
       'newsletter' => array(
         'api_key' => 'Clave API',
         'api_key_note' => 'Genere <b> clave de API </b> a partir de su <a target="_blank" href="https://mailchimp.com/"> <b> cuenta de Mailchimp </b> </a> y péguela arriba. caja de texto.',
@@ -590,6 +596,7 @@ return array(
       'language_settings' => array(
         'default_language' => 'Langage par défaut',
         'display_type' => 'Type d\'affichage',
+        'download_base_language_file' => 'Télécharger le fichier de langue de base',
         'left_to_right' => 'De gauche à droite',
         'right_to_left' => 'De droite à gauche',
         'title' => 'Paramètres de langue',
@@ -1314,6 +1321,14 @@ return array(
       'view_license' => 'Examiner la licence',
       'remove_license_title' => 'Supprimer la licence',
       'removing' => 'Suppression...',
+      'toggle_key_visibility' => 'Afficher/Masquer',
+      'standard' => 'Standard',
+      'syncing' => 'Synchronisation des utilisateurs...',
+      'sync_failed' => 'Échec de la synchronisation des utilisateurs',
+      'total' => 'Total',
+      'created' => 'Créés',
+      'attached' => 'Liés',
+      'failed' => 'Échoués',
     ),
     'smtp_settings' => array(
       'title' => 'Paramètres de messagerie (SMTP)',
@@ -1619,6 +1634,11 @@ return array(
       'title' => 'Accueil',
       'what_they_say_about_us' => 'Ce qu\'ils disent de nous',
       'no_data_available' => 'Pas de données disponibles',
+      'our_category' => 'Nos categories',
+      'category_1' => 'Categorie 1',
+      'category_2' => 'Categorie 2',
+      'category_3' => 'Categorie 3',
+      'category_4' => 'Categorie 4',
     ),
     'layouts' => array(
       'partials' => array(

--- a/resources/lang/fr/language_marketplace_pages.php
+++ b/resources/lang/fr/language_marketplace_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+return array(
+  'contribute' => array(
+    'page_title' => 'Contribution linguistique',
+    'title' => 'Contribution linguistique',
+    'subtitle' => 'Soumettez votre package JSON traduit pour :locale.',
+    'invitation_details' => 'Details de l\'invitation',
+    'contributor' => 'Contributeur',
+    'default_contributor' => 'Contributeur',
+    'email' => 'E-mail',
+    'status' => 'Statut',
+    'expires' => 'Expire le',
+    'no_expiry' => 'Pas d\'expiration',
+    'source_package' => 'Package source (:locale)',
+    'source_package_help' => 'Telechargez le package source actuel, traduisez-le, puis televersez le JSON traduit ci-dessous.',
+    'download_source_package' => 'Telecharger le package source',
+    'auto_detected_title' => 'Libelles non traduits detectes automatiquement',
+    'auto_detected_desc' => 'Nous avons detecte :count libelles non traduits en comparant la source :source avec la cible :target. Remplissez les champs ci-dessous puis envoyez.',
+    'no_source_modules' => 'Aucun module source n\'a ete trouve pour la langue source selectionnee. Publiez d\'abord un package source valide ou utilisez EN comme source.',
+    'module' => 'Module',
+    'source' => 'Source',
+    'current' => 'Actuel',
+    'insert_translation' => 'Inserer la traduction',
+    'no_untranslated_labels' => 'Aucun libelle non traduit detecte pour cette paire de langues.',
+    'upload_translated_json_file' => 'Televerser le fichier JSON traduit',
+    'or_paste_translated_json' => 'Ou coller le JSON traduit',
+    'message_to_reviewer' => 'Message au relecteur',
+    'optional_note' => 'Note facultative pour le relecteur administrateur',
+    'submit_translation' => 'Envoyer la traduction',
+  ),
+);

--- a/resources/lang/fr/license-ar.php
+++ b/resources/lang/fr/license-ar.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/fr/license.php
+++ b/resources/lang/fr/license.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/it/admin_pages.php
+++ b/resources/lang/it/admin_pages.php
@@ -1,6 +1,13 @@
 <?php
 
 return array(
+  'manual_assessment' => array(
+    'user_assessment_answers' => 'Risposte valutazione utente',
+    'marks_obtained' => 'Punteggio ottenuto',
+    'correct_answer' => 'Risposta corretta',
+    'user_answer' => 'Risposta utente',
+    'not_available' => 'N/A',
+  ),
   'pathway_assignments' => array(
     'title' => 'Assegnazioni percorsi di apprendimento',
     'make_new_assignment' => 'Crea nuova assegnazione',

--- a/resources/lang/it/course_pages.php
+++ b/resources/lang/it/course_pages.php
@@ -41,6 +41,7 @@ return array(
     'open_quiz' => 'Apri il quiz della lezione',
     'course_title' => 'Corso:',
     'complete_pass_quiz_unlock_next' => 'Completa e supera il quiz della lezione per sbloccare la lezione successiva',
+    'assessment_failed_no_certificate' => 'Spiacente, non hai superato la valutazione, quindi il certificato non puo essere emesso.',
   ),
   'certificate' => array(
     'course_name' => 'Nome del corso',

--- a/resources/lang/it/labels.php
+++ b/resources/lang/it/labels.php
@@ -425,6 +425,8 @@ return array(
         'mail_password_note' => 'Inserisci la password dell\'email che vuoi configurare per l\'invio dei messaggi',
         'mail_encryption' => 'Crittografia email',
         'mail_encryption_note' => 'Usa <b>tls</b> se il sito utilizza il protocollo <b>HTTP</b> e <b>ssl</b> se utilizza il protocollo <b>HTTPS</b>',
+        'site_logo' => 'Logo del sito',
+        'save_settings' => 'Salva impostazioni',
         'note' => '<b>Nota importante</b>: se stai usando <b>GMAIL</b> per la configurazione della posta, assicurati di aver completato il seguente processo prima di aggiornare:
       <ul>
       <li>Vai su <a target="_blank" href="https://myaccount.google.com/security">Il mio account</a> dall\'account Google che vuoi configurare ed effettua l\'accesso</li>
@@ -538,6 +540,8 @@ return array(
       'mail_password' => 'Password email',
       'enable_registration' => 'Abilita la registrazione',
       'change_email' => 'Cambia e-mail',
+      'site_logo' => 'Logo del sito',
+      'save_settings' => 'Salva impostazioni',
       'password_history' => 'Cronologia delle password',
       'password_expires_days' => 'La password scade giorni',
       'requires_approval' => 'Richiede l\'approvazione',
@@ -559,6 +563,7 @@ return array(
         'default_language' => 'Lingua predefinita',
         'right_to_left' => 'Da destra a sinistra',
         'left_to_right' => 'Da sinistra a destra',
+        'download_base_language_file' => 'Scarica il file di lingua base',
         'display_type' => 'Tipo di visualizzazione',
       ),
       'user_registration_settings' => array(
@@ -1270,6 +1275,14 @@ return array(
       'view_license' => 'Revisione licenza',
       'remove_license_title' => 'Rimuovi licenza',
       'removing' => 'Rimozione...',
+      'toggle_key_visibility' => 'Mostra/Nascondi',
+      'standard' => 'Standard',
+      'syncing' => 'Sincronizzazione utenti...',
+      'sync_failed' => 'Impossibile sincronizzare gli utenti',
+      'total' => 'Totale',
+      'created' => 'Creati',
+      'attached' => 'Associati',
+      'failed' => 'Non riusciti',
     ),
     'smtp_settings' => array(
       'title' => 'Impostazioni e-mail (SMTP)',
@@ -1333,6 +1346,7 @@ return array(
     'trash' => 'Cestino',
     'delete' => 'Elimina',
     'no_data_available' => 'Nessun dato disponibile',
+    'not_available' => 'N/D',
     'edit' => 'Modifica',
     'copyright' => 'Diritto d\'autore',
     'delete_selected' => 'Elimina selezionato',
@@ -1343,6 +1357,7 @@ return array(
     'toggle_navigation' => 'Attiva/disattiva navigazione',
     'sr_no' => 'Sig. No.',
     'read_more' => 'Leggi di più',
+    'view_all' => 'Visualizza tutto',
   ),
   'frontend' => array(
     'auth' => array(
@@ -1565,6 +1580,11 @@ return array(
       'all_teachers' => 'Tutti gli allenatori',
       'what_they_say_about_us' => 'Cosa dicono di noi',
       'no_data_available' => 'Nessun dato disponibile',
+      'our_category' => 'Le nostre categorie',
+      'category_1' => 'Categoria 1',
+      'category_2' => 'Categoria 2',
+      'category_3' => 'Categoria 3',
+      'category_4' => 'Categoria 4',
     ),
     'layouts' => array(
       'partials' => array(

--- a/resources/lang/it/language_marketplace_pages.php
+++ b/resources/lang/it/language_marketplace_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+return array(
+  'contribute' => array(
+    'page_title' => 'Contributo linguistico',
+    'title' => 'Contributo linguistico',
+    'subtitle' => 'Invia il tuo pacchetto JSON tradotto per :locale.',
+    'invitation_details' => 'Dettagli invito',
+    'contributor' => 'Contributore',
+    'default_contributor' => 'Contributore',
+    'email' => 'Email',
+    'status' => 'Stato',
+    'expires' => 'Scade',
+    'no_expiry' => 'Nessuna scadenza',
+    'source_package' => 'Pacchetto sorgente (:locale)',
+    'source_package_help' => 'Scarica il pacchetto sorgente corrente, traducilo, quindi carica il JSON tradotto qui sotto.',
+    'download_source_package' => 'Scarica pacchetto sorgente',
+    'auto_detected_title' => 'Etichette non tradotte rilevate automaticamente',
+    'auto_detected_desc' => 'Abbiamo rilevato :count etichette non tradotte confrontando la sorgente :source con la destinazione :target. Compila i campi qui sotto e invia.',
+    'no_source_modules' => 'Nessun modulo sorgente trovato per la lingua sorgente selezionata. Pubblica prima un pacchetto sorgente valido o usa EN come sorgente.',
+    'module' => 'Modulo',
+    'source' => 'Sorgente',
+    'current' => 'Corrente',
+    'insert_translation' => 'Inserisci traduzione',
+    'no_untranslated_labels' => 'Nessuna etichetta non tradotta rilevata per questa coppia di lingue.',
+    'upload_translated_json_file' => 'Carica file JSON tradotto',
+    'or_paste_translated_json' => 'Oppure incolla il JSON tradotto',
+    'message_to_reviewer' => 'Messaggio al revisore',
+    'optional_note' => 'Nota facoltativa per il revisore amministratore',
+    'submit_translation' => 'Invia traduzione',
+  ),
+);

--- a/resources/lang/it/license-ar.php
+++ b/resources/lang/it/license-ar.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/lang/it/license.php
+++ b/resources/lang/it/license.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/license-en.php';

--- a/resources/views/backend/announcement/create.blade.php
+++ b/resources/views/backend/announcement/create.blade.php
@@ -9,7 +9,7 @@
 <div class="pb-3 d-flex justify-content-between align-items">
     <h4 >Add Announcement</h4>
     <div >
-        <a href="{{ route('admin.announcement.index') }}" class="add-btn">View All</a>
+        <a href="{{ route('admin.announcement.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
 
     </div>
 </div>

--- a/resources/views/backend/announcement/edit.blade.php
+++ b/resources/views/backend/announcement/edit.blade.php
@@ -22,7 +22,7 @@
     <div class="pb-3 d-flex justify-content-between align-items-center">
         <h4>Update Announcement</h4>
         <div>
-            <a href="{{ route('admin.announcement.index') }}" class="add-btn">View All</a>
+            <a href="{{ route('admin.announcement.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
         </div>
     </div>
     <div class="card">

--- a/resources/views/backend/auth/user/index.blade.php
+++ b/resources/views/backend/auth/user/index.blade.php
@@ -262,7 +262,7 @@ $('#bulk-edit-form').on('submit', function (e) {
                     {data: "department", name: "department", orderable: false, searchable: false},
                     {data: "confirmed_label", name: "confirmed_label"},
                     {data: "roles", name: "roles.name", render: function(data, type, row) {
-                        if (!data || data.length === 0) return 'N/A';
+                        if (!data || data.length === 0) return "{{ __('labels.general.not_available') }}";
                         var mapped = data.map(function(r) {
                             if (r.id == 2) return 'Trainer';
                             if (r.id == 3) return 'Trainee';

--- a/resources/views/backend/auth/user/show/tabs/overview.blade.php
+++ b/resources/views/backend/auth/user/show/tabs/overview.blade.php
@@ -44,7 +44,7 @@
 
             <tr>
                 <th>@lang('labels.backend.access.users.tabs.content.overview.last_login_ip')</th>
-                <td>{{ $user->last_login_ip ?? 'N/A' }}</td>
+                <td>{{ $user->last_login_ip ?? __('labels.general.not_available') }}</td>
             </tr>
         </table>
     </div>

--- a/resources/views/backend/contacts/index.blade.php
+++ b/resources/views/backend/contacts/index.blade.php
@@ -11,7 +11,7 @@
     <h4 >Contact Request</h4>
     @can('blog_create')
         <div >
-            <a href="#" class="add-btn">View All</a>
+            <a href="#" class="add-btn">@lang('labels.general.view_all')</a>
         </div>
     @endcan
 </div>

--- a/resources/views/backend/dashboard.blade.php
+++ b/resources/views/backend/dashboard.blade.php
@@ -582,7 +582,7 @@ $show_dashboard_widget_tabs = auth()->user()->hasRole('administrator')
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">@lang('strings.backend.dashboard.Recent-Courses')</h5>
-                <a href="{{ route('admin.courses.index') }}" class="btn btn-sm btn-primary">View All</a>
+                <a href="{{ route('admin.courses.index') }}" class="btn btn-sm btn-primary">@lang('labels.general.view_all')</a>
             </div>
             <div class="card-body p-0">
                 @if($recent_courses->isNotEmpty())

--- a/resources/views/backend/employee/view_user_asssessement_answers.blade.php
+++ b/resources/views/backend/employee/view_user_asssessement_answers.blade.php
@@ -1,5 +1,5 @@
 @extends('backend.layouts.app')
-@section('title', 'User Assessement Answers' . ' | ' . app_name())
+@section('title', __('admin_pages.manual_assessment.user_assessment_answers') . ' | ' . app_name())
  <style>
     .card-header.bg-primary.text-white {
     color: #000 !important;
@@ -9,7 +9,7 @@
     <div class="container mt-5">
         <div class="row">
             <div class="col-md-8 offset-md-2 card mb-3 p-4">
-                <h4>Marks obtained: {{ $marks }}</h4>
+                <h4>{{ __('admin_pages.manual_assessment.marks_obtained') }}: {{ $marks }}</h4>
                 @php
                     $i = 1;
                 @endphp
@@ -33,17 +33,17 @@
                                 data-ans="{{ @$user_answer['is_correct'] }}">
                                 {{ $i++ }}. {!! $question->question_text !!}
                                 
-                                </br><span> Marks: {{ $question->marks }}</span>
+                                </br><span> {{ __('course_pages.admin_test_questions_index.marks') }}: {{ $question->marks }}</span>
                             </div>
                             <div class="card-body">
                                 {{-- <h5 class="card-title">What is the capital of France?</h5> --}}
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
-                                        <strong>Correct Answer:</br></strong> {!! $question->solution !!}
+                                        <strong>{{ __('admin_pages.manual_assessment.correct_answer') }}:</br></strong> {!! $question->solution !!}
                                     </li>
                                     <li class="list-group-item">
-                                        <strong>User's Answer:</br></strong>
-                                         {!! $user_answer['answer'] ?? 'N/A' !!}
+                                        <strong>{{ __('admin_pages.manual_assessment.user_answer') }}:</br></strong>
+                                         {!! $user_answer['answer'] ?? __('admin_pages.manual_assessment.not_available') !!}
                                         @if ($user_answer)
                                             <span @class([
                                                 'badge',

--- a/resources/views/backend/events/create.blade.php
+++ b/resources/views/backend/events/create.blade.php
@@ -9,7 +9,7 @@
 <div class="pb-3 d-flex justify-content-between align-items-center">
     <h4>Add Events</h4>
     <div >
-        <a href="{{ route('admin.events.index') }}" class="add-btn">View All</a>
+        <a href="{{ route('admin.events.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
 
     </div>
 </div>

--- a/resources/views/backend/events/edit.blade.php
+++ b/resources/views/backend/events/edit.blade.php
@@ -21,7 +21,7 @@
             <div class="card-header">
                 <h3 class="page-title d-inline">Update Events</h3>
                 <div class="float-right">
-                    <a href="{{ route('admin.events.index') }}" class="btn btn-success">View All</a>
+                    <a href="{{ route('admin.events.index') }}" class="btn btn-success">@lang('labels.general.view_all')</a>
                 </div>
             </div>
 

--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -23,7 +23,7 @@
         {{--@if(config('locale.status') && count(config('locale.languages')) > 1)--}}
             {{--<li class="nav-item px-3 dropdown">--}}
                 {{--<a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">--}}
-                    {{--<span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ strtoupper(app()->getLocale()) }})</span>--}}
+                    {{--<span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ strtoupper(app()->getLocale()) }})</span>--}}
                 {{--</a>--}}
 
                 {{--@include('includes.partials.lang')--}}
@@ -33,7 +33,7 @@
 
             <li class="nav-item px-3 dropdown">
                 <a class="nav-link dropdown-toggle nav-link " data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                 </a>
 
                 @include('includes.partials.lang')

--- a/resources/views/backend/lessons/index.blade.php
+++ b/resources/views/backend/lessons/index.blade.php
@@ -211,7 +211,7 @@
                     @endif
                     { data: 'DT_RowIndex', name: 'DT_RowIndex', searchable: false, orderable: false },
                     { data: 'title', name: 'title' },
-                    { data: 'course', name: 'course.title', defaultContent: 'N/A' },
+                    { data: 'course', name: 'course.title', defaultContent: "{{ __('labels.general.not_available') }}" },
                     { data: 'lesson_start_date', name: 'lesson_start_date' },
                     { data: 'duration', name: 'duration' },
                     { data: 'attendance', name: 'attendance' },

--- a/resources/views/backend/library/create.blade.php
+++ b/resources/views/backend/library/create.blade.php
@@ -9,7 +9,7 @@
 <div class="pb-3 d-flex justify-content-between align-items-center">
     <h4>Add Library</h4>
     <div>
-        <a href="{{ route('admin.events.index') }}" class="add-btn">View All</a>
+        <a href="{{ route('admin.events.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
 
     </div>
 </div>

--- a/resources/views/backend/library/edit.blade.php
+++ b/resources/views/backend/library/edit.blade.php
@@ -18,7 +18,7 @@
     <div class="pb-3 d-flex justify-content-between align-items-center">
         <h4>Update Library</h4>
         <div >
-            <a href="{{ route('admin.events.index') }}" class="add-btn">View All</a>
+            <a href="{{ route('admin.events.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
         </div>
     </div>
     <div class="card">

--- a/resources/views/backend/manual-assessment/user-assessment-answers.blade.php
+++ b/resources/views/backend/manual-assessment/user-assessment-answers.blade.php
@@ -1,11 +1,11 @@
 @extends('backend.layouts.app')
-@section('title', 'User Assessement Answers' . ' | ' . app_name())
+@section('title', __('admin_pages.manual_assessment.user_assessment_answers') . ' | ' . app_name())
 
 @section('content')
     <div class="container mt-5">
         <div class="row">
             <div class="col-md-8 offset-md-2 card mb-3 p-4">
-                <h4>Marks obtained: {{ $marks }}</h4>
+                <h4>{{ __('admin_pages.manual_assessment.marks_obtained') }}: {{ $marks }}</h4>
                 @php
                     $i = 1;
                 @endphp
@@ -22,16 +22,16 @@
                         <div class="card-header bg-primary text-white" data-id="{{ $question->id }}"
                             data-ans="{{ @$user_answer['is_correct'] }}">
                             {{ $i++ }}. {!! $question->question_text !!}
-                            </br><span> Marks: {{ $question->marks }}</span>
+                            </br><span> {{ __('course_pages.admin_test_questions_index.marks') }}: {{ $question->marks }}</span>
                         </div>
                         <div class="card-body">
                             {{-- <h5 class="card-title">What is the capital of France?</h5> --}}
                             <ul class="list-group list-group-flush">
                                 <li class="list-group-item">
-                                    <strong>Correct Answer:</br></strong> {!! $question->test_solutions !!}
+                                    <strong>{{ __('admin_pages.manual_assessment.correct_answer') }}:</br></strong> {!! $question->test_solutions !!}
                                 </li>
                                 <li class="list-group-item">
-                                    <strong>User's Answer:</br></strong> {!! $user_answer['answer'] ?? 'N/A' !!}
+                                    <strong>{{ __('admin_pages.manual_assessment.user_answer') }}:</br></strong> {!! $user_answer['answer'] ?? __('admin_pages.manual_assessment.not_available') !!}
                                     @if ($user_answer)
                                         <span @class([
                                             'badge',

--- a/resources/views/backend/news/create.blade.php
+++ b/resources/views/backend/news/create.blade.php
@@ -9,7 +9,7 @@
 <div class="pb-3 d-flex justify-content-between align-items-center">
     <h4>Add News</h4>
     <div >
-        <a href="{{ route('admin.news.index') }}" class="add-btn">View All</a>
+        <a href="{{ route('admin.news.index') }}" class="add-btn">@lang('labels.general.view_all')</a>
 
     </div>
 </div>

--- a/resources/views/backend/news/edit.blade.php
+++ b/resources/views/backend/news/edit.blade.php
@@ -21,7 +21,7 @@
             <div class="card-header">
                 <h3 class="page-title d-inline">Update News</h3>
                 <div class="float-right">
-                    <a href="{{ route('admin.news.index') }}" class="btn btn-success">View All</a>
+                    <a href="{{ route('admin.news.index') }}" class="btn btn-success">@lang('labels.general.view_all')</a>
                 </div>
             </div>
             <div class="card-body">

--- a/resources/views/backend/settings/external-apps/configure.blade.php
+++ b/resources/views/backend/settings/external-apps/configure.blade.php
@@ -42,7 +42,7 @@
                         <h5><i class="fas fa-info-circle mr-2"></i>{{ __('external_apps.external_apps.module_info') }}</h5>
                         <table class="table table-sm mb-0">
                             <tr><td><strong>{{ __('external_apps.external_apps.name') }}:</strong></td><td>{{ $app->name }}</td></tr>
-                            <tr><td><strong>{{ __('external_apps.external_apps.version') }}:</strong></td><td>{{ $app->version ?? 'N/A' }}</td></tr>
+                            <tr><td><strong>{{ __('external_apps.external_apps.version') }}:</strong></td><td>{{ $app->version ?? __('labels.general.not_available') }}</td></tr>
                             <tr>
                                 <td><strong>{{ __('external_apps.external_apps.status') }}:</strong></td>
                                 <td><span class="badge badge-{{ $app->getStatusBadge() }}">{{ ucfirst($app->status) }}</span></td>

--- a/resources/views/backend/settings/external-apps/show.blade.php
+++ b/resources/views/backend/settings/external-apps/show.blade.php
@@ -47,7 +47,7 @@
                                 <tr>
                                     <td><strong>{{ __('external_apps.external_apps.installation_path') }}:</strong></td>
                                     <td>
-                                        <code class="text-muted" style="font-size: 0.85em;">{{ $app->installed_path ?? 'N/A' }}</code>
+                                        <code class="text-muted" style="font-size: 0.85em;">{{ $app->installed_path ?? __('labels.general.not_available') }}</code>
                                     </td>
                                 </tr>
                                 <tr>

--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -191,10 +191,10 @@
 
                             <!-- Site Logo -->
                             <div class="form-group row">
-                                <label for="site_logo" class="col-md-2 form-control-label">Logo</label>
+                                <label for="site_logo" class="col-md-2 form-control-label">{{ __('labels.backend.general_settings.site_logo') }}</label>
                                 <div class="col-md-10">
                                     <label for="site_logo" class="control-label">
-                                        {{ 'Site Logo ' . trans('labels.backend.pages.max_file_size') }}
+                                        {{ __('labels.backend.general_settings.site_logo') . ' ' . trans('labels.backend.pages.max_file_size') }}
                                     </label>
                                     <input type="file" name="site_logo" class="form-control">
                                     <input type="hidden" name="site_logo_max_size" value="8">
@@ -246,7 +246,7 @@
 
                             <div class="text-end mt-3">
     <button type="submit" class="btn btn-primary">
-        Save Settings
+        {{ __('labels.backend.general_settings.save_settings') }}
     </button>
 </div>
 

--- a/resources/views/backend/settings/license.blade.php
+++ b/resources/views/backend/settings/license.blade.php
@@ -70,7 +70,7 @@
                                         <td class="text-muted" width="40%">{{ __('labels.backend.license_settings.license_key') }}</td>
                                         <td>
                                             <code id="maskedKey">{{ $license->masked_key }}</code>
-                                            <button type="button" class="btn btn-link btn-sm p-0 ml-2" id="toggleKeyVisibility" title="Show/Hide">
+                                            <button type="button" class="btn btn-link btn-sm p-0 ml-2" id="toggleKeyVisibility" title="{{ __('labels.backend.license_settings.toggle_key_visibility') }}">
                                                 <i class="fas fa-eye" id="keyVisibilityIcon"></i>
                                             </button>
                                             <span id="fullKey" class="d-none">{{ $license->license_key }}</span>
@@ -86,11 +86,11 @@
                                     </tr>
                                     <tr>
                                         <td class="text-muted">{{ __('labels.backend.license_settings.license_type') }}</td>
-                                        <td>{{ ucfirst($license->license_type ?? 'Standard') }}</td>
+                                        <td>{{ ucfirst($license->license_type ?? __('labels.backend.license_settings.standard')) }}</td>
                                     </tr>
                                     <tr>
                                         <td class="text-muted">{{ __('labels.backend.license_settings.licensed_to') }}</td>
-                                        <td>{{ $license->licensed_to ?? '-' }}</td>
+                                        <td>{{ $license->licensed_to ?? __('labels.general.not_available') }}</td>
                                     </tr>
                                     @if($license->licensee_email)
                                     <tr>
@@ -152,14 +152,14 @@
                                                     <span class="badge badge-secondary ml-2">{{ __('labels.backend.license_settings.expired') }}</span>
                                                 @endif
                                             @else
-                                                -
+                                                {{ __('labels.general.not_available') }}
                                             @endif
                                         </td>
                                     </tr>
                                     <tr>
                                         <td class="text-muted">{{ __('labels.backend.license_settings.last_validated') }}</td>
                                         <td>
-                                            {{ $license->last_validated_at ? $license->last_validated_at->diffForHumans() : '-' }}
+                                            {{ $license->last_validated_at ? $license->last_validated_at->diffForHumans() : __('labels.general.not_available') }}
                                         </td>
                                     </tr>
                                 </table>
@@ -330,7 +330,7 @@ $(document).ready(function() {
     $('#btnSyncUsers').on('click', function() {
         var btn = $(this);
         var btnHtml = btn.html();
-        btn.prop('disabled', true).html('<i class="fas fa-spinner fa-spin mr-1"></i> Syncing...');
+        btn.prop('disabled', true).html('<i class="fas fa-spinner fa-spin mr-1"></i> {{ __("labels.backend.license_settings.syncing") }}');
 
         $.ajax({
             url: '{{ route("admin.license.sync-users") }}',
@@ -338,10 +338,10 @@ $(document).ready(function() {
             data: { _token: '{{ csrf_token() }}' },
             dataType: 'json',
             success: function(response) {
-                var details = 'Total: ' + (response.total || 0) +
-                    ', Created: ' + (response.created || 0) +
-                    ', Attached: ' + (response.attached || 0) +
-                    ', Failed: ' + (response.failed || 0);
+                var details = '{{ __("labels.backend.license_settings.total") }}: ' + (response.total || 0) +
+                    ', {{ __("labels.backend.license_settings.created") }}: ' + (response.created || 0) +
+                    ', {{ __("labels.backend.license_settings.attached") }}: ' + (response.attached || 0) +
+                    ', {{ __("labels.backend.license_settings.failed") }}: ' + (response.failed || 0);
                 showAlert('success', response.message + ' (' + details + ')');
                 btn.prop('disabled', false).html(btnHtml);
                 setTimeout(function() {
@@ -349,15 +349,15 @@ $(document).ready(function() {
                 }, 2000);
             },
             error: function(xhr) {
-                var msg = 'Failed to sync users';
+                var msg = '{{ __("labels.backend.license_settings.sync_failed") }}';
                 var details = '';
                 if (xhr.responseJSON) {
                     if (xhr.responseJSON.message) {
                         msg = xhr.responseJSON.message;
                     }
-                    details = ' (Total: ' + (xhr.responseJSON.total || 0) +
-                        ', Created: ' + (xhr.responseJSON.created || 0) +
-                        ', Failed: ' + (xhr.responseJSON.failed || 0) + ')';
+                    details = ' ({{ __("labels.backend.license_settings.total") }}: ' + (xhr.responseJSON.total || 0) +
+                        ', {{ __("labels.backend.license_settings.created") }}: ' + (xhr.responseJSON.created || 0) +
+                        ', {{ __("labels.backend.license_settings.failed") }}: ' + (xhr.responseJSON.failed || 0) + ')';
                     if (xhr.responseJSON.errors && xhr.responseJSON.errors.length > 0) {
                         details += '<br><small>' + xhr.responseJSON.errors.join('<br>') + '</small>';
                     }

--- a/resources/views/backend/settings/notification_audit_log.blade.php
+++ b/resources/views/backend/settings/notification_audit_log.blade.php
@@ -38,7 +38,7 @@
                     @forelse($logs as $log)
                     <tr>
                         <td>{{ $log->created_at->format('Y-m-d H:i:s') }}</td>
-                        <td>{{ $log->user->full_name ?? 'N/A' }}</td>
+                        <td>{{ $log->user->full_name ?? __('labels.general.not_available') }}</td>
                         <td>
                             <span class="badge badge-{{ strpos($log->action, 'enabled') !== false ? 'success' : 'warning' }}">
                                 {{ $log->action_label }}

--- a/resources/views/backend/student-feedback/create.blade.php
+++ b/resources/views/backend/student-feedback/create.blade.php
@@ -11,7 +11,7 @@
             <h3 class="page-title d-inline">Add Feedback</h3>
             <div class="float-right">
                 <a href="{{ route('admin.events.index') }}"
-                   class="btn btn-success">View All</a>
+                   class="btn btn-success">@lang('labels.general.view_all')</a>
 
             </div>
         </div>

--- a/resources/views/backend/student-feedback/edit.blade.php
+++ b/resources/views/backend/student-feedback/edit.blade.php
@@ -21,7 +21,7 @@
             <h3 class="page-title d-inline">Update Feedback</h3>
             <div class="float-right">
                 <a href="{{ route('admin.events.index') }}"
-                   class="btn btn-success">View All</a>
+                   class="btn btn-success">@lang('labels.general.view_all')</a>
             </div>
         </div>
         <div class="card-body">

--- a/resources/views/backend/tests/show.blade.php
+++ b/resources/views/backend/tests/show.blade.php
@@ -14,7 +14,7 @@
                     <table class="table table-bordered table-striped">
                         <tr>
                             <th>@lang('labels.backend.tests.fields.course')</th>
-                            <td>{{ ($test->course) ? $test->course->title : 'N/A' }}</td>
+                            <td>{{ ($test->course) ? $test->course->title : __('labels.general.not_available') }}</td>
                         </tr>
 
                         <tr>

--- a/resources/views/frontend-rtl/cart/checkout.blade.php
+++ b/resources/views/frontend-rtl/cart/checkout.blade.php
@@ -123,7 +123,7 @@
                                                         <span>{{class_basename($course)}}</span>
                                                     </div>
                                                 </td>
-                                                <td>{{($course->start_date != "") ? $course->start_date : 'N/A'}}</td>
+                                                <td>{{($course->start_date != "") ? $course->start_date : __('labels.general.not_available')}}</td>
                                             </tr>
                                         @endforeach
                                     @else

--- a/resources/views/frontend-rtl/courses/course.blade.php
+++ b/resources/views/frontend-rtl/courses/course.blade.php
@@ -791,8 +791,8 @@ data-plyr-embed-id="{{$lesson1->mediavideo->file_name}}"></div>
                             </div>
 
                             <div class="col-sm-6 col-12"><div class="form-group">
-                            <label for="exampleInputEmail1">Classification number</label>
-                            <input type="text"  class="form-control" name="classification_no" id="classification_no" placeholder="Classification number" value="">
+                            <label for="exampleInputEmail1">{{ __('course_pages.registration.classification') }}</label>
+                            <input type="text"  class="form-control" name="classification_no" id="classification_no" placeholder="{{ __('course_pages.registration.placeholder_classification') }}" value="">
                         </div></div>
                             <div class="col-sm-6 col-12">
                             <div class="form-group">

--- a/resources/views/frontend-rtl/courses/lesson-quiz.blade.php
+++ b/resources/views/frontend-rtl/courses/lesson-quiz.blade.php
@@ -21,7 +21,7 @@
             <div class="page-breadcrumb-content text-center">
                 <div class="page-breadcrumb-title">
                     <h2 class="breadcrumb-head black bold">
-                        <span>{{ $lesson->course->title }}</span><br> {{ $lesson->title }} - Quiz
+                        <span>{{ $lesson->course->title }}</span><br> {{ $lesson->title }} - {{ __('lesson_quiz_pages.quiz') }}
                     </h2>
                 </div>
             </div>
@@ -45,11 +45,11 @@
                         <div class="course-single-text">
                             <div class="course-title mt10 headline relative-position">
                                 <h3>
-                                    <b><i class="fa fa-question-circle mr-1"></i> Lesson Quiz: {{ $lesson->title }}</b>
+                                    <b><i class="fa fa-question-circle mr-1"></i> {{ __('lesson_quiz_pages.lesson_quiz') }}: {{ $lesson->title }}</b>
                                 </h3>
                             </div>
                             <div class="course-details-content">
-                                <p>Complete this quiz to unlock the next lesson.</p>
+                                <p>{{ __('lesson_quiz_pages.complete_quiz_unlock_next') }}</p>
                             </div>
                         </div>
 
@@ -57,10 +57,10 @@
 
                         @if($lesson_quiz_result)
                             <div class="alert alert-info">
-                                Your score: {{ number_format($lesson_quiz_percentage, 0) }}%
+                                {{ __('lesson_quiz_pages.your_score') }} {{ number_format($lesson_quiz_percentage, 0) }}%
                                 ({{ $lesson_quiz_result->test_result }} / {{ $lesson_quiz_questions->count() }})
                                 <br>
-                                Result:
+                                {{ __('lesson_quiz_pages.result') }}
                                 <strong class="{{ $lesson_quiz_pass === 'Pass' ? 'text-success' : 'text-danger' }}">
                                     {{ $lesson_quiz_pass }}
                                 </strong>
@@ -68,7 +68,7 @@
 
                             @if($next_lesson && !$can_access_next_lesson)
                                 <div class="alert alert-warning">
-                                    You must pass this quiz to continue to the next lesson.
+                                    {{ __('lesson_quiz_pages.pass_quiz_to_continue') }}
                                 </div>
                             @endif
 
@@ -121,7 +121,7 @@
                             <p>
                                 <a class="btn btn-block gradient-bg font-weight-bold text-white"
                                    href="{{ route('lessons.show', [$course_id, $lesson->slug]) }}">
-                                    <i class="fa fa-angle-double-left"></i> Back To Lesson
+                                    <i class="fa fa-angle-double-left"></i> {{ __('lesson_quiz_pages.back_to_lesson') }}
                                 </a>
                             </p>
 
@@ -130,13 +130,13 @@
                                     <p>
                                         <a class="btn btn-block gradient-bg font-weight-bold text-white"
                                            href="{{ route('lessons.show', [$next_lesson->course_id, $next_lesson->model->slug]) }}">
-                                            Next Lesson <i class="fa fa-angle-double-right"></i>
+                                            {{ __('lesson_quiz_pages.next_lesson') }} <i class="fa fa-angle-double-right"></i>
                                         </a>
                                     </p>
                                 @else
                                     <p>
                                         <a class="btn btn-block bg-danger font-weight-bold text-white" href="javascript:void(0)">
-                                            Pass this quiz to unlock the next lesson
+                                            {{ __('lesson_quiz_pages.pass_quiz_to_unlock_next') }}
                                         </a>
                                     </p>
                                 @endif

--- a/resources/views/frontend-rtl/courses/lesson.blade.php
+++ b/resources/views/frontend-rtl/courses/lesson.blade.php
@@ -535,16 +535,16 @@
                                     @if(!empty($requires_lesson_quiz_pass_for_next) && empty($can_access_next_lesson))
                                         <a class="btn btn-block bg-danger font-weight-bold text-white"
                                            href="javascript:void(0)">
-                                            Complete and pass the lesson quiz to unlock the next lesson
+                                            {{ __('course_pages.course_detail.complete_pass_quiz_unlock_next') }}
                                         </a>
                                         @if($lesson->isCompleted() && !empty($lesson_quiz_url))
                                             <a class="btn btn-block btn-info font-weight-bold text-white mt-2"
                                                href="{{ $lesson_quiz_url }}">
-                                                Open Lesson Quiz
+                                                {{ __('course_pages.course_detail.open_quiz') }}
                                             </a>
                                         @elseif(!$lesson->isCompleted())
                                             <a class="btn btn-block btn-warning font-weight-bold text-white mt-2" href="javascript:void(0)">
-                                                Complete this lesson first to unlock its quiz section
+                                                {{ __('course_pages.course_detail.unlock_lesson') }}
                                             </a>
                                         @endif
                                     @else
@@ -562,7 +562,7 @@
                                 @elseif($lesson->isCompleted() && !empty($lesson_quiz_url))
                                     <a class="btn btn-block btn-info font-weight-bold text-white"
                                        href="{{ $lesson_quiz_url }}">
-                                        Open Lesson Quiz
+                                        {{ __('course_pages.course_detail.open_quiz') }}
                                     </a>
                                 @endif
 
@@ -574,13 +574,13 @@
                             @endif
 
                             @if ($nextTasks['reattempt_assesment'])
-                                <p class="text text-danger">@lang("Sorry! you didn't qualify the assignment. So certificate could not be issued.")</p>
+                                <p class="text text-danger">{{ __('course_pages.course_detail.assessment_failed_no_certificate') }}</p>
                                 <a class="btn btn-success btn-block text-white mb-3 text-uppercase font-weight-bold"
                                     target="_blank" href="{{ htmlspecialchars_decode($assessment_link) }}">@lang('labels.frontend.course.re_attempt_assesment')</a>
                             @endif
 
                             @if($nextTasks['failed_in_assesment_all_attempts'])
-                                <p class="text text-danger">@lang("Sorry! you didn't qualify the assignment. So certificate could not be issued.")</p>
+                                <p class="text text-danger">{{ __('course_pages.course_detail.assessment_failed_no_certificate') }}</p>
                                 <a class="btn btn-success btn-block text-white mb-3 text-uppercase font-weight-bold"
                                     href="javascript:void(0)">@lang('labels.frontend.course.assesment_completed')</a>
                             @endif
@@ -852,8 +852,7 @@
                         alert(counter)
                         // Display a next button box
                         $('#nextButton').html(
-                            "<a class='btn btn-block bg-danger font-weight-bold text-white' href='#'>@lang('labels.frontend.course.next') (in " +
-                            counter + " seconds)</a>")
+                            "<a class='btn btn-block bg-danger font-weight-bold text-white' href='#'>@lang('labels.frontend.course.next') ({{ __('lesson.time_left_next_lesson', ['attribute' => '" + counter + "']) }})</a>")
                         Cookies.set("duration_" + "{{ auth()->user()->id }}" + "_" + "{{ $lesson->id }}" +
                             "_" + "{{ $lesson->course->id }}", counter);
 
@@ -871,8 +870,8 @@
                             @if ($next_lesson && empty($nextTasks['open_assesment']) && empty($nextTasks['reattempt_assesment']))
                                 @if(!empty($requires_lesson_quiz_pass_for_next) && empty($can_access_next_lesson))
                                     $('#nextButton').html(
-                                        "<a class='btn btn-block bg-danger font-weight-bold text-white' href='javascript:void(0)'>Complete and pass the lesson quiz to unlock the next lesson</a>" +
-                                        "@if(!empty($lesson_quiz_url))<a class='btn btn-block btn-info font-weight-bold text-white mt-2' href='{{ $lesson_quiz_url }}'>Open Lesson Quiz</a>@endif"
+                                        "<a class='btn btn-block bg-danger font-weight-bold text-white' href='javascript:void(0)'>{{ __('course_pages.course_detail.complete_pass_quiz_unlock_next') }}</a>" +
+                                        "@if(!empty($lesson_quiz_url))<a class='btn btn-block btn-info font-weight-bold text-white mt-2' href='{{ $lesson_quiz_url }}'>{{ __('course_pages.course_detail.open_quiz') }}</a>@endif"
                                     );
                                 @else
                                     $('#nextButton').html(

--- a/resources/views/frontend-rtl/index-1.blade.php
+++ b/resources/views/frontend-rtl/index-1.blade.php
@@ -51,12 +51,12 @@
     @include('frontend.layouts.partials.slider')
  <div class="container">
         <div class="outcategory caterow">
-            <div> <h4>Our Category</h4> </div>
+            <div> <h4>@lang('labels.frontend.home.our_category')</h4> </div>
             <ul>
-                <li><img src="{{ asset('assets/img/icon1.png') }}" alt="Category">   Category 1 </li>
-                 <li><img src="{{ asset('assets/img/icon2.png') }}" alt="Category"> Category 2 </li>
-                  <li><img src="{{ asset('assets/img/icon3.png') }}" alt="Category"> Category 3 </li>
-                   <li><img src="{{ asset('assets/img/icon4.png') }}" alt="Category"> Category </li>
+                <li><img src="{{ asset('assets/img/icon1.png') }}" alt="@lang('labels.frontend.home.category_1')">   @lang('labels.frontend.home.category_1') </li>
+                 <li><img src="{{ asset('assets/img/icon2.png') }}" alt="@lang('labels.frontend.home.category_2')"> @lang('labels.frontend.home.category_2') </li>
+                  <li><img src="{{ asset('assets/img/icon3.png') }}" alt="@lang('labels.frontend.home.category_3')"> @lang('labels.frontend.home.category_3') </li>
+                   <li><img src="{{ asset('assets/img/icon4.png') }}" alt="@lang('labels.frontend.home.category_4')"> @lang('labels.frontend.home.category_4') </li>
             </ul>
         </div>
     </div>
@@ -167,7 +167,7 @@
                     <div class="w-100 d-flex justify-content-between section-title-3">
                         {{-- <h2>@lang('Latest') <strong>@lang('Events')</strong></h2> --}}
                         <h2><strong>@lang('Latest Events')</strong></h2>
-                        <a href="" class="btn border btn-all rounded-pill">@lang('View All')</a>
+                        <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                     </div>
                     @if (count($events) > 0)
                         @foreach ($events as $evet)
@@ -208,7 +208,7 @@
                     <div class="w-100 d-flex justify-content-between section-title-3">
                         {{-- <h2>@lang('Latest') <strong>@lang('Libraries')</strong></h2> --}}
                         <h2><strong>@lang('Latest Libraries')</strong></h2>
-                        <a href="" class="btn border btn-all rounded-pill">@lang('View All')</a>
+                        <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                     </div>
                     <div class="libraries">
                         <div class="row">
@@ -270,7 +270,7 @@
          <div class="container">
                 <div class="w-100 d-flex justify-content-between section-title-3">
                     <h2>Student's  <strong>Feedback</strong></h2>
-                    <a href="" class="btn border btn-all rounded-pill">View All</a>
+                    <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                 </div>
             <div class="row">
                 <div class="col-md-4">

--- a/resources/views/frontend-rtl/layouts/app1.blade.php
+++ b/resources/views/frontend-rtl/layouts/app1.blade.php
@@ -149,7 +149,7 @@
                 <div class="nav-item px-3 dropdown">
                     <a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="#" role="button"
                         aria-haspopup="true" aria-expanded="false">
-                        <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                        <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                     </a>
 
                     @include('includes.partials.lang')
@@ -263,7 +263,7 @@
                     @if (count($locales) > 1)
                         <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -271,7 +271,7 @@
 @if ($lang != app()->getLocale())
 <li>
                                                                                      <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
 @endif
 @endforeach

--- a/resources/views/frontend-rtl/layouts/app2.blade.php
+++ b/resources/views/frontend-rtl/layouts/app2.blade.php
@@ -188,7 +188,7 @@
                                         @if(count($locales) > 1)
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -264,7 +264,7 @@
                                         @if(count($locales) > 1)
                                             <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="">
@@ -272,7 +272,7 @@
                                                         @if($lang != app()->getLocale())
                                                             <li>
                                                                 <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
                                                         @endif
                                                     @endforeach

--- a/resources/views/frontend-rtl/layouts/app3.blade.php
+++ b/resources/views/frontend-rtl/layouts/app3.blade.php
@@ -118,7 +118,7 @@
 
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu bg-white" style="z-index: 1">
@@ -291,7 +291,7 @@
                                         @if(count($locales) > 1)
                                             <!--li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="">
@@ -299,7 +299,7 @@
                                                         @if($lang != app()->getLocale())
                                                             <li>
                                                                 <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                                                   class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                                                   class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                                             </li>
                                                         @endif
                                                     @endforeach

--- a/resources/views/frontend-rtl/layouts/app4.blade.php
+++ b/resources/views/frontend-rtl/layouts/app4.blade.php
@@ -224,7 +224,7 @@
                                     @if(count($locales) > 1)
                                         <li class="menu-item-has-children ul-li-block">
                                             <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                             </a>
                                             <ul class="sub-menu">
@@ -346,7 +346,7 @@
                                 <button class="menu-link" data-toggle="collapse"
                                         data-target="#collapseLang"
                                         aria-expanded="true" aria-controls="collapseLang">
-                                    {{ trans('menus.language-picker.language', [], 'en') }}
+                                    {{ trans('menus.language_picker.language', [], 'en') }}
                                     ({{ strtoupper(app()->getLocale()) }})
                                 </button>
                             </div>
@@ -357,7 +357,7 @@
                                     @if($lang != app()->getLocale())
                                         <li>
                                             <a href="{{ route('locale.swap', ['lang' => $lang]) }}"
-                                               class=""> {{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a>
+                                               class=""> {{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a>
                                         </li>
                                     @endif
                                 @endforeach

--- a/resources/views/frontend-rtl/search-result/blogs.blade.php
+++ b/resources/views/frontend-rtl/search-result/blogs.blade.php
@@ -92,7 +92,7 @@
                                                                 </div>
 
                                                                 <div class="view-all-btn bold-font">
-                                                                    <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">Read More <i
+                                                                    <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">@lang('labels.general.read_more') <i
                                                                                 class="fas fa-chevron-circle-right"></i></a>
                                                                 </div>
                                                             </div>
@@ -131,7 +131,7 @@
                                                                     </div>
 
                                                                     <div class="view-all-btn bold-font">
-                                                                        <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">Read More <i
+                                                                        <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">@lang('labels.general.read_more') <i
                                                                                     class="fas fa-chevron-circle-right"></i></a>
                                                                     </div>
                                                                 </div>

--- a/resources/views/frontend/cart/checkout.blade.php
+++ b/resources/views/frontend/cart/checkout.blade.php
@@ -128,7 +128,7 @@
                                                         <span>{{class_basename($course)}}</span>
                                                     </div>
                                                 </td>
-                                                <td>{{($course->start_date != "") ? $course->start_date : 'N/A'}}</td>
+                                                <td>{{($course->start_date != "") ? $course->start_date : __('labels.general.not_available')}}</td>
                                             </tr>
                                         @endforeach
                                     @else

--- a/resources/views/frontend/index-1.blade.php
+++ b/resources/views/frontend/index-1.blade.php
@@ -52,12 +52,12 @@
 
     <div class="container caterow">
         <div class="outcategory">
-            <div> <h4>Our Category</h4> </div>
+            <div> <h4>@lang('labels.frontend.home.our_category')</h4> </div>
             <ul>
-                <li><img src="{{ asset('assets/img/icon2.png') }}" alt="Medical & Technical">  Category 1 </li>
-                 <li><img src="{{ asset('assets/img/icon1.png') }}" alt="Quality & Safety"> Category 2</li>
-                  <li><img src="{{ asset('assets/img/icon4.png') }}" alt="Administrative Skills"> Category 3 </li>
-                   <li><img src="{{ asset('assets/img/icon3.png') }}" alt="Soft Skills"> Category 4 </li>
+                <li><img src="{{ asset('assets/img/icon2.png') }}" alt="@lang('labels.frontend.home.category_1')">  @lang('labels.frontend.home.category_1') </li>
+                 <li><img src="{{ asset('assets/img/icon1.png') }}" alt="@lang('labels.frontend.home.category_2')"> @lang('labels.frontend.home.category_2')</li>
+                  <li><img src="{{ asset('assets/img/icon4.png') }}" alt="@lang('labels.frontend.home.category_3')"> @lang('labels.frontend.home.category_3') </li>
+                   <li><img src="{{ asset('assets/img/icon3.png') }}" alt="@lang('labels.frontend.home.category_4')"> @lang('labels.frontend.home.category_4') </li>
             </ul>
         </div>
     </div>
@@ -197,7 +197,7 @@
                     <div class="w-100 d-flex justify-content-between items-center section-title-3">
                         {{-- <h2>@lang('Latest') <strong>@lang('Events')</strong></h2> --}}
                         <h2>@lang('Latest') <strong>@lang('Events')</strong></h2>
-                        <a href="" class="btn border btn-all rounded-pill">@lang('View All')</a>
+                        <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                     </div>
                     @if (count($events) > 0)
                         @foreach ($events as $evet)
@@ -238,7 +238,7 @@
                     <div class="w-100 d-flex justify-content-between items-center section-title-3">
                         {{-- <h2>@lang('Latest') <strong>@lang('Libraries')</strong></h2> --}}
                         <h2>@lang('Latest') <strong>@lang('Libraries')</strong></h2>
-                        <a href="" class="btn border btn-all rounded-pill">@lang('View All')</a>
+                        <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                     </div>
                     <div class="libraries">
                         <div class="row">
@@ -300,7 +300,7 @@
          <div class="container">
                 <div class="w-100 d-flex justify-content-between section-title-3">
                     <h2>Student's  <strong>Feedback</strong></h2>
-                    <a href="" class="btn border btn-all rounded-pill">View All</a>
+                    <a href="" class="btn border btn-all rounded-pill">@lang('labels.general.view_all')</a>
                 </div>
             <div class="row">
                 <div class="col-md-4">

--- a/resources/views/frontend/layouts/app1.blade.php
+++ b/resources/views/frontend/layouts/app1.blade.php
@@ -150,7 +150,7 @@
                 <div class="nav-item px-3 dropdown">
                     <a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="{{ url('/') }}" role="button"
                         aria-haspopup="true" aria-expanded="false">
-                        <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
+                        <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }} ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                     </a>
 
                     @include('includes.partials.lang')

--- a/resources/views/frontend/layouts/app2.blade.php
+++ b/resources/views/frontend/layouts/app2.blade.php
@@ -180,7 +180,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="sub-menu">
@@ -261,7 +261,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="">

--- a/resources/views/frontend/layouts/app3.blade.php
+++ b/resources/views/frontend/layouts/app3.blade.php
@@ -114,7 +114,7 @@
 
                                         <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu bg-white" style="z-index: 1">
@@ -281,7 +281,7 @@
                                             @if(count($locales) > 1)
                                                 <li class="menu-item-has-children ul-li-block">
                                                     <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                     </a>
                                                     <ul class="">

--- a/resources/views/frontend/layouts/app4.blade.php
+++ b/resources/views/frontend/layouts/app4.blade.php
@@ -218,7 +218,7 @@
                                         @if(count($locales) > 1)
                                             <li class="menu-item-has-children ul-li-block">
                                                 <a href="#">
-                                                    <span class="d-md-down-none">{{ trans('menus.language-picker.language', [], 'en') }}
+                                                    <span class="d-md-down-none">{{ trans('menus.language_picker.language', [], 'en') }}
                                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})</span>
                                                 </a>
                                                 <ul class="sub-menu">
@@ -337,7 +337,7 @@
                                     <button class="menu-link" data-toggle="collapse"
                                             data-target="#collapseLang"
                                             aria-expanded="true" aria-controls="collapseLang">
-                                        {{ trans('menus.language-picker.language', [], 'en') }}
+                                        {{ trans('menus.language_picker.language', [], 'en') }}
                                         ({{ locale_flag_emoji(app()->getLocale()) }} {{ strtoupper(app()->getLocale()) }})
                                     </button>
                                 </div>

--- a/resources/views/frontend/mail/contact-text.blade.php
+++ b/resources/views/frontend/mail/contact-text.blade.php
@@ -2,5 +2,5 @@
 
 @lang('validation.attributes.frontend.name'): {{ $request->name }}
 @lang('validation.attributes.frontend.email'): {{ $request->email }}
-@lang('validation.attributes.frontend.phone'): {{ ($request->phone == "") ? "N/A" : $request->phone }}
+@lang('validation.attributes.frontend.phone'): {{ ($request->phone == "") ? __('labels.general.not_available') : $request->phone }}
 @lang('validation.attributes.frontend.message'): {{ $request->message }}

--- a/resources/views/frontend/mail/contact.blade.php
+++ b/resources/views/frontend/mail/contact.blade.php
@@ -2,5 +2,5 @@
 
 <p><strong>@lang('validation.attributes.frontend.name'):</strong> {{ $request->name }}</p>
 <p><strong>@lang('validation.attributes.frontend.email'):</strong> {{ $request->email }}</p>
-<p><strong>@lang('validation.attributes.frontend.phone'):</strong>  {{ ($request->phone == "") ? "N/A" : $request->phone }}</p>
+<p><strong>@lang('validation.attributes.frontend.phone'):</strong>  {{ ($request->phone == "") ? __('labels.general.not_available') : $request->phone }}</p>
 <p><strong>@lang('validation.attributes.frontend.message'):</strong> {{ $request->message }}</p>

--- a/resources/views/frontend/search-result/blogs.blade.php
+++ b/resources/views/frontend/search-result/blogs.blade.php
@@ -92,7 +92,7 @@
                                                                 </div>
 
                                                                 <div class="view-all-btn bold-font">
-                                                                    <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">Read More <i
+                                                                    <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">@lang('labels.general.read_more') <i
                                                                                 class="fas fa-chevron-circle-right"></i></a>
                                                                 </div>
                                                             </div>
@@ -131,7 +131,7 @@
                                                                     </div>
 
                                                                     <div class="view-all-btn bold-font">
-                                                                        <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">Read More <i
+                                                                        <a href="{{route('blogs.index',['slug'=> $item->slug.'-'.$item->id])}}">@lang('labels.general.read_more') <i
                                                                                     class="fas fa-chevron-circle-right"></i></a>
                                                                     </div>
                                                                 </div>

--- a/resources/views/includes/partials/lang.blade.php
+++ b/resources/views/includes/partials/lang.blade.php
@@ -1,7 +1,7 @@
 <div class="dropdown-menu dropdown-menu-right add-dropmenu-position" aria-labelledby="navbarDropdownLanguageLink">
     {{--@foreach(array_keys(config('locale.languages')) as $lang)--}}
         {{--@if($lang != app()->getLocale())--}}
-            {{--<small><a href="{{ route('locale.swap', ['lang' => $lang]) }}" class="dropdown-item">{{ trans('menus.language-picker.langs.' . $lang, [], 'en') }}</a></small>--}}
+            {{--<small><a href="{{ route('locale.swap', ['lang' => $lang]) }}" class="dropdown-item">{{ trans('menus.language_picker.langs.' . $lang, [], 'en') }}</a></small>--}}
         {{--@endif--}}
     {{--@endforeach--}}
     @foreach($locales as $lang)

--- a/resources/views/language-marketplace/contribute.blade.php
+++ b/resources/views/language-marketplace/contribute.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>Language Contribution</title>
+    <title>{{ __('language_marketplace_pages.contribute.page_title') }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
 </head>
 <body style="background:#f5f7fb;">
@@ -13,9 +13,9 @@
         <div class="col-lg-9">
             <div class="card shadow-sm">
                 <div class="card-body p-4">
-                    <h2 class="mb-2">Language Contribution</h2>
+                    <h2 class="mb-2">{{ __('language_marketplace_pages.contribute.title') }}</h2>
                     <p class="text-muted mb-4">
-                        Submit your translated JSON package for <strong>{{ strtoupper($invitation->locale_code) }}</strong>.
+                        {{ __('language_marketplace_pages.contribute.subtitle', ['locale' => strtoupper($invitation->locale_code)]) }}
                     </p>
 
                     @php
@@ -42,20 +42,20 @@
                     @endif
 
                     <div class="mb-4">
-                        <h5 class="mb-3">Invitation Details</h5>
-                        <div><strong>Contributor:</strong> {{ $invitation->contributor_name ?: 'Contributor' }}</div>
-                        <div><strong>Email:</strong> {{ $invitation->contributor_email }}</div>
-                        <div><strong>Status:</strong> {{ ucfirst($invitation->status) }}</div>
-                        <div><strong>Expires:</strong> {{ optional($invitation->expires_at)->format('Y-m-d H:i') ?: 'No expiry' }}</div>
+                        <h5 class="mb-3">{{ __('language_marketplace_pages.contribute.invitation_details') }}</h5>
+                        <div><strong>{{ __('language_marketplace_pages.contribute.contributor') }}:</strong> {{ $invitation->contributor_name ?: __('language_marketplace_pages.contribute.default_contributor') }}</div>
+                        <div><strong>{{ __('language_marketplace_pages.contribute.email') }}:</strong> {{ $invitation->contributor_email }}</div>
+                        <div><strong>{{ __('language_marketplace_pages.contribute.status') }}:</strong> {{ ucfirst($invitation->status) }}</div>
+                        <div><strong>{{ __('language_marketplace_pages.contribute.expires') }}:</strong> {{ optional($invitation->expires_at)->format('Y-m-d H:i') ?: __('language_marketplace_pages.contribute.no_expiry') }}</div>
                     </div>
 
                     @if ($sourcePackage)
                         <div class="mb-4 p-3 border rounded bg-light">
-                            <h5 class="mb-2">Source Package ({{ strtoupper($sourceLocale ?? 'en') }})</h5>
-                            <p class="mb-2">Download the current source package, translate it, then upload the translated JSON below.</p>
+                            <h5 class="mb-2">{{ __('language_marketplace_pages.contribute.source_package', ['locale' => strtoupper($sourceLocale ?? 'en')]) }}</h5>
+                            <p class="mb-2">{{ __('language_marketplace_pages.contribute.source_package_help') }}</p>
                             <a class="btn btn-outline-primary"
                                          href="{{ route('language-marketplace.packages.download', ['package' => $sourcePackage->id]) }}">
-                                Download source package
+                                {{ __('language_marketplace_pages.contribute.download_source_package') }}
                             </a>
                         </div>
                     @endif
@@ -64,15 +64,14 @@
                         @csrf
 
                     <div class="mb-4 p-3 border rounded bg-white">
-                        <h5 class="mb-2">Auto-detected untranslated labels</h5>
+                        <h5 class="mb-2">{{ __('language_marketplace_pages.contribute.auto_detected_title') }}</h5>
                         <p class="text-muted mb-3">
-                            We detected <strong>{{ $missingCount }}</strong> untranslated labels by comparing source {{ strtoupper($sourceLocale ?? 'en') }} with target {{ strtoupper($invitation->locale_code) }}.
-                            Fill any fields below and submit directly.
+                            {{ __('language_marketplace_pages.contribute.auto_detected_desc', ['count' => $missingCount, 'source' => strtoupper($sourceLocale ?? 'en'), 'target' => strtoupper($invitation->locale_code)]) }}
                         </p>
 
                         @if ($sourceModuleCount === 0)
                             <div class="alert alert-warning">
-                                No source modules were found for the selected source locale. Publish a valid source package first, or use EN source.
+                                {{ __('language_marketplace_pages.contribute.no_source_modules') }}
                             </div>
                         @endif
 
@@ -80,44 +79,44 @@
                             <div style="max-height:420px; overflow:auto;">
                                 @foreach ($missingEntries as $module => $items)
                                     <div class="border rounded p-2 mb-3">
-                                        <h6 class="mb-2">Module: {{ $module }}</h6>
+                                        <h6 class="mb-2">{{ __('language_marketplace_pages.contribute.module') }}: {{ $module }}</h6>
                                         @foreach ($items as $entry)
                                             <div class="form-group mb-2">
                                                 <label class="mb-1 d-block">
                                                     <strong>{{ $entry['key'] }}</strong>
-                                                    <small class="text-muted d-block">Source: {{ $entry['source'] }}</small>
+                                                    <small class="text-muted d-block">{{ __('language_marketplace_pages.contribute.source') }}: {{ $entry['source'] }}</small>
                                                     @if (!empty($entry['current']))
-                                                        <small class="text-muted d-block">Current: {{ $entry['current'] }}</small>
+                                                        <small class="text-muted d-block">{{ __('language_marketplace_pages.contribute.current') }}: {{ $entry['current'] }}</small>
                                                     @endif
                                                 </label>
                                                 <input type="text"
                                                        class="form-control"
                                                        name="auto_translations[{{ $module }}][{{ $entry['key'] }}]"
                                                        value="{{ old('auto_translations.' . $module . '.' . $entry['key']) }}"
-                                                       placeholder="Insert translation">
+                                                       placeholder="{{ __('language_marketplace_pages.contribute.insert_translation') }}">
                                             </div>
                                         @endforeach
                                     </div>
                                 @endforeach
                             </div>
                         @else
-                            <div class="alert alert-success mb-0">No untranslated labels detected for this language pair.</div>
+                            <div class="alert alert-success mb-0">{{ __('language_marketplace_pages.contribute.no_untranslated_labels') }}</div>
                         @endif
                     </div>
 
                         <div class="form-group">
-                            <label for="language_payload_file">Upload translated JSON file</label>
+                            <label for="language_payload_file">{{ __('language_marketplace_pages.contribute.upload_translated_json_file') }}</label>
                             <input type="file" class="form-control" id="language_payload_file" name="language_payload_file" accept=".json,.txt">
                         </div>
                         <div class="form-group">
-                            <label for="language_payload_json">Or paste translated JSON</label>
+                            <label for="language_payload_json">{{ __('language_marketplace_pages.contribute.or_paste_translated_json') }}</label>
                             <textarea class="form-control" id="language_payload_json" name="language_payload_json" rows="10" placeholder='{"modules": {"messages": {"welcome": "Bonjour"}}}'></textarea>
                         </div>
                         <div class="form-group">
-                            <label for="message">Message to reviewer</label>
-                            <textarea class="form-control" id="message" name="message" rows="3" placeholder="Optional note for the admin reviewer"></textarea>
+                            <label for="message">{{ __('language_marketplace_pages.contribute.message_to_reviewer') }}</label>
+                            <textarea class="form-control" id="message" name="message" rows="3" placeholder="{{ __('language_marketplace_pages.contribute.optional_note') }}"></textarea>
                         </div>
-                        <button type="submit" class="btn btn-primary">Submit translation</button>
+                        <button type="submit" class="btn btn-primary">{{ __('language_marketplace_pages.contribute.submit_translation') }}</button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
📥 Pull Request Template

🔧 Description
What problem does this PR solve?
Several frontend and backend views still contained hardcoded UI strings, and translation keys had drift/inconsistency across locales (including language-key path mismatches and license translation filename differences). This led to untranslated labels and occasional missing-key runtime messages.

What feature does it add?
This PR completes the i18n hardcoded-text migration and normalizes translation structure/parity across supported locales.

Implemented components:
- Replaced hardcoded UI labels in affected Blade views with translation keys (`@lang`, `__`, `trans`) across frontend, frontend-rtl, and backend pages.
- Localized remaining hardcoded strings in notification/license/general settings UI and related JS messages.
- Added/updated missing translation keys in `resources/lang/{en,ar,es,fr,it}` for:
  - `labels.general` and `labels.backend.*` entries,
  - `admin_pages.notification_settings.*` alignment,
  - `course_pages` additions,
  - language marketplace contribution content.
- Added locale files for language marketplace pages in all supported locales:
  - `language_marketplace_pages.php`.
- Normalized language key path usage in views:
  - `menus.language-picker.*` → `menus.language_picker.*`.
- Added canonical license translation aliases to improve consistency and compatibility:
  - `license.php` and compatibility aliases (`license-ar.php` / `license-en.php`) per locale.
- Added defensive translation fallback resolution in `NotificationSetting` model labels to avoid missing-key output in runtime edge cases.

Fixes: #447
Related: #457

✅ Type of Change
Select all that apply:

- [x]   🐞 Bug fix
- [x]   ✨ New feature
- [x]   ♻️ Code refactor
- [ ]   📝 Documentation update
- [x]   🎨 UI/UX update
- [ ]   🔐 Security improvement
- [ ]   🔧 Other (please describe):

📸 Screenshots (if applicable)
N/A.

🚀 How Has This Been Tested?
Describe the tests you ran to verify your changes:

- [x]   Local environment
- [x]   Browser testing
- [ ]   Mobile testing
- [ ]   Database migrations tested
- [ ]   Unit/Feature tests added
- [x]   Other: syntax checks and i18n parity audit across `en/ar/es/fr/it`; cache clear (`php artisan optimize:clear`)

🧪 Steps to Reproduce (for bug fixes)

1. Open landing pages and backend settings pages previously showing untranslated literals.
2. Switch locale between `en`, `ar`, `es`, `fr`, `it`.
3. Verify labels render translated text instead of key names.
4. Visit notification settings and confirm event labels (including `course_enrollment`) resolve correctly.
5. Verify no runtime missing-key messages for touched keys.

🔄 Checklist
Before submitting the PR, ensure you:

- [x]   Followed the project's coding guidelines
- [ ]   Updated documentation (if needed)
- [ ]   Added/Updated tests (if applicable)
- [x]   Verified no sensitive data is included
- [x]   Ensured the app builds without errors

🙏 Additional Notes
- Working tree contains unrelated generated cache diffs in `bootstrap/cache/*` which are intentionally excluded from this commit.
- Translation file parity is now aligned across supported locales for missing keys in this scope.
