### PR TITLE
fix(kpi): align archive soft-delete lifecycle (#414)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/KpiController.php
+++ b/app/Http/Controllers/Backend/Admin/KpiController.php
@@ -304,13 +304,13 @@ class KpiController extends Controller
         $kpiModel->delete();
 
         $kpiModel->statusHistories()->create([
-            'action' => 'deleted',
+            'action' => 'archived',
             'previous_is_active' => $previousStatus,
             'new_is_active' => $previousStatus,
             'changed_by' => \Auth::id(),
             'meta' => ['soft_deleted' => true],
         ]);
 
-        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI deleted successfully.');
+        return redirect()->route('admin.kpis.index')->withFlashSuccess('KPI archived successfully.');
     }
 }

--- a/resources/views/backend/kpis/partials/table.blade.php
+++ b/resources/views/backend/kpis/partials/table.blade.php
@@ -119,10 +119,10 @@
                             </button>
                         </form>
 
-                        <form method="POST" action="{{ route('admin.kpis.destroy', $kpi->id) }}" class="d-inline-block" onsubmit="return confirm('Delete this KPI? It will be soft-deleted and historical records stay intact.');">
+                        <form method="POST" action="{{ route('admin.kpis.destroy', $kpi->id) }}" class="d-inline-block" onsubmit="return confirm('Archive this KPI? It will be soft-deleted and historical records stay intact.');">
                             @csrf
                             @method('DELETE')
-                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                            <button type="submit" class="btn btn-sm btn-danger">Archive</button>
                         </form>
                     </td>
                 </tr>

--- a/tests/Feature/Backend/Kpi/ArchiveKpiTest.php
+++ b/tests/Feature/Backend/Kpi/ArchiveKpiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Backend\Kpi;
+
+use App\Models\Kpi;
+use Illuminate\Support\Facades\Gate;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ArchiveKpiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::define('category_access', function () {
+            return true;
+        });
+    }
+
+    #[Test]
+    public function an_admin_can_archive_a_kpi_via_soft_delete()
+    {
+        $admin = $this->loginAsAdmin();
+
+        $kpi = Kpi::query()->create([
+            'name' => 'Completion KPI',
+            'code' => 'COURSE_COMPLETION',
+            'type' => 'completion',
+            'description' => 'Tracks course completion.',
+            'weight' => 25,
+            'is_active' => true,
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $response = $this->delete(route('admin.kpis.destroy', $kpi->id));
+
+        $response->assertRedirect(route('admin.kpis.index'));
+        $response->assertSessionHas(['flash_success' => 'KPI archived successfully.']);
+
+        $this->assertSoftDeleted('kpis', ['id' => $kpi->id]);
+        $this->assertDatabaseHas('kpi_status_histories', [
+            'kpi_id' => $kpi->id,
+            'action' => 'archived',
+            'changed_by' => $admin->id,
+        ]);
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes #414 

This PR closes the remaining lifecycle gap for KPI activation and deactivation by aligning the admin delete flow with the soft-delete behavior that already exists in the KPI module.

Most of the implementation for issue #414 was already in place before this change. KPIs already supported activation and deactivation, inactive KPIs were already excluded from calculations, historical records were already preserved, and the model already used soft deletes. This PR focuses on the final lifecycle polish so the admin experience and regression coverage match that behavior more clearly.

### Problem

- The bulk of the KPI lifecycle implementation was already present in the codebase, including `is_active`, soft deletes, status history, and inactive KPI exclusion in processing.
- The admin UI still exposed the destructive action as `Delete`, even though the controller performed a soft delete.
- The controller also stored the status history action as `deleted`, which made the lifecycle history read more like a permanent removal than an archive action.
- There was no focused feature test covering the archive flow end to end.

### Solution

- Updated the KPI admin table action label and confirmation copy from `Delete` to `Archive` so the UI matches the actual soft-delete behavior.
- Updated the KPI controller to record the lifecycle history entry as `archived` and to return a matching success flash message.
- Added a feature test that verifies an admin can archive a KPI, that the record is soft deleted, and that the lifecycle history entry is written.

Fixes: #414

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

Will enhance aesthetic once the KPI engine is fully implemented and tested. 

<img width="1546" height="587" alt="Screenshot from 2026-04-15 10-43-50" src="https://github.com/user-attachments/assets/d0f40ced-4018-43cc-9694-91c1cea37f05" />


---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [ ] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [x] Unit/Feature tests added
- [ ] Other:

### Test Scenarios

- Archived a KPI through the destroy route and verified the record is soft deleted.
- Verified the KPI status history stores `archived` instead of `deleted`.
- Verified the success flash message now reflects archive semantics.
- Ran the focused KPI feature test locally.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an admin and open the KPI management page.
2. Use the archive action for an existing KPI.
3. Confirm the KPI is removed from the active list via soft delete while its history remains intact.
4. Verify the UI and success message refer to the action as archive rather than permanent deletion.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [x] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This PR intentionally does not reimplement the KPI lifecycle engine because the majority of issue #414 was already delivered in earlier KPI work. It focuses only on the remaining soft-delete lifecycle wording and regression coverage needed to make the behavior explicit and safer for admins.
