### PR TITLE
Hide Positions Menu From Sidebar (#446)

### DIFF
--- a/src/layouts/SidebarConfig.js
+++ b/src/layouts/SidebarConfig.js
@@ -1,0 +1,14 @@
+// Sidebar configuration - hide Positions menu item
+const sidebarItems = [
+  { label: 'Dashboard', icon: 'home', path: '/', visible: true },
+  { label: 'Courses', icon: 'book', path: '/courses', visible: true },
+  { label: 'Students', icon: 'users', path: '/students', visible: true },
+  { label: 'Positions', icon: 'briefcase', path: '/positions', visible: false },  // Hidden per #466
+  { label: 'Settings', icon: 'cog', path: '/settings', visible: true },
+];
+
+export function getVisibleItems() {
+  return sidebarItems.filter(item => item.visible !== false);
+}
+
+export default sidebarItems;


### PR DESCRIPTION
Added visible flag to sidebar config, set Positions to hidden. Closes #466