### PR TITLE
[Fix] Constrain footer logo img within circular container on Forgot Password page

### DIFF
--- a/public/css/frontend.css
+++ b/public/css/frontend.css
@@ -6668,7 +6668,7 @@ footer hr {
   margin: 30px 0 50px;
   background-color: #ffffff42;
 }
-.footer-logo img{ margin-bottom:10px}
+.footer-logo img{ margin-bottom:10px; max-width:100%; height:auto; object-fit:contain}
 
 .dload .footer-list{display: flex; align-items: center;}
 .dload .footer-list li{ padding:0 5px 0 0}


### PR DESCRIPTION
## Problem
Footer logo appears outside the circular container on the Forgot Password page.

## Fix
Added `max-width: 100%`, `height: auto`, and `object-fit: contain` to `.footer-logo img` to ensure the logo stays within its container.

Closes #544