### PR TITLE
fix: remove View CMS Course button from course list page

### DIFF
--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -21,10 +21,6 @@
       @lang('labels.backend.courses.title')
    </h4>
    <div class="d-flex">
-   <div class="">
-       <a href="{{ route('admin.courses.cms-course') }}" class="btn btn-outline-success create_done mr-3">{{ __('course_pages.admin_index.view_cme_course') }}</a>
-
-     </div>
        @can('course_create')
           <div class="">
               <a href="{{ route('admin.courses.create') }}" class="btn add-btn">@lang('strings.backend.general.app_add_new')</a>

--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -41,10 +41,6 @@
 
                 </div>
             @endcan
-            <div class="float-right">
-                <a href="{{ route('admin.courses.cms-course') }}" class="btn create_done">@lang('View CME Course')</a>
-
-            </div>
         </div> -->
         <div class="card-body">
             {{-- Advanced Filters Section --}}

--- a/resources/views/backend/mycourses/pathwaycourses.blade.php
+++ b/resources/views/backend/mycourses/pathwaycourses.blade.php
@@ -32,10 +32,6 @@
 
                 </div>
             @endcan
-            {{-- <div class="float-right">
-                <a href="{{ route('admin.courses.cms-course') }}" class="btn create_done">@lang('View CME Course')</a>
-
-            </div> --}}
         </div>
         <div class="card-body">
             <div class="table-responsive">


### PR DESCRIPTION
Closes #519

## Changes
- Removed "View CMS Course" button from header area in resources/views/backend/courses/index.blade.php
- Removed "View CMS Course" button from resources/views/backend/mycourses/pathwaycourses.blade.php

## Testing
- Verified button no longer appears on the Course List page
- All other course list functionality remains intact