### PR TITLE
Fix lesson video rendering and editing

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Yajra\DataTables\Facades\DataTables;
 
@@ -409,11 +410,121 @@ class LessonsController extends Controller
 
 
         $courses    = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
-        $lesson     = Lesson::with(['media', 'mediaVideo'])->findOrFail($id);
+        $lesson     = Lesson::with(['media', 'mediaVideo', 'videos'])->findOrFail($id);
         $videos     = $lesson->media ? $lesson->media()->pluck('url')->implode(',') : '';
         $mediavideo = $lesson->mediaVideo;
 
         return view('backend.lessons.edit', compact('mediavideo', 'lesson', 'courses', 'videos'));
+    }
+
+    private function syncLessonVideos(Request $request, Lesson $lesson): void
+    {
+        $submittedVideos = $request->input('videos', []);
+
+        if (!is_array($submittedVideos)) {
+            return;
+        }
+
+        $sortOrder = 0;
+        $allowedTypes = ['upload', 'youtube', 'vimeo', 'embed'];
+
+        foreach ($submittedVideos as $index => $videoData) {
+            if (!is_array($videoData)) {
+                continue;
+            }
+
+            $lessonVideo = null;
+            if (!empty($videoData['id'])) {
+                $lessonVideo = LessonVideo::where('lesson_id', $lesson->id)
+                    ->where('id', (int) $videoData['id'])
+                    ->first();
+            }
+
+            if (($videoData['delete'] ?? '0') === '1') {
+                if ($lessonVideo) {
+                    if ($lessonVideo->file_path) {
+                        Storage::disk('public')->delete($lessonVideo->file_path);
+                    }
+                    $lessonVideo->delete();
+                }
+
+                continue;
+            }
+
+            $type = in_array(($videoData['type'] ?? 'upload'), $allowedTypes, true)
+                ? $videoData['type']
+                : 'upload';
+
+            $filePath = $lessonVideo->file_path ?? null;
+            if ($request->hasFile("videos.$index.file")) {
+                if ($filePath) {
+                    Storage::disk('public')->delete($filePath);
+                }
+
+                $filePath = $request->file("videos.$index.file")->store('lesson_videos', 'public');
+            }
+
+            if ($type !== 'upload') {
+                if ($filePath) {
+                    Storage::disk('public')->delete($filePath);
+                }
+                $filePath = null;
+            }
+
+            $submittedUrl = trim((string) ($videoData['url'] ?? ''));
+            $url = $type === 'upload'
+                ? ($submittedUrl !== '' ? $submittedUrl : ($lessonVideo->url ?? null))
+                : $submittedUrl;
+
+            $hasVideoSource = $type === 'upload'
+                ? ($filePath || $url)
+                : $url !== '';
+
+            if (!$lessonVideo && !$hasVideoSource && blank($videoData['title'] ?? null)) {
+                continue;
+            }
+
+            $lessonVideo = $lessonVideo ?: new LessonVideo(['lesson_id' => $lesson->id]);
+            $lessonVideo->title = $videoData['title'] ?? null;
+            $lessonVideo->type = $type;
+            $lessonVideo->url = $url ?: null;
+            $lessonVideo->file_path = $filePath;
+            $lessonVideo->sort_order = $sortOrder;
+            $lessonVideo->is_preview = isset($videoData['is_preview']) ? 1 : 0;
+            $lessonVideo->save();
+
+            $sortOrder++;
+        }
+    }
+
+    private function extractVideoIdentifier(?string $url, string $type): string
+    {
+        $url = trim((string) $url);
+        if ($url === '') {
+            return '';
+        }
+
+        if ($type === 'youtube') {
+            if (preg_match('/(?:v=|\/)([a-zA-Z0-9_-]{11})/', $url, $matches)) {
+                return $matches[1];
+            }
+
+            if (preg_match('/^[a-zA-Z0-9_-]{11}$/', $url)) {
+                return $url;
+            }
+        }
+
+        if ($type === 'vimeo') {
+            if (preg_match('/vimeo\.com\/(?:video\/)?([0-9]+)/', $url, $matches)) {
+                return $matches[1];
+            }
+
+            if (preg_match('/^[0-9]+$/', $url)) {
+                return $url;
+            }
+        }
+
+        return '';
     }
 
     public function update(UpdateLessonsRequest $request, $id)
