### PR TITLE
Fixes Issue #607: Bug: UI Components Overflowing and Overlapping Content

### DIFF
--- a/public/css/backend.css
+++ b/public/css/backend.css
@@ -23699,8 +23699,8 @@ table.dataTable tbody tr {
 .ltitle{ margin-top: 30px;}
 #cke_4_contents{    height: 100px !important;}
 .permission-blocks{ margin: 0; gap: 20px;}
-.permission-blocks .mb-2.border.p-2.rounded{    width: 23.7%;
     background: #fff; 
+.permission-blocks .mb-2.border.p-2.rounded{    min-width: 20%;
     padding: 15px !important;
     box-shadow: 0 0 0px #233e7421;
     border-radius: 10px !important;


### PR DESCRIPTION
## 🔧 Description

 UI elements overflow containers, causing text overlap and not properly aligned with in boundary

Fixes: #607

<img width="1920" height="3184" alt="image" src="https://github.com/user-attachments/assets/13be7359-f7bd-48c4-a079-673b7e8da1e6" />
