### PR TITLE
fix: correct translation key typo in header dropdown (#560)

### DIFF
--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -50,11 +50,11 @@
 
 @if(null !== (Session::get('setvaluesession')))
 @if((Session::get('setvaluesession')) == 1)
-@lang('menus.backend.sidebar.general')  
+@lang('menus.backend.sidebar.general')
 @elseif((Session::get('setvaluesession')) == 2)
-@lang('menus.backend.sidebarr.internal')  
+@lang('menus.backend.sidebar.internal')
 @elseif((Session::get('setvaluesession')) == 3)
-@lang('menus.backend.sidebar.external') 
+@lang('menus.backend.sidebar.external')
 @endif
 @else
 @lang('menus.backend.sidebar.general')


### PR DESCRIPTION
## Summary
Fix typo in translation key in header dropdown menu for employee type selection.

## Changes
- Corrected translation key from `menus.backend.sidebarr.internal` to `menus.backend.sidebar.internal` in header.blade.php
- This fixes the missing translation display in the admin panel's employee type dropdown

## Files Modified
- `resources/views/backend/includes/header.blade.php`

## Testing
- Verified the header dropdown menu displays correctly with the fixed translation key
- Dropdown now shows proper translations for all employee type options (General, Internal, External)

## Related Issue
Closes #560