### PR TITLE
Fix validation error on latest libraries create form #637

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LibraryController.php
+++ b/app/Http/Controllers/Backend/Admin/LibraryController.php
@@ -110,6 +110,10 @@ class LibraryController extends Controller
     public function store(Request $request)
     {
 
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+        ]);
+        
         $reason = new  Library();
         $reason->title = $request->title;
         $reason->event_date = date('Y-m-d H:i:s', strtotime($request->event_date));

--- a/resources/views/backend/library/create.blade.php
+++ b/resources/views/backend/library/create.blade.php
@@ -36,6 +36,9 @@
                 <label for="title" class="control-label">{{ trans('labels.backend.reasons.fields.title') }} *</label>
                 <input class="form-control" placeholder="{{ trans('labels.backend.reasons.fields.title') }}" name="title" type="text" value="{{ old('title') }}">
 
+                @error('title')
+                    <span class="text-danger">{{ $message }}</span>
+                @enderror
             </div>
 
             <div class="col-md-12 col-lg-4 form-group">


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the validation issue in the Add Library form where submitting the form without entering a Title caused the application to crash and display a Laravel Flare error page with a raw database error.

### Changes Made

* Added server-side validation for the required Title field
* Added proper validation error message display in the UI
* Prevented raw database errors from being exposed to users
* Preserved old input values after validation failure

### Problem Solved

Previously, clicking the Save button without entering a Title redirected users to a Laravel Flare error page instead of showing a proper validation message.

Fixes: #637 

---

## ✅ Type of Change

* [x]  Bug fix
* [x]  Security improvement

---

## 📸 Screenshots (if applicable)

<img width="1900" height="931" alt="image" src="https://github.com/user-attachments/assets/9a099842-3da9-4eaf-87f3-93926cb2fbed" />

---

## 🚀 How Has This Been Tested?

* [x] Local environment
* [x] Browser testing

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login with admin credentials
2. Navigate to Site Management → Latest Libraries → Add Libraries
3. Click the Save button without entering a Title
4. Verify validation message is displayed instead of Laravel error page

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Verified no sensitive data is included
* [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This fix improves application stability and security by handling missing required fields properly and preventing exposure of internal database and framework error details to users.
