### PR TITLE
Fix: add required field indicators in blog create form #627

### DIFF
--- a/resources/views/backend/blogs/create.blade.php
+++ b/resources/views/backend/blogs/create.blade.php
@@ -51,12 +51,12 @@
         <div class="card-body">
             <div class="row">
                 <div class="col-12 col-lg-6 form-group">
-                    <label for="title" class="control-label">{{ trans('labels.backend.blogs.fields.title') }}</label>
+                    <label for="title" class="control-label">{{ trans('labels.backend.blogs.fields.title') }}<span class="text-danger">*</span></label>
                     <input class="form-control" placeholder="{{ trans('labels.backend.blogs.fields.title') }}" name="title" type="text" value="{{ old('title') }}" id="title">
                 </div>
 
                 <div class="col-12 col-lg-6 form-group">
-                    <label for="category" class="control-label">{{ trans('labels.backend.blogs.fields.category') }}</label>
+                    <label for="category" class="control-label">{{ trans('labels.backend.blogs.fields.category') }}<span class="text-danger">*</span></label>
                     <select class="form-control select2" name="category" id="category">
                         @foreach($category as $key => $value)
                             <option value="{{ $key }}" {{ (old('category') == $key) ? 'selected' : '' }}>{{ $value }}</option>
@@ -90,7 +90,7 @@
 
             <div class="row">
                 <div class="col-12 form-group">
-                    <label for="content" class="control-label">{{ trans('labels.backend.blogs.fields.content') }}</label>
+                    <label for="content" class="control-label">{{ trans('labels.backend.blogs.fields.content') }}<span class="text-danger">*</span></label>
                     <textarea class="form-control editor" placeholder="" id="editor" name="content" cols="50" rows="10">{{ old('content') }}</textarea>
 
                 </div>


### PR DESCRIPTION
📥 Pull Request: Add Required Field Indicators in Blog Create Form

## 🔧 Description

In the Create Blog form, required fields such as Title, Category, and Content were not visually marked as mandatory.

Although backend validation prevents empty submission, users are not informed upfront, leading to confusion and unnecessary form submission errors.

This PR improves form usability by clearly marking required fields with an asterisk (*).

###  Changes Introduced
- Added visual required indicators (*) to mandatory fields
- Improved form usability and user experience
- Aligned UI with standard form design practices

Fixes: #627 

---

## ✅ Type of Change

-  Bug fix
-  UI/UX update

---

## 📸 Screenshots

<img width="1915" height="939" alt="image" src="https://github.com/user-attachments/assets/95fddb6b-661b-4607-84f3-c4b402894185" />

---

## 🚀 How Has This Been Tested?

-  Local environment testing
-  Browser testing

---

## 🧪 Steps to Reproduce

1. Login with admin credentials  
2. Go to Site Management → Blog → Add Blog  
3. Click Publish without filling fields  
4. All required fields should be clearly marked with (*) before submission.

---

## 🔄 Checklist

-  UI updated for required fields
-  Tested locally
-  No layout issues introduced