### PR TITLE
Add SweetAlert confirmation for user status toggle #631

### DIFF
--- a/app/Models/Auth/Traits/Attribute/UserAttribute.php
+++ b/app/Models/Auth/Traits/Attribute/UserAttribute.php
@@ -197,28 +197,32 @@ trait UserAttribute
      * @return string
      */
     public function getStatusButtonAttribute()
-    {
-        if ($this->id != auth()->id()) {
-            switch ($this->active) {
-                case 0:
-                    return '<a title="Activate" href="'.route('admin.auth.user.mark', [
-                            $this,
-                            1,
-                        ]).'" class=""><i class="fas fa-check-circle"></i></a> ';
+{
+    if ($this->id != auth()->id()) {
 
-                case 1:
-                    return '<a title="Deactivate" href="'.route('admin.auth.user.mark', [
-                            $this,
-                            0,
-                        ]).'" class=""><i class="fas fa-ban"></i></a> ';
+        switch ($this->active) {
 
-                default:
-                    return '';
-            }
+            case 0:
+                return '<a class="js-status-toggle"
+                    data-url="'.route('admin.auth.user.mark', [$this, 1]).'"
+                    data-action="activate">
+                    <i class="fas fa-check-circle"></i>
+                </a>';
+
+            case 1:
+                return '<a class="js-status-toggle"
+                    data-url="'.route('admin.auth.user.mark', [$this, 0]).'"
+                    data-action="deactivate">
+                    <i class="fas fa-ban"></i>
+                </a>';
+
+            default:
+                return '';
         }
-
-        return '';
     }
+
+    return '';
+}
 
     /**
      * @return string

--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -271,6 +271,27 @@
     });
 
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+
+<script>
+$(document).on('click', '.js-status-toggle', function(e){
+    e.preventDefault();
+
+    let url = $(this).data('url');
+    let action = $(this).data('action');
+
+    Swal.fire({
+        title: action === 'activate' ? 'Are you sure you want to ACTIVATE this user?' : 'Are you sure you want to DEACTIVATE this user?',
+        icon: action === 'activate' ? 'question' : 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Yes'
+    }).then((result) => {
+        if(result.isConfirmed){
+            window.location.href = url;
+        }
+    });
+});
+</script>
 
     @stack('after-scripts')
 


### PR DESCRIPTION
📥 Pull Request: Add Confirmation Dialog for User Status Change

## 🔧 Description

This PR improves the safety of the All Users module by adding a confirmation step before activating or deactivating a user account.

Previously, clicking the activate/deactivate icon immediately changed the user’s status without any confirmation, which could lead to accidental or unintended changes—especially for important accounts like administrators.

This update introduces a confirmation dialog using SweetAlert before performing the status change.

### Changes Introduced
- Replaced direct status change behavior with a confirmation prompt
- Added SweetAlert confirmation dialog for activate/deactivate actions
- Improved user experience for sensitive actions

Fixes: #631 
---

## ✅ Type of Change

-  Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1913" height="926" alt="image" src="https://github.com/user-attachments/assets/99c9f089-cccd-4204-81fd-71d9a62c7171" />
<img width="1918" height="940" alt="image" src="https://github.com/user-attachments/assets/86c6b1c7-1d63-4cd5-b74d-56066cd3952e" />


---

## 🚀 How Has This Been Tested?

- [x] Local environment testing
- [x] Browser testing

---

## 🧪 Steps to Reproduce

1. Login with admin credentials  
   URL: http://dev.tadreeblms.com/user/settings/notifications  
   Username: testadmin@tadreeblms.com  
   Password: 123456  

2. Navigate to User Management → All Users

3. Click on Activate / Deactivate icon

4. A confirmation dialog appears before changing user status
5. Action executes only after user confirmation
6. Prevents accidental activation/deactivation

---

## 🔄 Checklist

-  Followed coding guidelines
-  Tested locally
-  Verified UI behavior
-  Ensured no side effects

---

## 🙏 Additional Notes

This update improves safety and aligns with standard UX practices for sensitive administrative actions.