### PR TITLE
Application Crash on Empty Submission in Create News Form #629

### DIFF
--- a/app/Http/Controllers/Backend/Admin/NewsController.php
+++ b/app/Http/Controllers/Backend/Admin/NewsController.php
@@ -115,6 +115,10 @@ class NewsController extends Controller
      */
     public function store(Request $request)
     {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required',
+        ]);
 
         $reason = new  News();
         $reason->title = $request->title;


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes an issue on the Create News page where the application crashes when attempting to save a news item without filling required fields (Title and Content).

### Changes Made

- Added proper server-side validation for required fields (title, content)
- Prevented form submission when mandatory fields are empty
- Ensured user-friendly validation messages are displayed instead of system errors

     Fixes: #629 
---

## ✅ Type of Change

-  Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1886" height="932" alt="image" src="https://github.com/user-attachments/assets/09615707-ddc9-4348-89ae-08d568733322" />


---

## 🚀 How Has This Been Tested?

- Tested on Create News page
- Submitted empty form (Title + Content)
- Confirmed validation messages appear correctly
- Verified no Laravel error page is shown
- Database remains unaffected when validation fails

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as admin
    URL: http://dev.tadreeblms.com/user/settings/notifications
    Email: testadmin@tadreeblms.com
    Password: 123456
2. Navigate to:
     Site Management → News & Update
3. Click Add New
4. Click Save without filling any fields
5. Form validation prevents submission
6. Proper messages shown:
“Title is required”
“Content is required”

---

## 🙏 Additional Notes

This improves:

- User experience
- System stability
- Security (prevents exposing internal errors)
