### PR TITLE
feat(kpi): team-level KPI insights with filters and comparisons (#428)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/TeamKpiInsightController.php
+++ b/app/Http/Controllers/Backend/Admin/TeamKpiInsightController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Backend\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Auth\User;
+use App\Models\Department;
+use App\Models\Kpi;
+use App\Services\Kpi\TeamKpiInsightService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+class TeamKpiInsightController extends Controller
+{
+    /**
+     * @var TeamKpiInsightService
+     */
+    protected $insightService;
+
+    public function __construct(TeamKpiInsightService $insightService)
+    {
+        $this->insightService = $insightService;
+    }
+
+    public function index(Request $request)
+    {
+        $user = auth()->user();
+
+        if (!Gate::allows('kpi_access')) {
+            return abort(401);
+        }
+
+        $request->validate([
+            'team_id' => 'nullable|integer',
+            'date_from' => 'nullable|date',
+            'date_to' => 'nullable|date|after_or_equal:date_from',
+        ]);
+
+        $teamsQuery = Department::query()->select('id', 'title', 'user_id')->orderBy('title');
+
+        $isManagerOnly = $user->hasRole('manager') && !$user->hasAnyRole(['administrator', 'teacher']);
+        if ($isManagerOnly) {
+            $teamsQuery->where('user_id', $user->id);
+        }
+
+        $teams = $teamsQuery->get();
+
+        $selectedTeamId = (int) $request->input('team_id', 0);
+        if ($selectedTeamId <= 0 && $teams->isNotEmpty()) {
+            $selectedTeamId = (int) $teams->first()->id;
+        }
+
+        if ($selectedTeamId > 0 && !$teams->contains('id', $selectedTeamId)) {
+            return abort(403);
+        }
+
+        $dateFrom = $request->filled('date_from') ? Carbon::parse($request->input('date_from'))->startOfDay() : null;
+        $dateTo = $request->filled('date_to') ? Carbon::parse($request->input('date_to'))->endOfDay() : null;
+
+        $members = collect();
+        $memberDirectory = [];
+        $insights = [
+            'kpi_summaries' => [],
+            'top_performers' => [],
+            'bottom_performers' => [],
+            'team_score_average' => null,
+            'team_member_count' => 0,
+            'evaluated_member_count' => 0,
+        ];
+
+        if ($selectedTeamId > 0) {
+            $members = User::query()
+                ->select('users.id', 'users.first_name', 'users.last_name', 'users.email')
+                ->join('employee_profiles', 'employee_profiles.user_id', '=', 'users.id')
+                ->where('employee_profiles.department', $selectedTeamId)
+                ->orderBy('users.first_name')
+                ->orderBy('users.last_name')
+                ->get();
+
+            $memberDirectory = $members->mapWithKeys(function ($member) {
+                $fullName = trim((string) $member->first_name . ' ' . (string) $member->last_name);
+                return [(int) $member->id => $fullName !== '' ? $fullName : ((string) $member->email ?: ('User #' . $member->id))];
+            })->all();
+
+            $kpis = Kpi::query()
+                ->where('is_active', true)
+                ->with('categories:id,name', 'courses:id')
+                ->orderBy('name')
+                ->get();
+
+            $insights = $this->insightService->buildInsights(
+                $kpis,
+                $members->pluck('id')->all(),
+                $memberDirectory,
+                $dateFrom,
+                $dateTo
+            );
+        }
+
+        return view('backend.kpis.team_insights', [
+            'teams' => $teams,
+            'selectedTeamId' => $selectedTeamId,
+            'dateFrom' => $request->input('date_from'),
+            'dateTo' => $request->input('date_to'),
+            'members' => $members,
+            'insights' => $insights,
+        ]);
+    }
+}

--- a/app/Services/Kpi/TeamKpiInsightService.php
+++ b/app/Services/Kpi/TeamKpiInsightService.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class TeamKpiInsightService
+{
+    /**
+     * @param Collection $kpis
+     * @param array $userIds
+     * @param array $memberDirectory
+     * @param Carbon|null $dateFrom
+     * @param Carbon|null $dateTo
+     * @return array
+     */
+    public function buildInsights(Collection $kpis, array $userIds, array $memberDirectory, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        $userIds = collect($userIds)
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->filter()
+            ->unique()
+            ->values()
+            ->toArray();
+
+        $memberScores = [];
+        foreach ($userIds as $userId) {
+            $memberScores[$userId] = [
+                'weighted_total' => 0.0,
+                'weight_total' => 0.0,
+            ];
+        }
+
+        $summaries = [];
+
+        foreach ($kpis as $kpi) {
+            $courseIds = method_exists($kpi, 'resolveScopedCourseIds') ? $kpi->resolveScopedCourseIds() : [];
+            $valuesByUser = $this->getValuesByUserForType((string) $kpi->type, $userIds, $courseIds, $dateFrom, $dateTo);
+
+            $ranked = collect($valuesByUser)
+                ->filter(function ($value) {
+                    return $value !== null;
+                })
+                ->map(function ($value, $userId) {
+                    return [
+                        'user_id' => (int) $userId,
+                        'value' => round((float) $value, 2),
+                    ];
+                })
+                ->sortByDesc('value')
+                ->values();
+
+            $evaluatedCount = $ranked->count();
+            $avg = $evaluatedCount > 0 ? round((float) $ranked->avg('value'), 2) : null;
+            $top = $evaluatedCount > 0 ? $ranked->first() : null;
+            $bottom = $evaluatedCount > 0 ? $ranked->last() : null;
+
+            $kpiWeight = (float) ($kpi->weight ?? 0);
+            foreach ($ranked as $entry) {
+                if (!isset($memberScores[$entry['user_id']])) {
+                    continue;
+                }
+
+                $memberScores[$entry['user_id']]['weighted_total'] += ((float) $entry['value']) * $kpiWeight;
+                $memberScores[$entry['user_id']]['weight_total'] += $kpiWeight;
+            }
+
+            $summaries[] = [
+                'id' => (int) $kpi->id,
+                'name' => (string) $kpi->name,
+                'code' => (string) $kpi->code,
+                'type' => (string) $kpi->type,
+                'type_label' => (string) ($kpi->type_label ?? ucfirst((string) $kpi->type)),
+                'weight' => round((float) $kpiWeight, 2),
+                'team_average' => $avg,
+                'members_evaluated' => $evaluatedCount,
+                'top_performer' => $this->resolvePerformerPayload($top, $memberDirectory),
+                'bottom_performer' => $this->resolvePerformerPayload($bottom, $memberDirectory),
+                'spread' => ($top && $bottom) ? round((float) $top['value'] - (float) $bottom['value'], 2) : null,
+            ];
+        }
+
+        $memberComparisons = collect($memberScores)
+            ->map(function ($score, $userId) use ($memberDirectory) {
+                $overall = $score['weight_total'] > 0
+                    ? round($score['weighted_total'] / $score['weight_total'], 2)
+                    : null;
+
+                return [
+                    'user_id' => (int) $userId,
+                    'name' => $memberDirectory[$userId] ?? ('User #' . $userId),
+                    'overall_score' => $overall,
+                ];
+            })
+            ->filter(function ($entry) {
+                return $entry['overall_score'] !== null;
+            })
+            ->sortByDesc('overall_score')
+            ->values();
+
+        return [
+            'kpi_summaries' => $summaries,
+            'top_performers' => $memberComparisons->take(5)->values()->all(),
+            'bottom_performers' => $memberComparisons->sortBy('overall_score')->take(5)->values()->all(),
+            'team_score_average' => $memberComparisons->isNotEmpty() ? round((float) $memberComparisons->avg('overall_score'), 2) : null,
+            'team_member_count' => count($userIds),
+            'evaluated_member_count' => $memberComparisons->count(),
+        ];
+    }
+
+    /**
+     * @param string $type
+     * @param array $userIds
+     * @param array $courseIds
+     * @param Carbon|null $dateFrom
+     * @param Carbon|null $dateTo
+     * @return array<int, float|null>
+     */
+    protected function getValuesByUserForType(string $type, array $userIds, array $courseIds, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        $result = [];
+        foreach ($userIds as $userId) {
+            $result[(int) $userId] = null;
+        }
+
+        if (empty($userIds)) {
+            return $result;
+        }
+
+        $metricRows = [];
+        switch ($type) {
+            case 'completion':
+                $metricRows = $this->completionByUser($userIds, $courseIds, $dateFrom, $dateTo);
+                break;
+            case 'score':
+                $metricRows = $this->scoreByUser($userIds, $courseIds, $dateFrom, $dateTo);
+                break;
+            case 'activity':
+                $metricRows = $this->activityByUser($userIds, $dateFrom, $dateTo);
+                break;
+            case 'time':
+                $metricRows = $this->timeByUser($userIds, $dateFrom, $dateTo);
+                break;
+            default:
+                return $result;
+        }
+
+        foreach ($metricRows as $userId => $value) {
+            $id = (int) $userId;
+            if (!array_key_exists($id, $result)) {
+                continue;
+            }
+            $result[$id] = round((float) $value, 2);
+        }
+
+        return $result;
+    }
+
+    protected function completionByUser(array $userIds, array $courseIds, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        if (!Schema::hasTable('subscribe_courses') || !Schema::hasColumn('subscribe_courses', 'user_id')) {
+            return [];
+        }
+
+        $query = DB::table('subscribe_courses')
+            ->select('user_id', DB::raw('AVG(CASE WHEN is_completed = 1 THEN 100 ELSE 0 END) as metric'))
+            ->whereIn('user_id', $userIds)
+            ->groupBy('user_id');
+
+        if (Schema::hasColumn('subscribe_courses', 'deleted_at')) {
+            $query->whereNull('deleted_at');
+        }
+
+        if (!empty($courseIds) && Schema::hasColumn('subscribe_courses', 'course_id')) {
+            $query->whereIn('course_id', $courseIds);
+        }
+
+        if (Schema::hasColumn('subscribe_courses', 'completed_at')) {
+            $this->applyDateRange($query, 'completed_at', $dateFrom, $dateTo);
+        } elseif (Schema::hasColumn('subscribe_courses', 'updated_at')) {
+            $this->applyDateRange($query, 'updated_at', $dateFrom, $dateTo);
+        } elseif (Schema::hasColumn('subscribe_courses', 'created_at')) {
+            $this->applyDateRange($query, 'created_at', $dateFrom, $dateTo);
+        }
+
+        return $query->pluck('metric', 'user_id')->toArray();
+    }
+
+    protected function scoreByUser(array $userIds, array $courseIds, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        if (!Schema::hasTable('tests_results') || !Schema::hasColumn('tests_results', 'user_id')) {
+            return [];
+        }
+
+        $query = DB::table('tests_results')
+            ->select('tests_results.user_id', DB::raw('AVG(tests_results.test_result) as metric'))
+            ->whereIn('tests_results.user_id', $userIds)
+            ->groupBy('tests_results.user_id');
+
+        if (Schema::hasTable('tests') && Schema::hasColumn('tests_results', 'test_id') && Schema::hasColumn('tests', 'id')) {
+            $query->join('tests', 'tests.id', '=', 'tests_results.test_id');
+            if (!empty($courseIds) && Schema::hasColumn('tests', 'course_id')) {
+                $query->whereIn('tests.course_id', $courseIds);
+            }
+            if (Schema::hasColumn('tests', 'deleted_at')) {
+                $query->whereNull('tests.deleted_at');
+            }
+        }
+
+        if (Schema::hasColumn('tests_results', 'created_at')) {
+            $this->applyDateRange($query, 'tests_results.created_at', $dateFrom, $dateTo);
+        }
+
+        return $query->pluck('metric', 'tests_results.user_id')->toArray();
+    }
+
+    protected function activityByUser(array $userIds, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        if (Schema::hasTable('lms_kpi_events') && Schema::hasColumn('lms_kpi_events', 'user_id')) {
+            $query = DB::table('lms_kpi_events')
+                ->select('user_id', DB::raw('LEAST(100, COUNT(*) * 10) as metric'))
+                ->whereIn('user_id', $userIds)
+                ->groupBy('user_id');
+
+            if (Schema::hasColumn('lms_kpi_events', 'occurred_at')) {
+                $this->applyDateRange($query, 'occurred_at', $dateFrom, $dateTo);
+            }
+
+            return $query->pluck('metric', 'user_id')->toArray();
+        }
+
+        return [];
+    }
+
+    protected function timeByUser(array $userIds, ?Carbon $dateFrom, ?Carbon $dateTo): array
+    {
+        if (!Schema::hasTable('video_progresses') || !Schema::hasColumn('video_progresses', 'user_id')) {
+            return [];
+        }
+
+        $query = DB::table('video_progresses')
+            ->select('user_id', DB::raw('LEAST(100, SUM(progress) / 60) as metric'))
+            ->whereIn('user_id', $userIds)
+            ->groupBy('user_id');
+
+        if (Schema::hasColumn('video_progresses', 'updated_at')) {
+            $this->applyDateRange($query, 'updated_at', $dateFrom, $dateTo);
+        } elseif (Schema::hasColumn('video_progresses', 'created_at')) {
+            $this->applyDateRange($query, 'created_at', $dateFrom, $dateTo);
+        }
+
+        return $query->pluck('metric', 'user_id')->toArray();
+    }
+
+    /**
+     * @param mixed $performer
+     * @param array $memberDirectory
+     * @return array|null
+     */
+    protected function resolvePerformerPayload($performer, array $memberDirectory): ?array
+    {
+        if (!$performer) {
+            return null;
+        }
+
+        $userId = (int) ($performer['user_id'] ?? 0);
+
+        return [
+            'user_id' => $userId,
+            'name' => $memberDirectory[$userId] ?? ('User #' . $userId),
+            'value' => round((float) ($performer['value'] ?? 0), 2),
+        ];
+    }
+
+    /**
+     * @param mixed $query
+     * @param string $column
+     * @param Carbon|null $dateFrom
+     * @param Carbon|null $dateTo
+     * @return void
+     */
+    protected function applyDateRange($query, string $column, ?Carbon $dateFrom, ?Carbon $dateTo): void
+    {
+        if ($dateFrom) {
+            $query->where($column, '>=', $dateFrom->copy()->startOfDay());
+        }
+
+        if ($dateTo) {
+            $query->where($column, '<=', $dateTo->copy()->endOfDay());
+        }
+    }
+}

--- a/resources/views/backend/kpis/index.blade.php
+++ b/resources/views/backend/kpis/index.blade.php
@@ -15,6 +15,8 @@
                 <a href="{{ route('admin.kpi-templates.index') }}" class="btn btn-outline-secondary mr-2">Templates</a>
             @endcan
 
+            <a href="{{ route('admin.kpis.team-insights') }}" class="btn btn-outline-secondary mr-2">Team Insights</a>
+
             @can('kpi_target_access')
                 <a href="{{ route('admin.kpi-targets.index') }}" class="btn btn-outline-secondary mr-2">Manage Targets</a>
             @endcan

--- a/resources/views/backend/kpis/team_insights.blade.php
+++ b/resources/views/backend/kpis/team_insights.blade.php
@@ -1,0 +1,194 @@
+@extends('backend.layouts.app')
+
+@section('title', 'Team KPI Insights | ' . app_name())
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center pb-3">
+        <h4 class="mb-0">Team KPI Insights</h4>
+        <a href="{{ route('admin.kpis.index') }}" class="btn btn-outline-secondary">Back to KPI Management</a>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <form method="GET" action="{{ route('admin.kpis.team-insights') }}">
+                <div class="form-row align-items-end">
+                    <div class="col-md-4 mb-2">
+                        <label for="team_id">Team</label>
+                        <select id="team_id" name="team_id" class="form-control" required>
+                            <option value="">Select team</option>
+                            @foreach($teams as $team)
+                                <option value="{{ $team->id }}" {{ (int) $selectedTeamId === (int) $team->id ? 'selected' : '' }}>
+                                    {{ $team->title ?: ('Team #' . $team->id) }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="col-md-3 mb-2">
+                        <label for="date_from">From</label>
+                        <input type="date" id="date_from" name="date_from" class="form-control" value="{{ $dateFrom }}">
+                    </div>
+
+                    <div class="col-md-3 mb-2">
+                        <label for="date_to">To</label>
+                        <input type="date" id="date_to" name="date_to" class="form-control" value="{{ $dateTo }}">
+                    </div>
+
+                    <div class="col-md-2 mb-2">
+                        <button type="submit" class="btn btn-primary btn-block">Apply</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if($teams->isEmpty())
+        <div class="alert alert-warning">
+            No teams are available for your account.
+        </div>
+    @else
+        <div class="row mb-3">
+            <div class="col-md-4">
+                <div class="card border-left-primary h-100">
+                    <div class="card-body">
+                        <small class="text-muted text-uppercase">Team Members</small>
+                        <div class="h4 mb-0">{{ $insights['team_member_count'] }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card border-left-success h-100">
+                    <div class="card-body">
+                        <small class="text-muted text-uppercase">Evaluated Members</small>
+                        <div class="h4 mb-0">{{ $insights['evaluated_member_count'] }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card border-left-info h-100">
+                    <div class="card-body">
+                        <small class="text-muted text-uppercase">Team Average Score</small>
+                        <div class="h4 mb-0">
+                            @if($insights['team_score_average'] === null)
+                                <span class="text-muted">N/A</span>
+                            @else
+                                {{ number_format((float) $insights['team_score_average'], 2) }}
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header">Team-Level KPI Metrics</div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped table-bordered mb-0">
+                        <thead>
+                            <tr>
+                                <th>KPI</th>
+                                <th>Type</th>
+                                <th>Weight</th>
+                                <th>Team Average</th>
+                                <th>Members Evaluated</th>
+                                <th>Top Performer</th>
+                                <th>Bottom Performer</th>
+                                <th>Spread</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($insights['kpi_summaries'] as $summary)
+                                <tr>
+                                    <td>
+                                        <strong>{{ $summary['name'] }}</strong>
+                                        <div class="text-muted small">{{ $summary['code'] }}</div>
+                                    </td>
+                                    <td>{{ $summary['type_label'] }}</td>
+                                    <td>{{ number_format((float) $summary['weight'], 2) }}</td>
+                                    <td>
+                                        @if($summary['team_average'] === null)
+                                            <span class="text-muted">N/A</span>
+                                        @else
+                                            {{ number_format((float) $summary['team_average'], 2) }}
+                                        @endif
+                                    </td>
+                                    <td>{{ $summary['members_evaluated'] }}</td>
+                                    <td>
+                                        @if($summary['top_performer'])
+                                            {{ $summary['top_performer']['name'] }}
+                                            <div class="text-success small">{{ number_format((float) $summary['top_performer']['value'], 2) }}</div>
+                                        @else
+                                            <span class="text-muted">N/A</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($summary['bottom_performer'])
+                                            {{ $summary['bottom_performer']['name'] }}
+                                            <div class="text-danger small">{{ number_format((float) $summary['bottom_performer']['value'], 2) }}</div>
+                                        @else
+                                            <span class="text-muted">N/A</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($summary['spread'] === null)
+                                            <span class="text-muted">N/A</span>
+                                        @else
+                                            {{ number_format((float) $summary['spread'], 2) }}
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="8" class="text-center text-muted">No active KPI data found for the selected filters.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-header">Top Performers</div>
+                    <div class="card-body">
+                        @if(!empty($insights['top_performers']))
+                            <ul class="list-group list-group-flush">
+                                @foreach($insights['top_performers'] as $performer)
+                                    <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                        <span>{{ $performer['name'] }}</span>
+                                        <span class="badge badge-success">{{ number_format((float) $performer['overall_score'], 2) }}</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        @else
+                            <p class="text-muted mb-0">No performer ranking available for the selected filters.</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-header">Bottom Performers</div>
+                    <div class="card-body">
+                        @if(!empty($insights['bottom_performers']))
+                            <ul class="list-group list-group-flush">
+                                @foreach($insights['bottom_performers'] as $performer)
+                                    <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                        <span>{{ $performer['name'] }}</span>
+                                        <span class="badge badge-warning">{{ number_format((float) $performer['overall_score'], 2) }}</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        @else
+                            <p class="text-muted mb-0">No performer ranking available for the selected filters.</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+@endsection

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -49,6 +49,10 @@ Route::group(['middleware' => ['role:teacher|administrator']], function () {
     Route::post('kpi-templates/{kpiTemplate}/apply', 'Admin\KpiTemplateController@apply')->name('kpi-templates.apply');
 });
 
+Route::group(['middleware' => ['permission:kpi_access']], function () {
+    Route::get('kpis/team-insights', 'Admin\TeamKpiInsightController@index')->name('kpis.team-insights');
+});
+
 Route::group(['middleware' => 'role:teacher|administrator'], function () {
     Route::resource('orders', 'Admin\OrderController');
 });


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR adds manager-ready team KPI insights with aggregated metrics, comparisons, and filterable analysis.

### Problem Solved

Previously:

- KPI management focused on KPI definitions and current KPI values, but lacked a team-level performance view.
- Managers could not easily compare team members with top/bottom highlights.
- No unified filter for team + date range in KPI team analysis.

### What This PR Adds

- Team-level KPI insights page for users with KPI access.
- Team filter and date range filter for KPI analysis.
- Aggregated KPI summaries per team:
  - Team average
  - Members evaluated
  - Spread (top minus bottom)
  - KPI-level top performer and bottom performer
- Overall top 5 / bottom 5 performer comparison based on weighted KPI score.
- Navigation entry from KPI management to Team Insights.
- Permission-consistent routing and controller checks aligned with existing ACL (`kpi_access`).

Fixes: https://github.com/Tadreeb-LMS/tadreeblms/issues/428

## ✅ Type of Change

- New feature
- UI/UX update
- Backend enhancement

## 📸 Screenshots

- N/A 

## 🚀 How Has This Been Tested?

- PHP syntax checks:
  - `php -l app/Http/Controllers/Backend/Admin/TeamKpiInsightController.php`
  - `php -l app/Services/Kpi/TeamKpiInsightService.php`
- Route registration check:
  - `php artisan route:list --name=kpis.team-insights`
- Editor diagnostics checks for modified/new files: no errors.

### Test Scenarios

- Open Team Insights from KPI management.
- Filter by team only.
- Filter by team + date range.
- Verify aggregated KPI table shows team average and members evaluated.
- Verify top/bottom performer blocks populate correctly.
- Verify users without KPI permission cannot access the route.

## 🧪 Steps to Reproduce (for validation)

1. Login with a user that has `kpi_access`.
2. Navigate to KPI Management and click Team Insights.
3. Select a team and optional date range.
4. Verify team-level KPI summaries and top/bottom performers render correctly.
5. Compare with a different team/date range and confirm values update as expected.

## 🔄 Checklist

- Followed the project's coding guidelines
- Updated relevant UI navigation for discoverability
- Verified no sensitive data is included
- Ensured route/controller permissions are aligned with existing ACL patterns
- Ensured feature-level checks pass without syntax/diagnostic errors