@@ -431,11 +542,24 @@ class LessonsController extends Controller
                 return back()->withFlashDanger(__('alerts.backend.general.slug_exist'));
             }
 
-            $lesson                    = Lesson::findOrFail($id);
-            $lesson->update($request->except('downloadable_files', 'lesson_image'));
+            $lesson                    = Lesson::with('videos')->findOrFail($id);
+            $lesson->update($request->except('downloadable_files', 'lesson_image', 'videos', 'media_type', 'video', 'video_file', 'lesson_start_date'));
             $lesson->slug              = $slug;
             $lesson->duration          = $request->duration;
-            $lesson->lesson_start_date = date('Y-m-d H:i', strtotime($request->lesson_start_date));
+            if ($request->has('lesson_start_date')) {
+                if ($request->filled('lesson_start_date')) {
+                    $submittedLessonDate = date('Y-m-d', strtotime($request->lesson_start_date));
+                    $currentLessonDate = $lesson->lesson_start_date
+                        ? date('Y-m-d', strtotime($lesson->lesson_start_date))
+                        : null;
+
+                    if ($submittedLessonDate !== $currentLessonDate) {
+                        $lesson->lesson_start_date = date('Y-m-d H:i', strtotime($request->lesson_start_date));
+                    }
+                } else {
+                    $lesson->lesson_start_date = null;
+                }
+            }
             $lesson->save();
 
             try {
@@ -456,7 +580,7 @@ class LessonsController extends Controller
                 if ($request->media_type !== 'upload') {
                     $url      = $request->video;
                     $videoId  = in_array($request->media_type, ['youtube', 'vimeo'])
-                        ? array_last(explode('/', $request->video))
+                        ? $this->extractVideoIdentifier($request->video, $request->media_type)
                         : '';
 
                     $media->model_type = Lesson::class;
@@ -497,6 +621,8 @@ class LessonsController extends Controller
                 }
             }
 
+            $this->syncLessonVideos($request, $lesson);
+
 
             if ($request->hasFile('add_pdf')) {
                 optional($lesson->mediaPDF)->delete();
@@ -528,6 +654,10 @@ class LessonsController extends Controller
                 ->withFlashSuccess(__('alerts.backend.general.updated'));
         } catch (Exception $e) {
             DB::rollBack();
+            Log::error('Lesson update failed: ' . $e->getMessage(), [
+                'lesson_id' => $id,
+                'request_video_type' => $request->media_type,
+            ]);
 
             return back()->withFlashDanger('Error while updating...');
         }

--- a/app/Http/Controllers/LessonsController.php
+++ b/app/Http/Controllers/LessonsController.php
@@ -382,7 +382,7 @@ class LessonsController extends Controller
             return null;
         }
 
-        $baseQuery = Lesson::with(['downloadableMedia', 'mediaVideo', 'mediaPDF'])
+        $baseQuery = Lesson::with(['downloadableMedia', 'mediaVideo', 'mediaPDF', 'videos'])
             ->where('course_id', $course_id)
             ->where('published', 1);
 
@@ -659,7 +659,7 @@ class LessonsController extends Controller
 
 
         //dd($lesson, $lesson->mediaVideo()->exists());
