### PR TITLE
fix(auth): increase CAPTCHA image size for better readability

### DIFF
--- a/app/Helpers/CaptchaGenerator.php
+++ b/app/Helpers/CaptchaGenerator.php
@@ -43,8 +43,8 @@ class CaptchaGenerator
     private static function generateCaptchaImage($code)
     {
         // Create image
-        $width = 150;
-        $height = 50;
+        $width = 200;
+        $height = 60;
         $image = imagecreatetruecolor($width, $height);
         
         // Background color
@@ -91,7 +91,7 @@ class CaptchaGenerator
             imageline($image, rand(0, $width), rand(0, $height), rand(0, $width), rand(0, $height), $noiseColor);
         }
         
-        // Scale image by 1.5x to make it slightly bigger
+        // Scale image by 1.5x to make it clear and readable
         $scale = 1.5;
         $newWidth = (int)($width * $scale);
         $newHeight = (int)($height * $scale);

--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -101,6 +101,12 @@
     border-radius: 6px;
     border: 1px solid #e0e0e0;
 }
+
+    .captcha-container img {
+        height: 70px;
+        width: auto;
+        border-radius: 4px;
+    }
     
     
     .captcha-text {

--- a/resources/views/frontend/layouts/modals/loginModal.blade.php
+++ b/resources/views/frontend/layouts/modals/loginModal.blade.php
@@ -58,6 +58,8 @@
         border: 1px solid #ddd;
         border-radius: 4px;
         background: #f9f9f9;
+        height: 70px;
+        width: auto;
     }
 
     .captcha-refresh-btn {

--- a/tests/Unit/CaptchaGeneratorTest.php
+++ b/tests/Unit/CaptchaGeneratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\CaptchaGenerator;
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class CaptchaGeneratorTest extends TestCase
+{
+    /** @test */
+    public function it_generates_captcha_with_code_and_image()
+    {
+        $result = CaptchaGenerator::generate();
+
+        $this->assertArrayHasKey('code', $result);
+        $this->assertArrayHasKey('image', $result);
+        $this->assertEquals(6, strlen($result['code']));
+        $this->assertStringStartsWith('data:image/png;base64,', $result['image']);
+    }
+
+    /** @test */
+    public function it_stores_captcha_answer_in_session()
+    {
+        CaptchaGenerator::generate();
+
+        $this->assertTrue(Session::has('captcha_answer'));
+        $this->assertEquals(6, strlen(Session::get('captcha_answer')));
+    }
+
+    /** @test */
+    public function it_generates_image_with_sufficient_dimensions()
+    {
+        $result = CaptchaGenerator::generate();
+
+        // Decode the base64 image to check dimensions
+        $base64 = str_replace('data:image/png;base64,', '', $result['image']);
+        $imageData = base64_decode($base64);
+        $image = imagecreatefromstring($imageData);
+
+        $width = imagesx($image);
+        $height = imagesy($image);
+
+        // After fix: image should be at least 300x90 (200x60 * 1.5x)
+        $this->assertGreaterThanOrEqual(300, $width, 'CAPTCHA image width should be at least 300px');
+        $this->assertGreaterThanOrEqual(90, $height, 'CAPTCHA image height should be at least 90px');
+
+        imagedestroy($image);
+    }
+
+    /** @test */
+    public function it_validates_correct_captcha_input()
+    {
+        $result = CaptchaGenerator::generate();
+        $code = $result['code'];
+
+        $this->assertTrue(CaptchaGenerator::validate($code));
+    }
+
+    /** @test */
+    public function it_validates_captcha_case_insensitively()
+    {
+        $result = CaptchaGenerator::generate();
+        $code = strtoupper($result['code']);
+
+        $this->assertTrue(CaptchaGenerator::validate($code));
+    }
+
+    /** @test */
+    public function it_rejects_wrong_captcha_input()
+    {
+        CaptchaGenerator::generate();
+
+        $this->assertFalse(CaptchaGenerator::validate('wrongcode'));
+    }
+
+    /** @test */
+    public function it_rejects_empty_captcha_input()
+    {
+        CaptchaGenerator::generate();
+
+        $this->assertFalse(CaptchaGenerator::validate(''));
+        $this->assertFalse(CaptchaGenerator::validate(null));
+    }
+
+    /** @test */
+    public function it_generates_different_codes_each_time()
+    {
+        $result1 = CaptchaGenerator::generate();
+        $result2 = CaptchaGenerator::generate();
+
+        // While technically possible to get the same code twice,
+        // with 62^6 combinations this is astronomically unlikely
+        $this->assertNotEquals($result1['code'], $result2['code']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the CAPTCHA text rendering too small on the login page by increasing image dimensions and adding proper CSS sizing.

**Root Cause:**
- CAPTCHA image was generated at 150x50 (scaled to 225x75), with GD built-in font size 5 that only occupied ~30% of the image height
- No CSS rules to ensure the image scales properly within its container

**Changes:**
- `app/Helpers/CaptchaGenerator.php`: Increased base image from 150x50 to 200x60, resulting in 300x90 rendered output (1.5x scale)
- `resources/views/frontend/auth/login.blade.php`: Added `.captcha-container img` CSS rule with `height: 70px` for proper scaling
- `resources/views/frontend/layouts/modals/loginModal.blade.php`: Added `height: 70px` to `.captcha-image` class

## Testing
- 8 PHPUnit tests added covering: generation, session storage, image dimensions, correct/wrong/empty validation, case-insensitive matching, and uniqueness
- All tests pass locally with PHP 8.5

Closes #581