### PR TITLE
Precomputed KPI Snapshot System for Fast Dashboard Reads (#419)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/KpiController.php
+++ b/app/Http/Controllers/Backend/Admin/KpiController.php
@@ -7,18 +7,18 @@ use App\Http\Requests\Admin\StoreKpiRequest;
 use App\Http\Requests\Admin\UpdateKpiRequest;
 use App\Models\Course;
 use App\Models\Kpi;
-use App\Services\KpiCalculationService;
+use App\Services\Kpi\KpiSnapshotService;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 
 class KpiController extends Controller
 {
-    protected $calculationService;
+    protected $snapshotService;
 
-    public function __construct(KpiCalculationService $calculationService)
+    public function __construct(KpiSnapshotService $snapshotService)
     {
-        $this->calculationService = $calculationService;
+        $this->snapshotService = $snapshotService;
     }
 
     public function index(Request $request)
@@ -42,10 +42,7 @@ class KpiController extends Controller
         $allKpis = $query->get();
         $totalActiveWeight = (float) Kpi::query()->where('is_active', true)->sum('weight');
 
-        $calculatedKpis = $allKpis->map(function ($kpi) use ($totalActiveWeight) {
-            $kpi->calculation = $this->calculationService->calculateForKpi($kpi, $totalActiveWeight);
-            return $kpi;
-        });
+        $calculatedKpis = $this->snapshotService->attachCalculations($allKpis, $totalActiveWeight);
 
         $sorted = $calculatedKpis->sort(function ($left, $right) use ($sorts) {
             foreach ($sorts as $sort) {

--- a/app/Models/Kpi.php
+++ b/app/Models/Kpi.php
@@ -50,6 +50,16 @@ class Kpi extends Model
         return $this->belongsToMany(Course::class, 'kpi_course')->withTimestamps();
     }
 
+    public function snapshots()
+    {
+        return $this->hasMany(KpiSnapshot::class);
+    }
+
+    public function currentSnapshot()
+    {
+        return $this->hasOne(KpiSnapshot::class)->where('is_current', true)->latest('id');
+    }
+
     public function getTypeLabelAttribute()
     {
         return config('kpi.types.' . $this->type . '.label', ucfirst($this->type));

--- a/app/Models/KpiSnapshot.php
+++ b/app/Models/KpiSnapshot.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class KpiSnapshot extends Model
+{
+    protected $fillable = [
+        'kpi_id',
+        'previous_snapshot_id',
+        'calculation_version',
+        'input_signature',
+        'excluded',
+        'value',
+        'weighted_score',
+        'total_active_weight',
+        'is_current',
+        'calculated_at',
+        'meta',
+    ];
+
+    protected $casts = [
+        'excluded' => 'boolean',
+        'is_current' => 'boolean',
+        'value' => 'float',
+        'weighted_score' => 'float',
+        'total_active_weight' => 'float',
+        'calculated_at' => 'datetime',
+        'meta' => 'array',
+    ];
+
+    public function kpi()
+    {
+        return $this->belongsTo(Kpi::class);
+    }
+
+    public function previousSnapshot()
+    {
+        return $this->belongsTo(self::class, 'previous_snapshot_id');
+    }
+}

--- a/app/Services/Kpi/KpiSnapshotService.php
+++ b/app/Services/Kpi/KpiSnapshotService.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use App\Models\Kpi;
+use App\Models\KpiSnapshot;
+use App\Services\KpiCalculationService;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class KpiSnapshotService
+{
+    protected $calculationService;
+
+    public function __construct(KpiCalculationService $calculationService)
+    {
+        $this->calculationService = $calculationService;
+    }
+
+    /**
+     * @param Collection $kpis
+     * @param float $totalActiveWeight
+     * @return Collection
+     */
+    public function attachCalculations(Collection $kpis, $totalActiveWeight)
+    {
+        if ($kpis->isEmpty()) {
+            return $kpis;
+        }
+
+        $totalActiveWeight = (float) $totalActiveWeight;
+
+        if (!$this->canUseSnapshotStorage()) {
+            return $this->attachLiveCalculations($kpis, $totalActiveWeight);
+        }
+
+        $kpis->loadMissing('currentSnapshot', 'courses:id');
+
+        $globalContext = $this->buildGlobalContext($totalActiveWeight);
+        $globalContext['course_scope_signature'] = $this->buildCourseScopeSignatures($kpis);
+
+        return $kpis->map(function ($kpi) use ($globalContext, $totalActiveWeight) {
+            $snapshot = $this->resolveSnapshotForKpi($kpi, $globalContext, $totalActiveWeight);
+
+            $kpi->calculation = [
+                'excluded' => (bool) $snapshot->excluded,
+                'value' => $snapshot->value === null ? null : (float) $snapshot->value,
+                'weighted_score' => $snapshot->weighted_score === null ? null : (float) $snapshot->weighted_score,
+            ];
+
+            return $kpi;
+        });
+    }
+
+    /**
+     * @param Collection $kpis
+     * @param float $totalActiveWeight
+     * @return Collection
+     */
+    protected function attachLiveCalculations(Collection $kpis, $totalActiveWeight)
+    {
+        return $kpis->map(function ($kpi) use ($totalActiveWeight) {
+            $kpi->calculation = $this->calculationService->calculateForKpi($kpi, $totalActiveWeight);
+
+            return $kpi;
+        });
+    }
+
+    /**
+     * @param Kpi $kpi
+     * @param array $globalContext
+     * @param float $totalActiveWeight
+     * @return KpiSnapshot
+     */
+    protected function resolveSnapshotForKpi(Kpi $kpi, array $globalContext, $totalActiveWeight)
+    {
+        $expectedSignature = $this->buildInputSignature($kpi, $globalContext);
+
+        $currentSnapshot = $kpi->currentSnapshot;
+        if ($this->isSnapshotReusable($currentSnapshot, $expectedSignature)) {
+            return $currentSnapshot;
+        }
+
+        $calculation = $this->calculationService->calculateForKpi($kpi, $totalActiveWeight);
+
+        $snapshot = $this->storeSnapshot($kpi, $calculation, $expectedSignature, $globalContext, $currentSnapshot, $totalActiveWeight);
+        $kpi->setRelation('currentSnapshot', $snapshot);
+
+        return $snapshot;
+    }
+
+    /**
+     * @param KpiSnapshot|null $snapshot
+     * @param string $expectedSignature
+     * @return bool
+     */
+    protected function isSnapshotReusable($snapshot, $expectedSignature)
+    {
+        if (!$snapshot) {
+            return false;
+        }
+
+        if ((string) $snapshot->input_signature !== (string) $expectedSignature) {
+            return false;
+        }
+
+        if ((int) $snapshot->calculation_version !== (int) config('kpi.snapshots.version', 1)) {
+            return false;
+        }
+
+        $maxAgeMinutes = max(1, (int) config('kpi.snapshots.max_age_minutes', 5));
+        $validUntil = optional($snapshot->calculated_at)->copy()->addMinutes($maxAgeMinutes);
+
+        return $validUntil instanceof Carbon && $validUntil->isFuture();
+    }
+
+    /**
+     * @param Kpi $kpi
+     * @param array $calculation
+     * @param string $inputSignature
+     * @param array $globalContext
+     * @param KpiSnapshot|null $currentSnapshot
+     * @param float $totalActiveWeight
+     * @return KpiSnapshot
+     */
+    protected function storeSnapshot(Kpi $kpi, array $calculation, $inputSignature, array $globalContext, $currentSnapshot, $totalActiveWeight)
+    {
+        return DB::transaction(function () use ($kpi, $calculation, $inputSignature, $globalContext, $currentSnapshot, $totalActiveWeight) {
+            KpiSnapshot::query()
+                ->where('kpi_id', $kpi->id)
+                ->where('is_current', true)
+                ->update([
+                    'is_current' => false,
+                    'updated_at' => now(),
+                ]);
+
+            return KpiSnapshot::query()->create([
+                'kpi_id' => $kpi->id,
+                'previous_snapshot_id' => optional($currentSnapshot)->id,
+                'calculation_version' => (int) config('kpi.snapshots.version', 1),
+                'input_signature' => $inputSignature,
+                'excluded' => (bool) ($calculation['excluded'] ?? false),
+                'value' => array_key_exists('value', $calculation) ? $calculation['value'] : null,
+                'weighted_score' => array_key_exists('weighted_score', $calculation) ? $calculation['weighted_score'] : null,
+                'total_active_weight' => round((float) $totalActiveWeight, 2),
+                'is_current' => true,
+                'calculated_at' => now(),
+                'meta' => [
+                    'event_max_id' => $globalContext['event_max_id'],
+                    'course_max_updated_at' => $globalContext['course_max_updated_at'],
+                    'course_scope_signature' => $globalContext['course_scope_signature'][$kpi->id] ?? null,
+                ],
+            ]);
+        });
+    }
+
+    /**
+     * @param Kpi $kpi
+     * @param array $globalContext
+     * @return string
+     */
+    protected function buildInputSignature(Kpi $kpi, array $globalContext)
+    {
+        $courseScopeSignature = $globalContext['course_scope_signature'][$kpi->id] ?? '';
+
+        return sha1(implode('|', [
+            (int) config('kpi.snapshots.version', 1),
+            (int) $kpi->id,
+            (string) $kpi->type,
+            round((float) $kpi->weight, 4),
+            (int) (bool) $kpi->is_active,
+            $this->normalizeDateForSignature($kpi->updated_at),
+            round((float) $globalContext['total_active_weight'], 4),
+            (string) $globalContext['event_max_id'],
+            (string) $globalContext['course_max_updated_at'],
+            (string) $courseScopeSignature,
+        ]));
+    }
+
+    /**
+     * @param float $totalActiveWeight
+     * @return array
+     */
+    protected function buildGlobalContext($totalActiveWeight)
+    {
+        $context = [
+            'total_active_weight' => (float) $totalActiveWeight,
+            'event_max_id' => null,
+            'course_max_updated_at' => null,
+        ];
+
+        if (Schema::hasTable('lms_kpi_events') && Schema::hasColumn('lms_kpi_events', 'id')) {
+            $context['event_max_id'] = (string) DB::table('lms_kpi_events')->max('id');
+        }
+
+        if (
+            Schema::hasTable('courses')
+            && Schema::hasColumn('courses', 'updated_at')
+            && Schema::hasColumn('courses', 'id')
+        ) {
+            $courseQuery = DB::table('courses');
+            if (Schema::hasColumn('courses', 'deleted_at')) {
+                $courseQuery->whereNull('deleted_at');
+            }
+            if (Schema::hasColumn('courses', 'include_in_kpi')) {
+                $courseQuery->where('include_in_kpi', true);
+            }
+
+            $context['course_max_updated_at'] = $this->normalizeDateForSignature($courseQuery->max('updated_at'));
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param Collection $kpis
+     * @return array
+     */
+    protected function buildCourseScopeSignatures(Collection $kpis)
+    {
+        $signatures = [];
+
+        foreach ($kpis as $kpi) {
+            $courseIds = $kpi->courses
+                ->pluck('id')
+                ->map(function ($id) {
+                    return (int) $id;
+                })
+                ->filter()
+                ->unique()
+                ->sort()
+                ->values()
+                ->toArray();
+
+            $signatures[$kpi->id] = sha1(implode(',', $courseIds));
+        }
+
+        return $signatures;
+    }
+
+    /**
+     * @param mixed $date
+     * @return string
+     */
+    protected function normalizeDateForSignature($date)
+    {
+        if (!$date) {
+            return '';
+        }
+
+        try {
+            return Carbon::parse($date)->toAtomString();
+        } catch (\Throwable $e) {
+            return '';
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canUseSnapshotStorage()
+    {
+        return Schema::hasTable('kpi_snapshots');
+    }
+}

--- a/config/kpi.php
+++ b/config/kpi.php
@@ -4,6 +4,13 @@ return [
     'default_weight' => 1,
     'max_weight' => 100,
 
+    'snapshots' => [
+        // Increase this when KPI computation logic changes and all snapshots must refresh.
+        'version' => 1,
+        // Safety net for data sources without explicit invalidation signals.
+        'max_age_minutes' => 5,
+    ],
+
     // Centralized KPI type registry. Admin can only select these keys.
     'types' => [
         'completion' => [

--- a/database/migrations/2026_04_13_090000_create_kpi_snapshots_table.php
+++ b/database/migrations/2026_04_13_090000_create_kpi_snapshots_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateKpiSnapshotsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('kpi_snapshots')) {
+            return;
+        }
+
+        Schema::create('kpi_snapshots', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('kpi_id');
+            $table->unsignedBigInteger('previous_snapshot_id')->nullable();
+            $table->unsignedInteger('calculation_version')->default(1);
+            $table->string('input_signature', 40);
+            $table->boolean('excluded')->default(false);
+            $table->decimal('value', 8, 2)->nullable();
+            $table->decimal('weighted_score', 8, 2)->nullable();
+            $table->decimal('total_active_weight', 10, 2)->default(0);
+            $table->boolean('is_current')->default(true);
+            $table->timestamp('calculated_at')->useCurrent();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->index(['kpi_id', 'is_current'], 'kpi_snapshots_kpi_current_idx');
+            $table->index(['kpi_id', 'calculated_at'], 'kpi_snapshots_kpi_calculated_idx');
+            $table->index('input_signature', 'kpi_snapshots_signature_idx');
+
+            $table->foreign('kpi_id')->references('id')->on('kpis')->onDelete('cascade');
+            $table->foreign('previous_snapshot_id')->references('id')->on('kpi_snapshots')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('kpi_snapshots');
+    }
+}

--- a/tests/Feature/KpiSnapshotServiceTest.php
+++ b/tests/Feature/KpiSnapshotServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Kpi;
+use App\Models\KpiSnapshot;
+use App\Services\Kpi\KpiSnapshotService;
+use App\Services\KpiCalculationService;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class KpiSnapshotServiceTest extends TestCase
+{
+    #[Test]
+    public function it_persists_and_reuses_current_snapshot_for_fast_reads()
+    {
+        config([
+            'kpi.snapshots.version' => 1,
+            'kpi.snapshots.max_age_minutes' => 5,
+        ]);
+
+        $kpi = Kpi::query()->create([
+            'name' => 'Completion KPI',
+            'code' => 'COURSE_COMPLETION',
+            'type' => 'completion',
+            'description' => 'Tracks course completion.',
+            'weight' => 25,
+            'is_active' => true,
+        ]);
+
+        $calculationService = Mockery::mock(KpiCalculationService::class);
+        $calculationService
+            ->shouldReceive('calculateForKpi')
+            ->once()
+            ->andReturn([
+                'excluded' => false,
+                'value' => 80.5,
+                'weighted_score' => 20.13,
+            ]);
+
+        $this->app->instance(KpiCalculationService::class, $calculationService);
+        $snapshotService = $this->app->make(KpiSnapshotService::class);
+
+        $kpis = Kpi::query()->with('courses:id')->get();
+
+        $snapshotService->attachCalculations($kpis, 100);
+        $snapshotService->attachCalculations($kpis, 100);
+
+        $kpi->refresh();
+        $currentSnapshot = $kpi->currentSnapshot;
+
+        $this->assertNotNull($currentSnapshot);
+        $this->assertSame(1, KpiSnapshot::query()->count());
+        $this->assertTrue($currentSnapshot->is_current);
+        $this->assertNull($currentSnapshot->previous_snapshot_id);
+        $this->assertSame(80.5, (float) $currentSnapshot->value);
+        $this->assertSame(20.13, (float) $currentSnapshot->weighted_score);
+    }
+
+    #[Test]
+    public function it_creates_new_snapshot_version_and_links_to_previous_one()
+    {
+        config([
+            'kpi.snapshots.version' => 1,
+            'kpi.snapshots.max_age_minutes' => 60,
+        ]);
+
+        $kpi = Kpi::query()->create([
+            'name' => 'Score KPI',
+            'code' => 'ASSESSMENT_SCORE',
+            'type' => 'score',
+            'description' => 'Tracks assessment score.',
+            'weight' => 40,
+            'is_active' => true,
+        ]);
+
+        $calculationService = Mockery::mock(KpiCalculationService::class);
+        $calculationService
+            ->shouldReceive('calculateForKpi')
+            ->twice()
+            ->andReturn([
+                'excluded' => false,
+                'value' => 60.0,
+                'weighted_score' => 24.0,
+            ]);
+
+        $this->app->instance(KpiCalculationService::class, $calculationService);
+        $snapshotService = $this->app->make(KpiSnapshotService::class);
+
+        $kpis = Kpi::query()->with('courses:id')->get();
+        $snapshotService->attachCalculations($kpis, 100);
+
+        $firstSnapshot = KpiSnapshot::query()->where('kpi_id', $kpi->id)->where('is_current', true)->first();
+        $this->assertNotNull($firstSnapshot);
+
+        config(['kpi.snapshots.version' => 2]);
+
+        $kpis = Kpi::query()->with('courses:id')->get();
+        $snapshotService->attachCalculations($kpis, 100);
+
+        $kpi->refresh();
+        $currentSnapshot = $kpi->currentSnapshot;
+        $historicalSnapshot = KpiSnapshot::query()->where('id', $firstSnapshot->id)->first();
+
+        $this->assertSame(2, KpiSnapshot::query()->count());
+        $this->assertFalse((bool) $historicalSnapshot->is_current);
+        $this->assertTrue((bool) $currentSnapshot->is_current);
+        $this->assertSame($firstSnapshot->id, $currentSnapshot->previous_snapshot_id);
+        $this->assertSame(2, (int) $currentSnapshot->calculation_version);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR implements a precomputed KPI snapshot system to avoid recalculating KPI scores on every request.

Fixes #419 

### Problem

The KPI dashboard and related views were recalculating KPI metrics repeatedly at read time, which can become expensive as event volume grows.

This led to:

- Slower dashboard/API responses
- Repeated CPU/database work for unchanged KPI inputs
- No dedicated historical chain for computed KPI outputs

### Solution

- Added a new `kpi_snapshots` table for read-optimized KPI results
- Added a `KpiSnapshot` model and KPI relations (`snapshots`, `currentSnapshot`)
- Introduced `KpiSnapshotService` to:
  - Reuse current snapshots when inputs are still valid
  - Recompute and append a new snapshot when inputs change or snapshot is stale
  - Preserve history (no overwrite) and link versions via `previous_snapshot_id`
- Wired KPI index calculation flow to read from snapshot service instead of recalculating every row directly
- Added snapshot config controls in `config/kpi.php`:
  - `snapshots.version` for logic-version refreshes
  - `snapshots.max_age_minutes` as a consistency safety window
- Added feature tests for:
  - Snapshot reuse (fast subsequent reads)
  - Version bump refresh with previous snapshot linkage

### Outcome

- Fast retrieval path for UI/API KPI reads
- Snapshot updates after calculation when needed
- Preserved historical insights with version linkage
- Better scalability for KPI-heavy dashboards

Fixes: #419  
Related to parent: #461

---

## ✅ Type of Change

- Feature
- Performance improvement
- Data model update

---

## 🚀 How Has This Been Tested?

- Feature tests in local environment
- Targeted test run for snapshot behavior:
  - `tests/Feature/KpiSnapshotServiceTest.php`

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Open KPI Management page with active KPIs
2. Observe KPI values are served from current snapshots when valid
3. Change snapshot version (or modify KPI input state)
4. Reload KPI Management page
5. Observe a new snapshot is created and linked to the previous one

---

## 🔄 Checklist

- Followed the project's coding guidelines
- Verified no sensitive data is included
- Ensured feature test coverage for the snapshot workflow

---

## 🙏 Additional Notes

- Snapshot storage is additive and keeps historical records intact.
- The snapshot service includes a fallback to live calculation if snapshot storage is unavailable.
