### PR TITLE
Update Save button color in News update form #628

### DIFF
--- a/resources/views/backend/news/edit.blade.php
+++ b/resources/views/backend/news/edit.blade.php
@@ -83,7 +83,7 @@
                     </div>
 
                     <div class="col-12 form-group text-center">
-                        <button type="submit" class="btn mt-auto btn-danger">
+                        <button type="submit" class="btn mt-auto btn-primary">
                             {{ trans('strings.backend.general.app_save') }}
                         </button>
                     </div>


### PR DESCRIPTION
📥 Pull Request: Fix Save Button Color in News Update Interface

## 🔧 Description

In the Update News interface, the primary action button labeled “Save” was styled with a red background, which is not aligned with standard UI/UX design conventions.

Red color is typically used for destructive actions such as delete or remove. Using it for a positive action like “Save” can confuse users and reduce usability.

This PR updates the button styling to follow standard design conventions.

###  Changes Introduced
- Updated “Save” button color from red (btn-danger) to a neutral/positive style
- Improved UI consistency and user experience
- Aligned button styling with standard UX practices

Fixes: #628 

---

## ✅ Type of Change

- Bug fix
- UI/UX update

---

## 📸 Screenshots

<img width="1918" height="936" alt="image" src="https://github.com/user-attachments/assets/96500f4e-0d76-4796-9be7-e17f587577e0" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment testing
- [x] Browser testing

---

## 🧪 Steps to Reproduce

1. Login with admin credentials  
2. Go to Site Management → News & Update  
3. Edit any existing news record  
4. Observe Save button color

---

## 🔄 Checklist

- [x] UI follows standard UX guidelines
- [x] Tested locally
- [x] No functionality broken
