### PR TITLE
Fix: Correct step numbering display in offline course variant of stepper

### DIFF
--- a/resources/views/backend/includes/partials/course-steps.blade.php
+++ b/resources/views/backend/includes/partials/course-steps.blade.php
@@ -155,9 +155,9 @@ if (!$course) {
                 </li>
             
 
-                
-                <li class="{{ $current_step == 4 ? 'completed' : ($current_step == 4 ? 'active' : '') }}">
-                    <span class="circle">{{ $current_step }}</span>
+
+                <li class="{{ $current_step > 4 ? 'completed' : ($current_step == 4 ? 'active' : '') }}">
+                    <span class="circle">4</span>
                     <span class="label">Feedback</span>
                 </li>
         @else
@@ -169,8 +169,8 @@ if (!$course) {
             
 
                 
-                <li class="{{ $current_step == 3 ? 'completed' : ($current_step == 3 ? 'active' : '') }}">
-                    <span class="circle">{{ $current_step }}</span>
+                <li class="{{ $current_step > 3 ? 'completed' : ($current_step == 3 ? 'active' : '') }}">
+                    <span class="circle">3</span>
                     <span class="label">Feedback</span>
                 </li>
                 


### PR DESCRIPTION
## Summary
Fix step numbering display in course creation progress stepper for both online and offline course types.

## Changes
- Fixed Feedback step circle displaying incorrect step number in online course variant
  - Changed from displaying `{{ $current_step }}` variable to hardcoded `4`
  - Updated condition logic from `$current_step == 4` to `$current_step > 4` for completed state
- Applied same fix to offline course variant
  - Changed Feedback step number to hardcoded `3`
  - Updated condition logic from `$current_step == 3` to `$current_step > 3` for completed state

## Files Modified
- `resources/views/backend/includes/partials/course-steps.blade.php`

## Testing
- Verified step numbers display correctly throughout course creation workflow
- Confirmed progress stepper shows accurate step indicators for both online and offline course types

## Related Issue
Closes #574