### PR TITLE
Fix login title overlapping navbar banner

### DIFF
--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -14,8 +14,8 @@
     /* Breadcrumb - Compact */
     .breadcrumb-section {
         background-color: #c1902d4a;
-        padding: 20px 0 !important; /* Reduced from 75px */
-    }
+        padding: 120px 0 40px !important;
+}
 
     /* Card Styling - Glassmorphic & Compact */
     .card {


### PR DESCRIPTION
## 🔧 Description

This PR fixes the login page title overlapping with the navbar/banner section.

The issue was caused by insufficient top spacing in the breadcrumb section of the login page layout.

Fixes: #548

---

## ✅ Type of Change

* [x] 🐞 Bug fix
* [x] 🎨 UI/UX update

---

## 📸 Screenshots (if applicable)

N/A

---

## 🚀 How Has This Been Tested?

* [x] Local environment

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Open the login page
2. Observe the "Login To Account" title overlapping with the navbar/banner
3. Verify the updated spacing fixes the overlap

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Verified no sensitive data is included

---

## 🙏 Additional Notes

Adjusted the `.breadcrumb-section` padding to improve spacing consistency and prevent overlap issues on the login page.

