### PR TITLE
fix: localize login failure responses by selected language

### DIFF
--- a/app/Http/Controllers/Frontend/Auth/LoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/LoginController.php
@@ -97,7 +97,9 @@ class LoginController extends Controller
                 'captcha' => 'required',
             ],
             [
-                'captcha.required' => 'Please solve the captcha',
+                'captcha.required' => __('validation.required', [
+                    'attribute' => __('auth_pages.login.captcha'),
+                ]),
             ]
         );
 
@@ -110,12 +112,12 @@ class LoginController extends Controller
 
         // CAPTCHA CHECK
         if ((int) $request->captcha !== (int) Session::get('captcha_answer')) {
-        return response([
-            'success' => false,
-            'errors' => [
-                'captcha' => ['Invalid captcha answer']
-            ]
-        ], 422);
+            return response([
+                'success' => false,
+                'errors' => [
+                    'captcha' => [__('auth.invalid_captcha')],
+                ],
+            ], 422);
         }
 
         $credentials = [
@@ -163,8 +165,10 @@ class LoginController extends Controller
                 if (!$ldapUser) {
                     return response([
                         'success' => false,
-                        'message' => 'User not found in LDAP',
-                    ], Response::HTTP_FORBIDDEN);
+                        'errors' => [
+                            'email' => [__('auth.failed')],
+                        ],
+                    ], 422);
                 }
 
                 $dn = $ldapUser->getDn();
@@ -174,11 +178,13 @@ class LoginController extends Controller
                     ->auth()
                     ->attempt($dn, $request->password);
 
-                                if (!$auth) {
+                if (!$auth) {
                     return response([
                         'success' => false,
-                        'message' => 'Invalid LDAP password',
-                    ], Response::HTTP_FORBIDDEN);
+                        'errors' => [
+                            'email' => [__('auth.failed')],
+                        ],
+                    ], 422);
                 }
 
                 // Create or sync user in LMS database
@@ -207,15 +213,17 @@ class LoginController extends Controller
             } catch (\Exception $e) {
                 return response([
                     'success' => false,
-                    'message' => 'LDAP Error: ' . $e->getMessage(),
+                    'message' => __('auth.unknown'),
                 ], Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         }
 
         return response([
             'success' => false,
-            'message' => 'Login failed. Account not found',
-        ], Response::HTTP_FORBIDDEN);
+            'errors' => [
+                'email' => [__('auth.failed')],
+            ],
+        ], 422);
     }
 
     /**

--- a/resources/lang/ar/auth.php
+++ b/resources/lang/ar/auth.php
@@ -8,6 +8,7 @@ return array(
   'socialite' => array(
     'unacceptable' => ': مزود ليس نوع تسجيل الدخول مقبول.',
   ),
+  'invalid_captcha' => 'إجابة الكابتشا غير صحيحة.',
   'throttle' => 'محاولات تسجيل الدخول كثيرة جدًا. يرجى المحاولة مرة أخرى بعد: ثوانٍ.',
   'unknown' => 'حدث خطأ غير معروف',
   'welcome' => ':attribute أهلا وسهلا',

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -9,6 +9,7 @@ return array (
   'password_rules' => 'Your password must be more than 8 characters long, should contain at least 1 uppercase, 1 lowercase and 1 number.',
   'password_used' => 'You can not set a password that you have previously used.',
   'failed' => 'These credentials do not match our records.',
+  'invalid_captcha' => 'Invalid captcha answer.',
   'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
   'unknown' => 'An unknown error occurred',
   'welcome' => 'Welcome, :attribute',

--- a/resources/lang/es/auth.php
+++ b/resources/lang/es/auth.php
@@ -8,6 +8,7 @@ return array(
   'socialite' => array(
     'unacceptable' => ': proveedor no es un tipo de inicio de sesión aceptable.',
   ),
+  'invalid_captcha' => 'Respuesta de captcha no válida.',
   'throttle' => 'Demasiados intentos de inicio de sesión. Por favor, intente de nuevo en: segundos segundos.',
   'unknown' => 'Un error desconocido ocurrió',
   'welcome' => 'Bienvenido, :attribute',

--- a/resources/lang/fr/auth.php
+++ b/resources/lang/fr/auth.php
@@ -8,6 +8,7 @@ return array(
   'socialite' => array(
     'unacceptable' => ': fournisseur n\'est pas un type de connexion acceptable.',
   ),
+  'invalid_captcha' => 'Réponse captcha invalide.',
   'throttle' => 'Trop de tentatives de connexion. Veuillez réessayer dans: secondes secondes.',
   'unknown' => 'Une erreur inconnue est survenue',
   'welcome' => 'Bienvenue, :attribute',

--- a/resources/lang/it/auth.php
+++ b/resources/lang/it/auth.php
@@ -8,6 +8,7 @@ return array(
   'password_rules' => 'La tua password deve essere lunga più di 8 caratteri, deve contenere almeno 1 lettera maiuscola, 1 lettera minuscola e 1 numero.',
   'password_used' => 'Non è possibile impostare una password utilizzata in precedenza.',
   'failed' => 'Queste credenziali non corrispondono ai nostri record.',
+  'invalid_captcha' => 'Risposta captcha non valida.',
   'throttle' => 'Troppi tentativi di accesso. Riprova tra :seconds secondi.',
   'unknown' => 'Si è verificato un errore sconosciuto',
   'welcome' => 'Benvenuto, :attribute',


### PR DESCRIPTION
## Description
This PR fixes login error messaging so users see localized, credential-specific feedback instead of a generic fallback.

## What Changed
- Localized failed login responses in `LoginController` using existing translation keys.
- Replaced hardcoded captcha and LDAP credential failure messages with translation-driven responses.
- Added `invalid_captcha` key to auth translation files for `en`, `ar`, `es`, `fr`, and `it`.
- Kept frontend error handling compatible with `errors` and `message` payloads.

## Issue
Closes #516

## Testing
- `php -l app/Http/Controllers/Frontend/Auth/LoginController.php`
- `php -l resources/lang/en/auth.php`
- `php -l resources/lang/ar/auth.php`
- `php -l resources/lang/es/auth.php`
- `php -l resources/lang/fr/auth.php`
- `php -l resources/lang/it/auth.php`

## Notes
This change reuses existing repo translation conventions and returns localized messages based on the selected application language.