### PR TITLE
fix: correct broken logo and back to homepage links on 404 error page

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -147,7 +147,7 @@
                             @lang('http.404.description2')
                         </p>
                         <div class="nws-button genius-btn text-center  d-inline-block gradient-bg text-uppercase">
-                            <a href="{{url('/')}}">@lang('http.404.back')</a>
+                            <a href="{{ route('home') }}">@lang('http.404.back')</a>
                         </div>
                     </div>
                 </div>

--- a/resources/views/frontend/layouts/app1.blade.php
+++ b/resources/views/frontend/layouts/app1.blade.php
@@ -132,7 +132,7 @@
         <nav class="navbar navbar-expand-lg navbar-light">
            
                 <div class="navbar-header float-left">
-                    <a class="navbar-brand text-uppercase" href="{{ url('/') }}">
+                    <a class="navbar-brand text-uppercase" href="{{ route('home') }}">
                         @if( isset($site_logo->value) )
                        <img src="{{ asset('assets/img/logo.png') }}" alt="logo" class="logoimg">
                        @else


### PR DESCRIPTION
## 🐛 Bug Fix: Broken Navigation Links on 404 Error Page

### Problem
Both the branding logo in the header and the "BACK TO HOMEPAGE" button on the 404 error page were linked using `url('/')`, which caused incorrect redirects in certain server configurations — trapping users on the error page with no way out.

### Root Cause
The `url('/')` helper was generating an invalid path in the app's environment, instead of resolving to the correct home route.

### Fix
Replaced `url('/')` with `route('home')` in both affected files to ensure the links always resolve to the correct application home URL.

### Files Changed
- `resources/views/errors/404.blade.php` — Fixed "BACK TO HOMEPAGE" button link
- `resources/views/frontend/layouts/app1.blade.php` — Fixed navbar logo link

### Before
```php
<a href="{{ url('/') }}">  ❌
```

### After
```php
<a href="{{ route('home') }}">  ✅
```

### Testing
- Navigate to any invalid URL to trigger the 404 page
- Click the logo → should redirect to homepage ✅
- Click "BACK TO HOMEPAGE" → should redirect to homepage ✅

Closes #[ISSUE_NUMBER]