### PR TITLE
Fix KPI RBAC permissions

### DIFF
--- a/app/Http/Controllers/Backend/Admin/RolesController.php
+++ b/app/Http/Controllers/Backend/Admin/RolesController.php
@@ -12,6 +12,8 @@ use Spatie\Permission\Models\Permission;
 
 class RolesController extends Controller
 {
+    private const PERMISSION_ACTIONS = ['access', 'create', 'edit', 'view', 'delete'];
+
     /**
      * Display a listing of Role.
      *
@@ -42,7 +44,7 @@ class RolesController extends Controller
         }
 
         $permissions = Permission::all()->groupBy(function ($perm) {
-            return explode('_', $perm->name)[0]; // e.g., 'user', 'course', 'lesson'
+            return $this->permissionModule($perm->name);
         });
 
         return view('backend.roles.create', compact('permissions'));
@@ -86,7 +88,7 @@ class RolesController extends Controller
             return abort(401);
         }
         $permissions = Permission::all()->groupBy(function ($perm) {
-            return explode('_', $perm->name)[0];
+            return $this->permissionModule($perm->name);
         });
 
         $role = Role::findOrFail($id);
@@ -244,5 +246,17 @@ class RolesController extends Controller
         });
 
         return redirect()->route('admin.roles.index');
+    }
+
+    private function permissionModule(string $permissionName): string
+    {
+        $parts = explode('_', $permissionName);
+        $action = end($parts);
+
+        if (in_array($action, self::PERMISSION_ACTIONS, true) && count($parts) > 1) {
+            array_pop($parts);
+        }
+
+        return implode('_', $parts);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 use Laravel\Passport\Passport;
 
 /**
@@ -27,7 +28,44 @@ class AuthServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPolicies();
+        $this->registerGates();
+    }
 
+    /**
+     * Register all gate definitions for permission checks.
+     *
+     * @return void
+     */
+    protected function registerGates()
+    {
+        // KPI Module Gates
+        $kpiPermissions = [
+            'kpi_access',
+            'kpi_create',
+            'kpi_edit',
+            'kpi_view',
+            'kpi_delete',
+            'kpi_role_config_access',
+            'kpi_role_config_create',
+            'kpi_role_config_edit',
+            'kpi_role_config_view',
+            'kpi_role_config_delete',
+            'kpi_target_access',
+            'kpi_target_create',
+            'kpi_target_edit',
+            'kpi_target_view',
+            'kpi_target_delete',
+            'kpi_template_access',
+            'kpi_template_create',
+            'kpi_template_edit',
+            'kpi_template_view',
+            'kpi_template_delete',
+        ];
 
+        foreach ($kpiPermissions as $permission) {
+            Gate::define($permission, function ($user) use ($permission) {
+                return $user->checkPermissionTo($permission);
+            });
+        }
     }
 }

--- a/database/migrations/2026_04_30_000000_add_kpi_permissions.php
+++ b/database/migrations/2026_04_30_000000_add_kpi_permissions.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return new class extends Migration {
+    public function up()
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $modules = [
+            'kpi',
+            'kpi_role_config',
+            'kpi_target',
+            'kpi_template',
+        ];
+
+        $actions = ['access', 'create', 'edit', 'view', 'delete'];
+        $permissions = collect();
+
+        foreach ($modules as $module) {
+            foreach ($actions as $action) {
+                $permissions->push(Permission::firstOrCreate([
+                    'name' => "{$module}_{$action}",
+                    'guard_name' => 'web',
+                ]));
+            }
+        }
+
+        $adminRoleName = config('access.users.admin_role');
+        Role::whereIn('name', array_filter([$adminRoleName, 'teacher']))
+            ->get()
+            ->each(function (Role $role) use ($permissions) {
+                $role->givePermissionTo($permissions);
+            });
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function down()
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        Permission::whereIn('name', [
+            'kpi_access',
+            'kpi_create',
+            'kpi_edit',
+            'kpi_view',
+            'kpi_delete',
+            'kpi_role_config_access',
+            'kpi_role_config_create',
+            'kpi_role_config_edit',
+            'kpi_role_config_view',
+            'kpi_role_config_delete',
+            'kpi_target_access',
+            'kpi_target_create',
+            'kpi_target_edit',
+            'kpi_target_view',
+            'kpi_target_delete',
+            'kpi_template_access',
+            'kpi_template_create',
+            'kpi_template_edit',
+            'kpi_template_view',
+            'kpi_template_delete',
+        ])->delete();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+};

--- a/resources/views/backend/roles/create.blade.php
+++ b/resources/views/backend/roles/create.blade.php
@@ -33,7 +33,7 @@
                 <div class="permission-blocks row">
                 @foreach($permissions as $module => $modulePermissions)
                     <div class="mb-2 border p-2 rounded">
-                        <strong>{{ ucfirst($module) }}</strong>
+                        <strong>{{ ucfirst(str_replace('_', ' ', $module)) }}</strong>
                         <div class="form-check">
                             <input type="checkbox" class="form-check-input select-all" data-module="{{ $module }}" id="select_all_{{ $module }}">
                             <label class="form-check-label" for="select_all_{{ $module }}">{{ __('admin_pages.roles.select_all') }}</label>

--- a/resources/views/backend/roles/edit.blade.php
+++ b/resources/views/backend/roles/edit.blade.php
@@ -29,7 +29,7 @@
                 <div class="permission-blocks row">
                 @foreach($permissions as $module => $modulePermissions)
                     <div class="mb-2 border p-2 rounded">
-                        <strong>{{ ucfirst($module) }}</strong>
+                        <strong>{{ ucfirst(str_replace('_', ' ', $module)) }}</strong>
                         <div class="form-check">
                             <input type="checkbox" class="form-check-input select-all" data-module="{{ $module }}" id="select_all_{{ $module }}">
                             <label class="form-check-label" for="select_all_{{ $module }}">{{ __('admin_pages.roles.select_all') }}</label>
@@ -93,5 +93,4 @@ document.addEventListener('DOMContentLoaded', function () {
 @endpush
 
 @endsection
-
 


### PR DESCRIPTION
Closes #538

## Summary
- add KPI-related permissions to RBAC via migration and assign them to administrator/teacher roles
- register KPI gates so Gate::allows checks resolve through assigned RBAC permissions
- group multi-word permission modules correctly in Roles management so KPI role config/targets/templates are visible to administrators

## Validation
- php -l app/Providers/AuthServiceProvider.php
- php -l app/Http/Controllers/Backend/Admin/RolesController.php
- php -l database/migrations/2026_04_30_000000_add_kpi_permissions.php