### PR TITLE
Fix course publish confirmation #616

### DIFF
--- a/resources/views/backend/datatable/action-publish.blade.php
+++ b/resources/views/backend/datatable/action-publish.blade.php
@@ -1,4 +1,9 @@
 <a href="{{ $route }}"
-   class="" title="Upload" >
-<i class="fa fa-upload" aria-hidden="true"></i>
+   class=""
+   title="Publish"
+   name="confirm_item"
+   data-trans-button-cancel="{{ __('buttons.general.cancel') }}"
+   data-trans-button-confirm="{{ __('buttons.general.continue') }}"
+   data-trans-title="Are you sure you want to publish this course? This will make the course visible to trainees.">
+    <i class="fa fa-upload" aria-hidden="true"></i>
 </a>

--- a/resources/views/backend/datatable/action-unpublish.blade.php
+++ b/resources/views/backend/datatable/action-unpublish.blade.php
@@ -1,4 +1,9 @@
 <a href="{{ $route }}"
-   class="" title="Unpublish">
-	<i class="fas fa-ban"></i>
+   class=""
+   title="Unpublish"
+   name="confirm_item"
+   data-trans-button-cancel="{{ __('buttons.general.cancel') }}"
+   data-trans-button-confirm="{{ __('buttons.general.continue') }}"
+   data-trans-title="Are you sure you want to unpublish this course? This will make the course invisible to trainees.">
+    <i class="fas fa-ban"></i>
 </a>

--- a/tests/Unit/Backend/CoursePublishActionConfirmationTest.php
+++ b/tests/Unit/Backend/CoursePublishActionConfirmationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Backend;
+
+use PHPUnit\Framework\TestCase;
+
+class CoursePublishActionConfirmationTest extends TestCase
+{
+    public function test_course_unpublish_action_uses_confirmation_modal(): void
+    {
+        $view = file_get_contents(
+            __DIR__ . '/../../../resources/views/backend/datatable/action-unpublish.blade.php'
+        );
+
+        $this->assertStringContainsString('name="confirm_item"', $view);
+        $this->assertStringContainsString(
+            'Are you sure you want to unpublish this course? This will make the course invisible to trainees.',
+            $view
+        );
+        $this->assertStringContainsString('data-trans-button-confirm', $view);
+    }
+
+    public function test_course_publish_action_uses_confirmation_modal(): void
+    {
+        $view = file_get_contents(
+            __DIR__ . '/../../../resources/views/backend/datatable/action-publish.blade.php'
+        );
+
+        $this->assertStringContainsString('name="confirm_item"', $view);
+        $this->assertStringContainsString(
+            'Are you sure you want to publish this course? This will make the course visible to trainees.',
+            $view
+        );
+        $this->assertStringContainsString('data-trans-button-confirm', $view);
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR adds a confirmation prompt before admins publish or unpublish a course from the Courses action column.

Previously, clicking the Publish/Unpublish icon changed the course status immediately. The unpublish action can make a course invisible to trainees, so the UI now asks for confirmation before continuing.

#### What problem does this PR solve?

- Course publish/unpublish actions were executed instantly.
- Admins could accidentally unpublish a visible course without a warning.
- The expected unpublish confirmation message was missing.

#### What feature does it add?

- Adds a confirmation modal to the course Unpublish action.
- Adds a confirmation modal to the course Publish action for consistency.
- Reuses the existing backend SweetAlert confirmation handler.
- Adds regression coverage for the publish/unpublish action partials.

     Fixes: #616

---

## ✅ Type of Change

- Bug fix

---

## 📸 Screenshots

<img width="1613" height="741" alt="Screenshot_20260515_132756" src="https://github.com/user-attachments/assets/cfc201f5-7125-4870-b879-da7a58934f4d" />


---

## 🚀 How Has This Been Tested?

- Local environment
- PHP syntax checks
- Focused PHPUnit regression test

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an admin.
2. Navigate to Course management -> Courses.
3. Click the Unpublish icon in the action column.
4. Verify the confirmation modal appears before the course status changes.

---

## 🔄 Checklist

- Followed project coding guidelines.
- Reused existing confirmation modal behavior.
- Added test coverage for the confirmation attributes and messages.
- No breaking changes introduced.

---

## 🙏 Additional Notes

- Tested with `vendor/bin/phpunit tests/Unit/Backend/CoursePublishActionConfirmationTest.php`.
