### PR TITLE
Fix lesson course column rendering #617

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -97,13 +97,14 @@ class LessonsController extends Controller
                 return $actions;
             })
             ->editColumn('course', function ($q) {
-    if ($q->course) {
-        return '<a href="'.route('admin.courses.edit', $q->course->id).'">'
-            . e($q->course->title) .
-        '</a>';
-    }
-    return 'N/A';
-})
+                if ($q->course) {
+                    return '<a href="' . route('admin.courses.edit', $q->course->id) . '" class="text-primary">'
+                        . e($q->course->title) .
+                    '</a>';
+                }
+
+                return 'N/A';
+            })
             ->addColumn('attendance', function ($q) {
                 $courseId = (int) ($q->course_id ?? optional($q->course)->id ?? 0);
 
@@ -155,7 +156,7 @@ class LessonsController extends Controller
             })
             ->editColumn('free_lesson', fn($q) => $q->free_lesson == 1 ? 'Yes' : 'No')
             ->editColumn('published', fn($q) => $q->published == 1 ? 'Yes' : 'No')
-            ->rawColumns(['lesson_image', 'qr_code', 'attendance', 'actions'])
+            ->rawColumns(['lesson_image', 'course', 'qr_code', 'attendance', 'actions'])
             ->make();
     }
 

--- a/tests/Unit/Backend/LessonCourseColumnLinkTest.php
+++ b/tests/Unit/Backend/LessonCourseColumnLinkTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Backend;
+
+use PHPUnit\Framework\TestCase;
+
+class LessonCourseColumnLinkTest extends TestCase
+{
+    public function test_lessons_course_column_renders_clickable_course_link(): void
+    {
+        $controller = file_get_contents(
+            __DIR__ . '/../../../app/Http/Controllers/Backend/Admin/LessonsController.php'
+        );
+
+        $this->assertStringContainsString("->editColumn('course'", $controller);
+        $this->assertStringContainsString("route('admin.courses.edit'", $controller);
+        $this->assertStringContainsString('class="text-primary"', $controller);
+        $this->assertStringContainsString('e($q->course->title)', $controller);
+        $this->assertStringContainsString(
+            "->rawColumns(['lesson_image', 'course', 'qr_code', 'attendance', 'actions'])",
+            $controller
+        );
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the Lessons table Course column so it renders a proper clickable course link instead of escaped HTML/code text.

Previously, the backend returned an anchor tag for the Course column, but the column was not marked as raw HTML for DataTables. As a result, admins saw broken code strings instead of a usable course name link.

#### What problem does this PR solve?

- Raw HTML was displayed in the Lessons Course column.
- Course names were not rendered as clickable links.
- The Lessons table showed broken code strings instead of usable navigation.

#### What feature does it add?

- Marks the `course` DataTables column as raw HTML.
- Keeps the course title escaped for safe output.
- Adds a blue `text-primary` link to the course edit page.
- Adds regression coverage for the Course column link rendering.

     Fixes: #617

---

## ✅ Type of Change

- Bug fix

---

## 📸 Screenshots

<img width="1613" height="741" alt="Screenshot_20260515_133234" src="https://github.com/user-attachments/assets/43960c3b-b3e2-42d4-a0b1-8f21fc38e005" />


---

## 🚀 How Has This Been Tested?

- Local environment
- PHP syntax checks
- Focused PHPUnit regression test

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an admin.
2. Navigate to Course management -> Lessons.
3. Observe the Course column.
4. Verify each course displays as a clickable blue course-name link.

---

## 🔄 Checklist

- Followed project coding guidelines.
- Course title output remains escaped.
- Added regression coverage for the Lessons Course column link.
- No breaking changes introduced.

---

## 🙏 Additional Notes

- Tested with `vendor/bin/phpunit tests/Unit/Backend/LessonCourseColumnLinkTest.php`.
