### PR TITLE
Fix clickable confirmed badge in user view page #632

### DIFF
--- a/app/Models/Auth/Traits/Attribute/UserAttribute.php
+++ b/app/Models/Auth/Traits/Attribute/UserAttribute.php
@@ -46,17 +46,10 @@ trait UserAttribute
     public function getConfirmedLabelAttribute()
     {
         if ($this->isConfirmed()) {
-            if ($this->id != 1 && $this->id != auth()->id()) {
-                return '<a href="'.route(
-                    'admin.auth.user.unconfirm',
-                        $this
-                ).'" data-toggle="tooltip" data-placement="top" title="'.__('buttons.backend.access.users.unconfirm').'" name="confirm_item"><span class="pill-publish" style="cursor:pointer">'.__('labels.general.yes').'</span></a>';
-            } else {
-                return '<span class="pill-publish">'.__('labels.general.yes').'</span>';
-            }
+            return "<span class='badge badge-success'>Yes</span>";
         }
 
-        return '<a href="'.route('admin.auth.user.confirm', $this).'" data-toggle="tooltip" data-placement="top" title="'.__('buttons.backend.access.users.confirm').'" name="confirm_item"><span class="badge badge-danger" style="cursor:pointer">'.__('labels.general.no').'</span></a>';
+        return "<span class='badge badge-danger'>No</span>";
     }
 
     /**


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the issue where the “Confirmed” status badge on the View User page was incorrectly interactive.

Previously, clicking the badge triggered a SweetAlert confirmation modal, even though the View User page is intended to be read-only. This created confusing behavior and exposed unintended actions from a non-editable screen.

### Changes Made

* Removed clickable/action behavior from the “Confirmed” status badge
* Replaced interactive link/button element with a read-only badge display
* Ensured the View User page remains fully non-interactive for status indicators

### Problem Solved

The “Confirmed” badge now:

* Displays confirmation status correctly
* Is fully read-only
* No longer triggers SweetAlert popup
* Prevents unintended user actions

Fixes: #632 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1916" height="943" alt="image" src="https://github.com/user-attachments/assets/719cd217-b6b4-4548-a810-3e5c0676291d" />

---

## 🚀 How Has This Been Tested?

* [x] Local environment
* [x] Browser testing


### Test Scenarios

1. Opened User Management → All Users
2. Opened View User page
3. Clicked “Confirmed” badge
4. Verified no popup/action occurs
5. Verified confirmation status still displays correctly

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as admin
2. Navigate to User Management → All Users
3. Click View icon for a user
4. Click on the “Confirmed” badge
5. No SweetAlert popup appears

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Verified no sensitive data is included
* [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This fix improves UI consistency by ensuring that read-only pages do not expose interactive actions through status badges.