-        if ($lesson instanceof Lesson && !$lesson->mediaVideo()->exists()) {
+        if ($lesson instanceof Lesson && !$lesson->mediaVideo()->exists() && !$lesson->videos()->exists()) {
 
             $custom_helper = new CustomHelper();
             $custom_helper->updateUserProgress($logged_in_user_id, $course_id);
@@ -667,8 +667,8 @@ class LessonsController extends Controller
 
 
 
-        if ((int)config('lesson_timer') == 0) {
-            if (!$lesson->live_lesson && !$lesson->mediaVideo) {
+        if ((int)config('lesson_timer') == 0 && $lesson instanceof Lesson) {
+            if (!$lesson->live_lesson && !$lesson->mediaVideo && $lesson->videos->isEmpty()) {
                 if ($lesson->chapterStudents()->where('user_id', \Auth::id())->count() == 0) {
                     $lesson->chapterStudents()->create([
                         'model_type' => get_class($lesson),

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -38,6 +38,8 @@ class Lesson extends Model
             $course = $lesson->course;
 
             if (!$course) return;
+            if (empty($lesson->lesson_start_date) || empty($course->start_date) || empty($course->expire_at)) return;
+            if ($lesson->exists && !$lesson->isDirty('lesson_start_date') && !$lesson->isDirty('course_id')) return;
 
             $lessonDate = \Carbon\Carbon::parse($lesson->lesson_start_date)->startOfDay();
             $courseStart = \Carbon\Carbon::parse($course->start_date)->startOfDay();

--- a/app/Models/LessonVideo.php
+++ b/app/Models/LessonVideo.php
@@ -20,4 +20,47 @@ class LessonVideo extends Model
     {
         return $this->belongsTo(Lesson::class);
     }
+
+    public function getPlaybackUrlAttribute()
+    {
+        if ($this->type === 'upload') {
+            if ($this->file_path) {
+                return asset('storage/' . ltrim($this->file_path, '/'));
+            }
+
+            return $this->url;
+        }
+
+        return $this->url;
+    }
+
+    public function getPlyrEmbedIdAttribute()
+    {
+        $url = $this->url;
+        if (!$url) {
+            return null;
+        }
+
+        if ($this->type === 'youtube') {
+            if (preg_match('/(?:v=|\/)([a-zA-Z0-9_-]{11})/', $url, $matches)) {
+                return $matches[1];
+            }
+
+            if (preg_match('/^[a-zA-Z0-9_-]{11}$/', $url)) {
+                return $url;
+            }
+        }
+
+        if ($this->type === 'vimeo') {
+            if (preg_match('/vimeo\.com\/(?:video\/)?([0-9]+)/', $url, $matches)) {
+                return $matches[1];
+            }
+
+            if (preg_match('/^[0-9]+$/', $url)) {
+                return $url;
+            }
+        }
+
+        return $url;
+    }
 }

--- a/resources/views/backend/lessons/edit.blade.php
+++ b/resources/views/backend/lessons/edit.blade.php
@@ -299,6 +299,113 @@
             <div class="row">
                 <div class="col-md-12 form-group">
                      <label for="add_video" class="control-label">{{ trans('labels.backend.lessons.fields.add_video') }}</label>
+
+                     @if($mediavideo && $lesson->videos->isEmpty())
+                        <div class="video-item card p-3 mb-3">
+                            <h5 class="mb-3">{{ __('course_pages.admin_lessons_create.preview_video') }}</h5>
+
+                            <label class="mt-2">Type</label>
+                            <select name="media_type" class="form-control video-type">
+                                <option value="upload" {{ $mediavideo->type == 'upload' ? 'selected' : '' }}>Upload</option>
+                                <option value="youtube" {{ $mediavideo->type == 'youtube' ? 'selected' : '' }}>YouTube</option>
+                                <option value="vimeo" {{ $mediavideo->type == 'vimeo' ? 'selected' : '' }}>Vimeo</option>
+                                <option value="embed" {{ $mediavideo->type == 'embed' ? 'selected' : '' }}>Embed</option>
+                            </select>
+
+                            <div class="video-url mt-2" {{ $mediavideo->type == 'upload' ? 'style=display:none;' : '' }}>
+                                <label>Video URL</label>
+                                <input type="text" name="video" class="form-control" value="{{ $mediavideo->url }}">
+                            </div>
+
+                            <div class="video-file mt-2" {{ $mediavideo->type != 'upload' ? 'style=display:none;' : '' }}>
+                                <label>Upload File</label>
+                                <input type="file" name="video_file" class="form-control">
+
+                                @if($mediavideo->url)
+                                    <div class="mt-2">
+                                        <a href="{{ $mediavideo->url }}" target="_blank">Current File</a>
+                                    </div>
+
+                                    <div class="mt-2">
+                                        <video width="320" controls>
+                                            <source src="{{ $mediavideo->url }}" type="video/mp4">
+                                            Your browser does not support the video tag.
+                                        </video>
+                                    </div>
+                                @endif
+                            </div>
+
+                            @if($mediavideo->type == 'youtube' && $mediavideo->url)
+                                @php
+                                    $youtubeUrl = trim((string) $mediavideo->url);
+                                    $youtubeEmbedUrl = null;
+                                    $videoId = '';
+
+                                    $parts = parse_url($youtubeUrl);
+                                    $host = strtolower($parts['host'] ?? '');
+                                    $path = $parts['path'] ?? '';
+                                    $query = $parts['query'] ?? '';
+
+                                    if (strpos($host, 'youtu.be') !== false) {
+                                        $videoId = trim($path, '/');
+                                    } elseif (strpos($host, 'youtube.com') !== false || strpos($host, 'youtube-nocookie.com') !== false) {
+                                        if (preg_match('#^/shorts/([^/?]+)#', $path, $m)) {
+                                            $videoId = $m[1];
+                                        } elseif (preg_match('#^/embed/([^/?]+)#', $path, $m)) {
+                                            $videoId = $m[1];
+                                        } else {
+                                            parse_str($query, $queryParams);
+                                            $videoId = $queryParams['v'] ?? '';
+                                        }
+                                    } elseif (preg_match('/^[a-zA-Z0-9_-]{11}$/', $youtubeUrl)) {
+                                        $videoId = $youtubeUrl;
+                                    }
+
+                                    if ($videoId !== '') {
+                                        $youtubeEmbedUrl = 'https://www.youtube.com/embed/' . $videoId;
+                                    }
+                                @endphp
+
+                                @if($youtubeEmbedUrl)
+                                    <div class="mt-3">
+                                        <iframe width="420" height="250"
+                                            src="{{ $youtubeEmbedUrl }}"
+                                            frameborder="0"
+                                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                            referrerpolicy="strict-origin-when-cross-origin"
+                                            allowfullscreen>
+                                        </iframe>
+                                    </div>
+                                @endif
+                            @endif
+
+                            @if($mediavideo->type == 'vimeo' && $mediavideo->url)
+                                @php
+                                    $vimeoUrl = trim((string) $mediavideo->url);
+                                    $vimeoEmbedUrl = null;
+                                    if (preg_match('#(?:vimeo\.com/(?:video/|channels/[^/]+/|groups/[^/]+/videos/|album/[^/]+/video/)?|player\.vimeo\.com/video/)(\d+)#i', $vimeoUrl, $vm)) {
+                                        $vimeoEmbedUrl = 'https://player.vimeo.com/video/' . $vm[1];
+                                    }
+                                @endphp
+                                @if($vimeoEmbedUrl)
+                                    <div class="mt-3">
+                                        <iframe width="420" height="250"
+                                            src="{{ $vimeoEmbedUrl }}"
+                                            frameborder="0"
+                                            allow="autoplay; fullscreen; picture-in-picture"
+                                            allowfullscreen>
+                                        </iframe>
+                                    </div>
+                                @endif
+                            @endif
+
+                            @if($mediavideo->type == 'embed' && $mediavideo->url)
+                                <div class="mt-3">
+                                    {!! $mediavideo->url !!}
+                                </div>
+                            @endif
+                        </div>
+                     @endif
                      
                      <div id="videos-wrapper">
     @forelse($lesson->videos as $index => $video)
@@ -436,7 +543,9 @@
             <input type="hidden" name="videos[{{ $index }}][delete]" class="delete-flag" value="0">
         </div>
     @empty
-        <p class="text-muted">No videos associated with this lesson.</p>
+        @unless($mediavideo)
+            <p class="text-muted">No videos associated with this lesson.</p>
+        @endunless
     @endforelse
 </div>
                     <button type="button" id="addVideo" class="btn btn-outline-info mt-2">Add Video</button>

--- a/resources/views/frontend-rtl/courses/lesson.blade.php
+++ b/resources/views/frontend-rtl/courses/lesson.blade.php
@@ -129,6 +129,117 @@
             display: none !important;
         }
 
+        .lesson-video-section {
+            margin: 24px 0 32px;
+        }
+
+        .lesson-video-heading {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 14px;
+        }
+
+        .lesson-video-heading h4 {
+            margin: 0;
+            font-size: 20px;
+            font-weight: 700;
+            color: #222;
+        }
+
+        .lesson-video-count {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 26px;
+            padding: 3px 10px;
+            border-radius: 13px;
+            background: #eef5f8;
+            color: #236071;
+            font-size: 12px;
+            font-weight: 700;
+            white-space: nowrap;
+        }
+
+        .lesson-video-stack {
+            display: grid;
+            gap: 18px;
+        }
+
+        .lesson-video-item {
+            border: 1px solid #e8edf1;
+            border-radius: 8px;
+            background: #fff;
+            overflow: hidden;
+            box-shadow: 0 8px 24px rgba(20, 34, 47, 0.06);
+        }
+
+        .lesson-video-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 12px 14px;
+            border-bottom: 1px solid #eef1f4;
+        }
+
+        .lesson-video-title {
+            min-width: 0;
+            margin: 0;
+            color: #222;
+            font-size: 16px;
+            font-weight: 700;
+            line-height: 1.35;
+            word-break: break-word;
+        }
+
+        .lesson-video-type {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 24px;
+            padding: 2px 9px;
+            border-radius: 12px;
+            background: #f7f4ec;
+            color: #866322;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .lesson-video-frame {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            background: #111820;
+        }
+
+        .lesson-video-frame iframe,
+        .lesson-video-frame video,
+        .lesson-video-frame .plyr,
+        .lesson-video-frame .plyr__video-wrapper {
+            width: 100%;
+            height: 100%;
+        }
+
+        .lesson-video-frame iframe {
+            display: block;
+            border: 0;
+        }
+
+        @media screen and (max-width: 576px) {
+            .lesson-video-heading,
+            .lesson-video-meta {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .lesson-video-heading h4 {
+                font-size: 18px;
+            }
+        }
+
         @media screen and (max-width: 768px) {}
     </style>
 @endpush
@@ -389,10 +500,19 @@
 
 
                         @if ($lesson->mediaVideo)
-                            <div class="course-single-text">
+                            <div class="course-single-text lesson-video-section">
                                 @if ($lesson->mediavideo != '')
-                                    <div class="course-details-content mt-3">
-                                        <div class="video-container mb-5" data-id="{{ $lesson->mediavideo->id }}">
+                                    <div class="lesson-video-heading">
+                                        <h4>{{ __('course_pages.admin_lessons_create.lesson_videos') }}</h4>
+                                        <span class="lesson-video-count">1</span>
+                                    </div>
+                                    <div class="lesson-video-stack">
+                                        <div class="video-container lesson-video-item" data-id="{{ $lesson->mediavideo->id }}">
+                                            <div class="lesson-video-meta">
+                                                <h5 class="lesson-video-title">{{ $lesson->title }}</h5>
+                                                <span class="lesson-video-type">{{ $lesson->mediavideo->type }}</span>
+                                            </div>
+                                            <div class="lesson-video-frame">
                                             @if ($lesson->mediavideo->type == 'youtube')
                                                 <div id="player" onclick="videoPer(this);" class="js-player"
                                                     data-plyr-provider="youtube"
@@ -408,11 +528,14 @@
                                             @elseif($lesson->mediavideo->type == 'embed')
                                                 {!! $lesson->mediavideo->url !!}
                                             @endif
+                                            </div>
                                         </div>
                                     </div>
                                 @endif
                             </div>
                         @endif
+
+                        @include('frontend.courses.partials.lesson-videos')
 
                         @if ($lesson->media)
                             <div class="course-single-text mb-5">
@@ -694,6 +817,14 @@
 
 
     <script>
+        document.querySelectorAll('.lesson-video-player').forEach(function(playerElement) {
+            new Plyr(playerElement, {
+                youtube: {
+                    noCookie: true
+                }
+            });
+        });
+
         @if ($lesson->mediaPDF)
             $(function() {
                 $("#myPDF").pdf({

--- a/resources/views/frontend/courses/lesson.blade.php
+++ b/resources/views/frontend/courses/lesson.blade.php
@@ -129,6 +129,117 @@
             display: none !important;
         }
 
+        .lesson-video-section {
+            margin: 24px 0 32px;
+        }
+
+        .lesson-video-heading {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 14px;
+        }
+
+        .lesson-video-heading h4 {
+            margin: 0;
+            font-size: 20px;
+            font-weight: 700;
+            color: #222;
+        }
+
+        .lesson-video-count {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 26px;
+            padding: 3px 10px;
+            border-radius: 13px;
+            background: #eef5f8;
+            color: #236071;
+            font-size: 12px;
+            font-weight: 700;
+            white-space: nowrap;
+        }
+
+        .lesson-video-stack {
+            display: grid;
+            gap: 18px;
+        }
+
+        .lesson-video-item {
+            border: 1px solid #e8edf1;
+            border-radius: 8px;
+            background: #fff;
+            overflow: hidden;
+            box-shadow: 0 8px 24px rgba(20, 34, 47, 0.06);
+        }
+
+        .lesson-video-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 12px 14px;
+            border-bottom: 1px solid #eef1f4;
+        }
+
+        .lesson-video-title {
+            min-width: 0;
+            margin: 0;
+            color: #222;
+            font-size: 16px;
+            font-weight: 700;
+            line-height: 1.35;
+            word-break: break-word;
+        }
+
+        .lesson-video-type {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 24px;
+            padding: 2px 9px;
+            border-radius: 12px;
+            background: #f7f4ec;
+            color: #866322;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .lesson-video-frame {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            background: #111820;
+        }
+
+        .lesson-video-frame iframe,
+        .lesson-video-frame video,
+        .lesson-video-frame .plyr,
+        .lesson-video-frame .plyr__video-wrapper {
+            width: 100%;
+            height: 100%;
+        }
+
+        .lesson-video-frame iframe {
+            display: block;
+            border: 0;
+        }
+
+        @media screen and (max-width: 576px) {
+            .lesson-video-heading,
+            .lesson-video-meta {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .lesson-video-heading h4 {
+                font-size: 18px;
+            }
+        }
+
         @media screen and (max-width: 768px) {}
     </style>
 @endpush
@@ -387,10 +498,19 @@
 
 
                         @if ($lesson->mediaVideo)
-                            <div class="course-single-text">
+                            <div class="course-single-text lesson-video-section">
                                 @if ($lesson->mediavideo != '')
-                                    <div class="course-details-content mt-3">
-                                        <div class="video-container mb-5" data-id="{{ $lesson->mediavideo->id }}">
+                                    <div class="lesson-video-heading">
+                                        <h4>{{ __('course_pages.admin_lessons_create.lesson_videos') }}</h4>
+                                        <span class="lesson-video-count">1</span>
+                                    </div>
+                                    <div class="lesson-video-stack">
+                                        <div class="video-container lesson-video-item" data-id="{{ $lesson->mediavideo->id }}">
+                                            <div class="lesson-video-meta">
+                                                <h5 class="lesson-video-title">{{ $lesson->title }}</h5>
+                                                <span class="lesson-video-type">{{ $lesson->mediavideo->type }}</span>
+                                            </div>
+                                            <div class="lesson-video-frame">
                                             @if ($lesson->mediavideo->type == 'youtube')
                                                 <div id="player" onclick="videoPer(this);" class="js-player"
                                                     data-plyr-provider="youtube"
@@ -406,11 +526,14 @@
                                             @elseif($lesson->mediavideo->type == 'embed')
                                                 {!! $lesson->mediavideo->url !!}
                                             @endif
+                                            </div>
                                         </div>
                                     </div>
                                 @endif
                             </div>
                         @endif
+
+                        @include('frontend.courses.partials.lesson-videos')
 
                         @if ($lesson->media)
                             <div class="course-single-text mb-5">
@@ -665,6 +788,14 @@
 
 
     <script>
+        document.querySelectorAll('.lesson-video-player').forEach(function(playerElement) {
+            new Plyr(playerElement, {
+                youtube: {
+                    noCookie: true
+                }
+            });
+        });
+
         @if ($lesson->mediaPDF)
             $(function() {
                 $("#myPDF").pdf({

--- a/resources/views/frontend/courses/partials/lesson-videos.blade.php
+++ b/resources/views/frontend/courses/partials/lesson-videos.blade.php
@@ -1,0 +1,50 @@
+@php
+    $lessonVideos = ($lesson->videos ?? collect())->filter(function ($lessonVideo) {
+        return !empty($lessonVideo->playback_url);
+    });
+@endphp
+
+@if($lessonVideos->isNotEmpty())
+    <div class="course-single-text lesson-video-section">
+        <div class="lesson-video-heading">
+            <h4>{{ __('course_pages.admin_lessons_create.lesson_videos') }}</h4>
+            <span class="lesson-video-count">{{ $lessonVideos->count() }}</span>
+        </div>
+        <div class="lesson-video-stack">
+            @foreach($lessonVideos as $lessonVideo)
+                @php
+                    $videoUrl = $lessonVideo->playback_url;
+                    $embedId = $lessonVideo->plyr_embed_id;
+                    $videoTitle = $lessonVideo->title ?: __('course_pages.admin_lessons_create.preview_video');
+                @endphp
+
+                @if($videoUrl)
+                    <div class="video-container lesson-video-item" data-id="lesson-video-{{ $lessonVideo->id }}">
+                        <div class="lesson-video-meta">
+                            <h5 class="lesson-video-title">{{ $videoTitle }}</h5>
+                            <span class="lesson-video-type">{{ $lessonVideo->type }}</span>
+                        </div>
+
+                        <div class="lesson-video-frame">
+                        @if($lessonVideo->type === 'youtube')
+                            <div class="js-player lesson-video-player"
+                                 data-plyr-provider="youtube"
+                                 data-plyr-embed-id="{{ $embedId }}"></div>
+                        @elseif($lessonVideo->type === 'vimeo')
+                            <div class="js-player lesson-video-player"
+                                 data-plyr-provider="vimeo"
+                                 data-plyr-embed-id="{{ $embedId }}"></div>
+                        @elseif($lessonVideo->type === 'upload')
+                            <video class="js-player lesson-video-player" playsinline controls>
+                                <source src="{{ $videoUrl }}" type="video/mp4" />
+                            </video>
+                        @elseif($lessonVideo->type === 'embed')
+                            {!! $videoUrl !!}
+                        @endif
+                        </div>
+                    </div>
+                @endif
+            @endforeach
+        </div>
+    </div>
+@endif


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR restores lesson video handling after the recent lesson-level quiz updates.

- Fixes the missing student video player by loading and rendering lesson_videos alongside legacy mediaVideo data.
- Adds a shared lesson video partial for the student lesson UI and applies the same responsive video-card layout in LTR and RTL views.
- Adds playback helpers for uploaded, YouTube, Vimeo, and embed lesson videos.
- Updates the admin lesson edit flow so already linked or uploaded videos appear in the update section.
- Syncs lesson video add, update, delete, and uploaded file replacement operations to lesson_videos.
- Keeps legacy lesson media videos visible in edit mode when no new lesson_videos records exist.
- Prevents video-only lesson updates from being blocked by unchanged lesson date validation.

Fixes: #485

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

N/A

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: PHP syntax checks were run for every touched PHP/Blade file, and git whitespace checks passed for the PR diff.

Validated commands:

- php -l app/Http/Controllers/Backend/Admin/LessonsController.php
- php -l app/Http/Controllers/LessonsController.php
- php -l app/Models/Lesson.php
- php -l app/Models/LessonVideo.php
- php -l resources/views/backend/lessons/edit.blade.php
- php -l resources/views/frontend/courses/lesson.blade.php
- php -l resources/views/frontend-rtl/courses/lesson.blade.php
- php -l resources/views/frontend/courses/partials/lesson-videos.blade.php
- git diff --check origin/main...HEAD

Not tested:

- Local uploaded video playback was not tested end to end.
- Full browser regression was not completed because the local database connection is unavailable.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an admin, create or open a course, add a lesson video using an uploaded file or a linked YouTube/Vimeo/embed video, and enroll a student.
2. Log in as the enrolled student, open My Courses, select the course, and continue to the lesson.
3. Before this fix, the lesson loaded but the student video player was missing; in the admin update form, existing linked/uploaded lesson videos were also not shown correctly, and linking a YouTube video during update could fail.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [ ] Ensured the app builds without errors

---

## 🙏 Additional Notes


Local uploaded video playback has not been tested end to end.