### PR TITLE
fix: resolve 404 on profile access for Teacher/Trainer users

### DIFF
--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -3,10 +3,6 @@
 use App\Http\Controllers\Backend\Admin\TestsController;
 use App\Http\Controllers\Backend\DashboardController;
 use App\Http\Controllers\Backend\Admin\RolesController;
-use App\Http\Controllers\Backend\Auth\User\AccountController;
-use App\Http\Controllers\Backend\Auth\User\ProfileController;
-use \App\Http\Controllers\Backend\Auth\User\UpdatePasswordController;
-use \App\Http\Controllers\Backend\Auth\User\UserPasswordController;
 use App\Http\Controllers\UserCourseRequestController;
 use FontLib\Table\Type\name;
 
@@ -487,11 +483,7 @@ Route::post('media/remove', ['uses' => 'Admin\MediaController@destroy', 'as' => 
 
 
 //===== User Account Routes =====//
-Route::group(['middleware' => ['auth', 'password_expires']], function () {
-    Route::get('account', [AccountController::class, 'index'])->name('account');
-    Route::patch('account/{email?}', [UserPasswordController::class, 'update'])->name('account.post');
-    Route::patch('profile/update', [ProfileController::class, 'update'])->name('profile.update');
-});
+// (Moved to web.php to ensure access for all authenticated users including Teachers)
 
 
 Route::group(['middleware' => 'role:teacher'], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -170,6 +170,11 @@ Route::group(['namespace' => 'Backend', 'prefix' => 'user', 'as' => 'admin.', 'm
     Route::post('messages/unread', ['uses' => 'MessagesController@getUnreadMessages', 'as' => 'messages.unread']);
     Route::post('messages/send', ['uses' => 'MessagesController@send', 'as' => 'messages.send']);
     Route::post('messages/reply', ['uses' => 'MessagesController@reply', 'as' => 'messages.reply']);
+
+    //==== User Account Routes =====//
+    Route::get('account', [\App\Http\Controllers\Backend\Auth\User\AccountController::class, 'index'])->name('account');
+    Route::patch('account/{email?}', [\App\Http\Controllers\Backend\Auth\User\UserPasswordController::class, 'update'])->name('account.post');
+    Route::patch('profile/update', [\App\Http\Controllers\Backend\Auth\User\ProfileController::class, 'update'])->name('profile.update');
 });
 
 


### PR DESCRIPTION
Fixes:#570

Moved account/profile routes from routes/backend/admin.php to routes/web.php inside the auth-only middleware group to ensure all authenticated users (including Teachers/Trainers) can access their profile page.

Bug: When a logged-in Teacher/Trainer clicked Profile from the account dropdown menu, they were redirected to a 404 Page Not Found error.

Root cause: The admin.account route was defined inside routes/backend/admin.php, which is included via include_route_files() within the 'admin' middleware group at web.php:141. This middleware group applies both 'auth' and 'password_expires', and the deeply nested route inclusion caused route resolution failures for non-administrator roles.

Changes:
- Moved GET /user/account (admin.account), PATCH /user/account/{email?} (admin.account.post), and PATCH /user/profile/update (admin.profile.update) to routes/web.php inside the existing auth-only middleware group (lines 166-178)
- Removed duplicate route definitions from routes/backend/admin.php
- Cleaned up unused controller imports in admin.php

Files changed:
- routes/web.php: Added account routes to auth middleware group
- routes/backend/admin.php: Removed duplicate account routes and unused imports

After deploying, run:
  php artisan route:clear 
  php artisan route:cache

