### PR TITLE
fix: Reset button now clears all dashboard filter fields (#546)

### DIFF
--- a/resources/views/backend/dashboard.blade.php
+++ b/resources/views/backend/dashboard.blade.php
@@ -978,6 +978,14 @@ $show_dashboard_widget_tabs = auth()->user()->hasRole('administrator')
     });
 
     $(document).ready(function () {
+        $('#reset').on('click', function () {
+            $('#user_id').val('').trigger('change');
+            $('#department_id').val('').trigger('change');
+            $('#course_id').val('').trigger('change');
+            $('#category_id').val('').trigger('change');
+            $('#assign_from_date').val('');
+        });
+
         $('#dashboard-form-filter').on('submit', function (e) {
             e.preventDefault();
 


### PR DESCRIPTION
## What changed

Added a click handler for the `#reset` button in the Dashboard filter section.

Previously the button had `type="button"` (correct — no form submit) but **no JavaScript handler**, so clicking it did nothing.

## Fix

```js
$('#reset').on('click', function () {
    $('#user_id').val('').trigger('change');
    $('#department_id').val('').trigger('change');
    $('#course_id').val('').trigger('change');
    $('#category_id').val('').trigger('change');
    $('#assign_from_date').val('');
});
```

- Select2 dropdowns require `.trigger('change')` after `.val('')` so the plugin updates its displayed value.
- The date input is cleared with `.val('')` directly.

## How to test

1. Go to the Dashboard page.
2. Open the Filter section and populate all fields (Employee, Department, Course, Period, Category).
3. Click **Reset**.
4. All fields should return to their empty/default state.

Closes #546