### PR TITLE
fix(positions): disable positions module and hide sidebar menu item

### DIFF
--- a/app/Http/Controllers/Backend/Admin/PositionController.php
+++ b/app/Http/Controllers/Backend/Admin/PositionController.php
@@ -25,6 +25,13 @@ class PositionController extends Controller
     use FileUploadTrait;
     private $tags;
 
+    // Intentionally returns 404 for all Position routes while the module is unmapped.
+    // All routes in routes/backend/admin.php are pointed here until the feature is active.
+    public function disabled(): never
+    {
+        abort(404);
+    }
+
     public function index()
     {
         if (!Gate::allows('page_access')) {

--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -164,10 +164,11 @@
                     </li>
                 @endif
 
-                @if (
-                        null == Session::get('setvaluesession') ||
+                {{-- Temporarily disabled: Positions menu item hidden per issue #466 --}}
+                @if (false && (
+                    null == Session::get('setvaluesession') ||
                         (null !== Session::get('setvaluesession') && in_array(Session::get('setvaluesession'), [1, 2]))
-                    )
+                ))
                     <li class="nav-item ">
                         <a class="nav-link {{ $request->segment(2) == 'position' ? 'active' : '' }}"
                             href="{{ route('admin.position.index') }}">

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -623,21 +623,21 @@ Route::post('department_restore/{page}', ['uses' => 'Admin\DepartmentController@
 Route::delete('department_perma_del/{page}', ['uses' => 'Admin\DepartmentController@perma_del', 'as' => 'department.perma_del']);
 
 
-// Position
-Route::get('position', 'Admin\PositionController@index')->name('position.index');
-Route::get('position-create', 'Admin\PositionController@create')->name('position.create');
-Route::post('position-store', 'Admin\PositionController@store')->name('position.store');
-Route::get('position-view/{page}', 'Admin\PositionController@show')->name('position.show');
-Route::get('position-edit/{page}', 'Admin\PositionController@edit')->name('position.edit');
-Route::post('position-update/{page}', 'Admin\PositionController@update')->name('position.update');
-Route::delete('position-destroy/{page}', 'Admin\PositionController@destroy')->name('position.destroy');
+// Position module is intentionally disabled until it is mapped to active functionality.
+Route::get('position', 'Admin\PositionController@disabled')->name('position.index');
+Route::get('position-create', 'Admin\PositionController@disabled')->name('position.create');
+Route::post('position-store', 'Admin\PositionController@disabled')->name('position.store');
+Route::get('position-view/{page}', 'Admin\PositionController@disabled')->name('position.show');
+Route::get('position-edit/{page}', 'Admin\PositionController@disabled')->name('position.edit');
+Route::post('position-update/{page}', 'Admin\PositionController@disabled')->name('position.update');
+Route::delete('position-destroy/{page}', 'Admin\PositionController@disabled')->name('position.destroy');
 
-Route::post('position/import/', 'Admin\PositionController@import_exl')->name('position.add.import');
+Route::post('position/import/', 'Admin\PositionController@disabled')->name('position.add.import');
 
-Route::get('get-position-data', ['uses' => 'Admin\PositionController@getData', 'as' => 'position.get_data']);
-Route::post('position_mass_destroy', ['uses' => 'Admin\PositionController@massDestroy', 'as' => 'position.mass_destroy']);
-Route::post('position_restore/{page}', ['uses' => 'Admin\PositionController@restore', 'as' => 'position.restore']);
-Route::delete('position_perma_del/{page}', ['uses' => 'Admin\PositionController@perma_del', 'as' => 'position.perma_del']);
+Route::get('get-position-data', 'Admin\PositionController@disabled')->name('position.get_data');
+Route::post('position_mass_destroy', 'Admin\PositionController@disabled')->name('position.mass_destroy');
+Route::post('position_restore/{page}', 'Admin\PositionController@disabled')->name('position.restore');
+Route::delete('position_perma_del/{page}', 'Admin\PositionController@disabled')->name('position.perma_del');
 
 Route::get('subscription', 'Admin\SubscriptionController@index')->name('subscription.index');
 Route::get('subscription-create', 'Admin\SubscriptionController@create')->name('subscription.create');

--- a/tests/Feature/Backend/DisabledPositionsModuleTest.php
+++ b/tests/Feature/Backend/DisabledPositionsModuleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Backend;
+
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class DisabledPositionsModuleTest extends TestCase
+{
+    /** @test */
+    public function positions_sidebar_link_is_not_rendered_for_admin_users()
+    {
+        $adminRole = $this->getAdminRole();
+        // category_access is required for the admin dashboard to render the General sidebar section.
+        $adminRole->givePermissionTo(Permission::findOrCreate('category_access'));
+
+        $this->loginAsAdmin();
+
+        // Assert by the route URL so we don't false-positive on the word "Positions"
+        // appearing elsewhere on the dashboard (titles, widgets, etc.).
+        $this->get(route('admin.dashboard'))
+            ->assertOk()
+            ->assertDontSee(route('admin.position.index'));
+    }
+
+    /** @test */
+    public function positions_get_routes_are_disabled_for_direct_access()
+    {
+        $this->loginAsAdmin();
+
+        $this->get(route('admin.position.index'))->assertNotFound();
+        $this->get(route('admin.position.create'))->assertNotFound();
+        $this->get(route('admin.position.show', ['page' => 1]))->assertNotFound();
+        $this->get(route('admin.position.edit', ['page' => 1]))->assertNotFound();
+        $this->get(route('admin.position.get_data'))->assertNotFound();
+    }
+
+    /** @test */
+    public function positions_post_routes_are_disabled_for_direct_access()
+    {
+        $this->loginAsAdmin();
+
+        $this->post(route('admin.position.store'))->assertNotFound();
+        $this->post(route('admin.position.update', ['page' => 1]))->assertNotFound();
+        $this->post(route('admin.position.add.import'))->assertNotFound();
+        $this->post(route('admin.position.mass_destroy'))->assertNotFound();
+        $this->post(route('admin.position.restore', ['page' => 1]))->assertNotFound();
+    }
+
+    /** @test */
+    public function positions_delete_routes_are_disabled_for_direct_access()
+    {
+        $this->loginAsAdmin();
+
+        $this->delete(route('admin.position.destroy', ['page' => 1]))->assertNotFound();
+        $this->delete(route('admin.position.perma_del', ['page' => 1]))->assertNotFound();
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

The "Positions" module is not linked to any active feature or dataset, yet it was fully accessible via the sidebar and direct URL. This caused confusion for users and added unnecessary clutter to the UI.

This PR removes the Positions menu item from the sidebar and blocks all direct URL access to the module by returning a 404 for every Position route.

Removes the Positions <li> nav item from the sidebar
Routes all Position endpoints to a disabled() controller method that returns abort(404)
Adds feature tests verifying the sidebar link is gone and all GET/POST/DELETE routes return 404

Fixes: #466

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1440" height="860" alt="Screenshot 2026-04-26 at 1 54 20 AM" src="https://github.com/user-attachments/assets/1c424967-86dd-4705-9a8e-48cc2e6fb7f7" />

<img width="1440" height="866" alt="Screenshot 2026-04-26 at 1 55 14 AM" src="https://github.com/user-attachments/assets/ad912c76-d586-40af-bdb2-8ab90bf9978d" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [x] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin at http://test.tadreeblms.com/
2. Observe the left sidebar — "Positions" menu item should no longer be visible
3. Navigate directly to /backend/position — should return a 404 page

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [x] Updated documentation (if needed)
- [x] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

The Position routes are intentionally kept in the routes file (pointed to PositionController@disabled) rather than deleted outright. This makes it easy to re-enable the module in the future by simply swapping the controller methods back — the route structure is preserved.

