### PR TITLE
Fix: Remove problematic groupBy from trash/archive queries

### DIFF
--- a/app/Http/Controllers/Backend/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Backend/Admin/EmployeeController.php
@@ -226,14 +226,13 @@ class EmployeeController extends Controller
                     $q->where('active', '1');
                 })
                 ->onlyTrashed()
-                ->groupBy('email')
                 ->orderBy('created_at', 'desc');
         } else {
             $teachers = User::query()->role('student')
             ->when($status == 'active', function ($q) {
                     $q->where('active', '1');
             })
-            ->groupBy('email')->orderBy('created_at', 'desc');
+            ->orderBy('created_at', 'desc');
         }      
 
         if (auth()->user()->isAdmin()) {


### PR DESCRIPTION
## Summary
Fix Database Error that occurs when attempting to view the Trash/Archive list of deleted trainees/employees.

## Changes
- Remove problematic groupBy('email') clause from onlyTrashed() queries in EmployeeController
- MySQL ONLY_FULL_GROUP_BY strict mode was causing error when viewing deleted records
- Affected queries: Trainee and Internal Trainee trash/archive listings

## Files Modified
- `app/Http/Controllers/Backend/Admin/EmployeeController.php`

## Testing
- Verified that trash/archive pages load without Database Error
- Confirmed deleted records can be viewed, restored, or permanently deleted

## Related Issue
Closes #585