### PR TITLE
feat(kpi): admin-configurable KPI dashboard widgets (#430)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/KpiDashboardController.php
+++ b/app/Http/Controllers/Backend/Admin/KpiDashboardController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Backend\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Kpi\KpiDashboardConfigService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+
+class KpiDashboardController extends Controller
+{
+    protected $configService;
+
+    public function __construct(KpiDashboardConfigService $configService)
+    {
+        $this->configService = $configService;
+    }
+
+    public function edit()
+    {
+        $user = Auth::user();
+
+        if (!$user || !$user->hasRole('administrator') || !Gate::allows('kpi_edit')) {
+            return abort(403);
+        }
+
+        $configuration = $this->configService->getEditableConfiguration();
+
+        return view('backend.kpis.dashboard_settings', $configuration);
+    }
+
+    public function update(Request $request)
+    {
+        $user = Auth::user();
+
+        if (!$user || !$user->hasRole('administrator') || !Gate::allows('kpi_edit')) {
+            return abort(403);
+        }
+
+        $validated = $request->validate([
+            'visible_kpis' => 'nullable|array|max:8',
+            'visible_kpis.*' => 'integer|distinct|exists:kpis,id',
+            'presentation' => 'nullable|array',
+            'presentation.*' => 'nullable|string|in:compact,detail',
+            'display_order' => 'nullable|array',
+            'display_order.*' => 'nullable|integer|min:1|max:99',
+        ]);
+
+        $this->configService->updateConfiguration(
+            $validated['visible_kpis'] ?? [],
+            $validated['presentation'] ?? [],
+            $validated['display_order'] ?? [],
+            $user->id
+        );
+
+        return redirect()
+            ->route('admin.kpis.dashboard-settings.edit')
+            ->withFlashSuccess('KPI dashboard settings updated successfully.');
+    }
+}

--- a/app/Models/KpiDashboardSetting.php
+++ b/app/Models/KpiDashboardSetting.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Auth\User;
+use Illuminate\Database\Eloquent\Model;
+
+class KpiDashboardSetting extends Model
+{
+    protected $fillable = [
+        'scope',
+        'widgets',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'widgets' => 'array',
+    ];
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updater()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/app/Services/Kpi/KpiDashboardConfigService.php
+++ b/app/Services/Kpi/KpiDashboardConfigService.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use App\Models\Kpi;
+use App\Models\KpiDashboardSetting;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class KpiDashboardConfigService
+{
+    public const SCOPE = 'global';
+    public const PRESENTATION_COMPACT = 'compact';
+    public const PRESENTATION_DETAIL = 'detail';
+
+    protected $snapshotService;
+
+    public function __construct(KpiSnapshotService $snapshotService)
+    {
+        $this->snapshotService = $snapshotService;
+    }
+
+    public function getEditableConfiguration(): array
+    {
+        $setting = $this->ensureDefaultConfiguration();
+        $widgets = collect($setting ? ($setting->widgets ?? []) : []);
+        $widgetMap = $widgets->keyBy(function (array $widget) {
+            return (int) ($widget['kpi_id'] ?? 0);
+        });
+
+        $activeKpis = Kpi::query()
+            ->where('is_active', true)
+            ->orderByDesc('weight')
+            ->orderBy('name')
+            ->get(['id', 'name', 'code', 'type', 'weight']);
+
+        return [
+            'setting' => $setting,
+            'active_kpis' => $activeKpis,
+            'selected_ids' => $widgets->pluck('kpi_id')->map(function ($id) {
+                return (int) $id;
+            })->all(),
+            'widget_map' => $widgetMap,
+        ];
+    }
+
+    public function updateConfiguration(array $selectedKpiIds, array $presentations, array $displayOrder, ?int $actorId = null): KpiDashboardSetting
+    {
+        $selectedKpiIds = collect($selectedKpiIds)
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->filter()
+            ->unique()
+            ->values();
+
+        $validIds = Kpi::query()
+            ->where('is_active', true)
+            ->whereIn('id', $selectedKpiIds->all())
+            ->pluck('id')
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->all();
+
+        $widgets = collect($validIds)
+            ->map(function (int $kpiId, int $index) use ($presentations, $displayOrder) {
+                $presentation = (string) ($presentations[$kpiId] ?? self::PRESENTATION_COMPACT);
+                if (!in_array($presentation, [self::PRESENTATION_COMPACT, self::PRESENTATION_DETAIL], true)) {
+                    $presentation = self::PRESENTATION_COMPACT;
+                }
+
+                return [
+                    'kpi_id' => $kpiId,
+                    'presentation' => $presentation,
+                    'display_order' => max(1, (int) ($displayOrder[$kpiId] ?? ($index + 1))),
+                ];
+            })
+            ->sortBy([
+                ['display_order', 'asc'],
+                ['kpi_id', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        $setting = $this->tableExists()
+            ? KpiDashboardSetting::query()->firstOrNew(['scope' => self::SCOPE])
+            : new KpiDashboardSetting(['scope' => self::SCOPE]);
+
+        $setting->widgets = $widgets;
+
+        if (!$setting->exists) {
+            $setting->created_by = $actorId;
+        }
+
+        $setting->updated_by = $actorId;
+        $setting->save();
+
+        return $setting;
+    }
+
+    public function getDashboardWidgets(): array
+    {
+        $setting = $this->ensureDefaultConfiguration();
+        $configuredWidgets = collect($setting ? ($setting->widgets ?? []) : []);
+        $selectedIds = $configuredWidgets->pluck('kpi_id')->map(function ($id) {
+            return (int) $id;
+        })->filter()->values()->all();
+
+        if (empty($selectedIds)) {
+            return [
+                'widgets' => [],
+                'setting' => $setting,
+            ];
+        }
+
+        $activeKpis = Kpi::query()
+            ->where('is_active', true)
+            ->whereIn('id', $selectedIds)
+            ->with('categories:id,name', 'courses:id', 'currentSnapshot')
+            ->get()
+            ->keyBy('id');
+
+        if ($activeKpis->isEmpty()) {
+            return [
+                'widgets' => [],
+                'setting' => $setting,
+            ];
+        }
+
+        $totalActiveWeight = (float) Kpi::query()->where('is_active', true)->sum('weight');
+        $calculatedKpis = $this->snapshotService
+            ->attachCalculations($activeKpis->values(), $totalActiveWeight)
+            ->keyBy('id');
+
+        $widgets = $configuredWidgets
+            ->map(function (array $widget) use ($calculatedKpis) {
+                $kpiId = (int) ($widget['kpi_id'] ?? 0);
+                $kpi = $calculatedKpis->get($kpiId);
+                if (!$kpi) {
+                    return null;
+                }
+
+                $presentation = (string) ($widget['presentation'] ?? self::PRESENTATION_COMPACT);
+                if (!in_array($presentation, [self::PRESENTATION_COMPACT, self::PRESENTATION_DETAIL], true)) {
+                    $presentation = self::PRESENTATION_COMPACT;
+                }
+
+                $kpi->dashboard_presentation = $presentation;
+                $kpi->dashboard_display_order = (int) ($widget['display_order'] ?? 0);
+
+                return $kpi;
+            })
+            ->filter()
+            ->values();
+
+        return [
+            'widgets' => $widgets,
+            'setting' => $setting,
+        ];
+    }
+
+    protected function ensureDefaultConfiguration(): ?KpiDashboardSetting
+    {
+        if (!$this->tableExists()) {
+            return null;
+        }
+
+        $setting = KpiDashboardSetting::query()->firstOrNew(['scope' => self::SCOPE]);
+        if ($setting->exists && is_array($setting->widgets) && !empty($setting->widgets)) {
+            return $setting;
+        }
+
+        $defaultIds = Kpi::query()
+            ->where('is_active', true)
+            ->orderByDesc('weight')
+            ->orderBy('name')
+            ->limit(4)
+            ->pluck('id')
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->values()
+            ->all();
+
+        $setting->widgets = collect($defaultIds)
+            ->map(function (int $id, int $index) {
+                return [
+                    'kpi_id' => $id,
+                    'presentation' => $index === 0 ? self::PRESENTATION_DETAIL : self::PRESENTATION_COMPACT,
+                    'display_order' => $index + 1,
+                ];
+            })
+            ->all();
+
+        $setting->save();
+
+        return $setting;
+    }
+
+    protected function tableExists(): bool
+    {
+        return Schema::hasTable('kpi_dashboard_settings');
+    }
+}

--- a/database/migrations/2026_04_28_120000_create_kpi_dashboard_settings_table.php
+++ b/database/migrations/2026_04_28_120000_create_kpi_dashboard_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('kpi_dashboard_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('scope')->default('global')->unique();
+            $table->json('widgets')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_dashboard_settings');
+    }
+};

--- a/resources/views/backend/dashboard/partials/kpi_widgets.blade.php
+++ b/resources/views/backend/dashboard/partials/kpi_widgets.blade.php
@@ -1,0 +1,91 @@
+@php
+    $presentationClassMap = [
+        'compact' => 'col-lg-3 col-md-6',
+        'detail' => 'col-lg-6 col-md-12',
+    ];
+@endphp
+
+<div class="row">
+    <div class="col-12 mb-2 d-flex justify-content-between align-items-center">
+        <div>
+            <h5 class="mb-1">KPI Dashboard</h5>
+            <p class="text-muted mb-0">Visible KPI cards are controlled from KPI dashboard settings.</p>
+        </div>
+
+        @if(auth()->user()->hasRole('administrator') && auth()->user()->can('kpi_edit'))
+            <a href="{{ route('admin.kpis.dashboard-settings.edit') }}" class="btn btn-outline-primary btn-sm">Configure KPI Cards</a>
+        @endif
+    </div>
+
+    @foreach($dashboardKpiWidgets as $kpi)
+        @php
+            $presentation = $kpi->dashboard_presentation ?? 'compact';
+            $cardColumnClass = $presentationClassMap[$presentation] ?? $presentationClassMap['compact'];
+            $value = $kpi->calculation['value'] ?? null;
+            $weightedScore = $kpi->calculation['weighted_score'] ?? null;
+            $target = $kpi->calculation['target'] ?? null;
+            $deviationDirection = $kpi->calculation['deviation_direction'] ?? null;
+            $targetBadgeClass = $deviationDirection === 'over'
+                ? 'badge-success'
+                : ($deviationDirection === 'under' ? 'badge-warning' : 'badge-secondary');
+            $categoryNames = $kpi->categories->pluck('name')->filter()->take(3)->implode(', ');
+        @endphp
+
+        <div class="{{ $cardColumnClass }} mb-3">
+            <div class="card h-100 kpi-dashboard-card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                        <div>
+                            <div class="text-muted small text-uppercase">{{ $kpi->code }}</div>
+                            <h5 class="mb-1">{{ $kpi->name }}</h5>
+                            <div class="text-muted small">{{ $kpi->type_label }}</div>
+                        </div>
+                        <span class="badge badge-light">Weight {{ number_format((float) $kpi->weight, 2) }}</span>
+                    </div>
+
+                    <div class="kpi-dashboard-value mb-2">
+                        @if($value === null || ($kpi->calculation['excluded'] ?? false))
+                            <span class="text-muted">No data</span>
+                        @else
+                            {{ number_format((float) $value, 2) }}
+                        @endif
+                    </div>
+
+                    @if($presentation === 'detail')
+                        <div class="row text-muted small">
+                            <div class="col-sm-6 mb-2">
+                                <strong class="d-block text-dark">Weighted Score</strong>
+                                {{ $weightedScore === null ? 'N/A' : number_format((float) $weightedScore, 2) }}
+                            </div>
+                            <div class="col-sm-6 mb-2">
+                                <strong class="d-block text-dark">Target</strong>
+                                {{ $target === null ? 'No target' : number_format((float) $target, 2) }}
+                            </div>
+                            <div class="col-sm-6 mb-2">
+                                <strong class="d-block text-dark">Target Status</strong>
+                                <span class="badge {{ $targetBadgeClass }}">
+                                    {{ $deviationDirection ? ucfirst(str_replace('_', ' ', $deviationDirection)) : 'Not set' }}
+                                </span>
+                            </div>
+                            <div class="col-sm-6 mb-2">
+                                <strong class="d-block text-dark">Categories</strong>
+                                {{ $categoryNames !== '' ? $categoryNames : 'All / unmapped' }}
+                            </div>
+                        </div>
+                    @else
+                        <div class="d-flex justify-content-between text-muted small">
+                            <span>Weighted: {{ $weightedScore === null ? 'N/A' : number_format((float) $weightedScore, 2) }}</span>
+                            <span>
+                                @if($target === null)
+                                    No target
+                                @else
+                                    Target {{ number_format((float) $target, 2) }}
+                                @endif
+                            </span>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/backend/kpis/dashboard_settings.blade.php
+++ b/resources/views/backend/kpis/dashboard_settings.blade.php
@@ -1,0 +1,96 @@
+@extends('backend.layouts.app')
+
+@section('title', 'KPI Dashboard Settings | ' . app_name())
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center pb-3">
+        <div>
+            <h4 class="mb-1">KPI Dashboard Settings</h4>
+            <p class="text-muted mb-0">Choose up to 8 active KPIs and a simple presentation mode for the dashboard.</p>
+        </div>
+
+        <a href="{{ route('admin.kpis.index') }}" class="btn btn-secondary">Back to KPIs</a>
+    </div>
+
+    <div class="alert alert-info">
+        A default dashboard configuration is created automatically from active KPIs if none exists yet.
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="POST" action="{{ route('admin.kpis.dashboard-settings.update') }}">
+                @csrf
+
+                <div class="table-responsive">
+                    <table class="table table-bordered align-middle">
+                        <thead>
+                            <tr>
+                                <th style="width: 90px;">Visible</th>
+                                <th>KPI</th>
+                                <th style="width: 140px;">Code</th>
+                                <th style="width: 140px;">Weight</th>
+                                <th style="width: 180px;">Presentation</th>
+                                <th style="width: 160px;">Display Order</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($active_kpis as $kpi)
+                                @php
+                                    $widget = $widget_map->get($kpi->id);
+                                    $isVisible = in_array($kpi->id, $selected_ids, true);
+                                @endphp
+                                <tr>
+                                    <td class="text-center">
+                                        <input
+                                            type="checkbox"
+                                            name="visible_kpis[]"
+                                            value="{{ $kpi->id }}"
+                                            {{ $isVisible ? 'checked' : '' }}
+                                        >
+                                    </td>
+                                    <td>
+                                        <strong>{{ $kpi->name }}</strong>
+                                        <div class="text-muted small">{{ ucfirst($kpi->type) }}</div>
+                                    </td>
+                                    <td>{{ $kpi->code }}</td>
+                                    <td>{{ number_format((float) $kpi->weight, 2) }}</td>
+                                    <td>
+                                        <select name="presentation[{{ $kpi->id }}]" class="form-control">
+                                            <option value="compact" {{ ($widget['presentation'] ?? 'compact') === 'compact' ? 'selected' : '' }}>Compact card</option>
+                                            <option value="detail" {{ ($widget['presentation'] ?? '') === 'detail' ? 'selected' : '' }}>Detailed card</option>
+                                        </select>
+                                    </td>
+                                    <td>
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            max="99"
+                                            name="display_order[{{ $kpi->id }}]"
+                                            value="{{ old('display_order.' . $kpi->id, $widget['display_order'] ?? 99) }}"
+                                            class="form-control"
+                                        >
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted">No active KPIs are available for dashboard display yet.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                @if($errors->any())
+                    <div class="alert alert-danger mt-3 mb-0">
+                        {{ $errors->first() }}
+                    </div>
+                @endif
+
+                <div class="mt-3 d-flex justify-content-between align-items-center">
+                    <small class="text-muted">Detailed cards show more KPI context. Compact cards keep the dashboard denser.</small>
+                    <button type="submit" class="btn btn-primary">Save Dashboard Settings</button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection


### PR DESCRIPTION

Fixes #430

## 🔧 Description
This PR allows administrators to control which KPIs are visible on dashboards and how each KPI card is presented, using a simple persisted global configuration.
### Problem Solved

Previously:
- KPI visibility and presentation on dashboards were not admin-configurable.
### What This PR Adds
- A persisted global KPI dashboard configuration (with default auto-generated configuration).
- Admin UI to select visible KPIs (up to 8), set display order, and choose a simple presentation mode per KPI (compact/detail).
- KPI cards rendered from existing KPI calculations/snapshots to keep behavior consistent.
## ✅ Type of Change
- New feature
- Backend enhancement
- UI/UX update
## 🚀 How Has This Been Tested?
- PHP syntax checks:
  - `php -l app/Models/KpiDashboardSetting.php`
  - `php -l app/Services/Kpi/KpiDashboardConfigService.php`
  - `php -l app/Http/Controllers/Backend/Admin/KpiDashboardController.php`
  - `php -l database/migrations/2026_04_28_120000_create_kpi_dashboard_settings_table.php`

## Screenshots 

<img width="1139" height="873" alt="Screenshot_20260428_115928" src="https://github.com/user-attachments/assets/06db9e35-964b-4a80-ae3e-e251b8210dfc" />

---

<img width="1139" height="873" alt="Screenshot_20260428_120033" src="https://github.com/user-attachments/assets/3ea9755a-74a5-4bde-bd6b-543e54de7fdd" />


### Test Scenarios
1. Login as administrator.
2. Go to KPI Management and open `Dashboard Layout`.
3. Select KPIs + presentation + order and save.
4. Verify dashboard KPI cards update accordingly.
## 🔄 Checklist
- Scoped only to Issue #430
- Default configuration exists
- Configuration is intentionally minimal (visibility, order, compact/detail)
