### PR TITLE
fix(categories): show create success message

### DIFF
--- a/resources/views/backend/categories/create.blade.php
+++ b/resources/views/backend/categories/create.blade.php
@@ -21,7 +21,7 @@
             <div class="row">
                 <div class="col-12">
 
-                    <form method="POST" id="addcategory" enctype="multipart/form-data">
+                    <form method="POST" id="addcategory" action="{{ route('admin.categories.store') }}" enctype="multipart/form-data">
                     @csrf
 
                     <div class="row">
@@ -40,8 +40,6 @@
 
 
                 </div>
-                <input type="hidden" id="teacher" value="{{ route('admin.categories.index') }}">
-                <input type="hidden" id="new-assisment" value="{{ route('admin.courses.create') }}">
             </div>
         </div>
     </div>
@@ -70,49 +68,5 @@
         })
 
     </script>
-
-<script>
-
-$(document).on('submit', '#addcategory', function (e) {
-    e.preventDefault();
-    hrefurl=$(location).attr("href");
-  last_part=hrefurl.substr(hrefurl.lastIndexOf('/') + 8)
-//   alert(last_part)
-    // setTimeout(() => {
-        let data = $('#addcategory').serialize();
-        let url = '{{route('admin.categories.store')}}'
-        var redirect_url=$("#teacher").val()
-        var redirect_url_assi=$("#new-assisment").val()
-    $.ajax({
-            type: 'POST',
-            url: url,
-            data: data,
-            datatype: "json",
-            success: function (res) {
-            console.log(res)
-            // alert(last_part)
-                if(last_part == 'create'){
-                    window.location.href = redirect_url_assi;
-                    return;
-                }
-                else{
-                    window.location.href = redirect_url;
-                    return;
-                }
-            },
-            error: function(xhr, status, error) {
-                console.log(xhr)
-                res= JSON.parse(xhr.responseText)
-                if (res.errors) {
-                    var firstError = Object.values(res.errors)[0][0];
-                    alert(firstError);
-                } else {
-                    alert('An error occurred. Please try again.');
-                }
-            }
-        })
-    // }, 100);
-})
-</script>
 
 @endpush


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Restores success feedback after creating a category by letting the Create Category form use the normal Laravel POST/redirect flow.

- Adds the explicit form action for the category store route.
- Removes the AJAX submit handler that consumed the flashed redirect response before the browser navigation.
- Reuses the existing controller success flash and backend message partial.

Fixes: #624

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1618" height="843" alt="Screenshot_20260515_165738" src="https://github.com/user-attachments/assets/a267dd28-78f9-48f6-9784-3e5f34ef9711" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Verified the Blade diff, confirmed the controller already flashes alerts.backend.general.created, and ran git diff --check.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to the Categories module from the menu bar.
2. Click Add and create a category.
3. Confirm the user is redirected to the categories list and the success message is displayed.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project coding guidelines
- [x] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

The backend layout already includes the shared flash message partial, and CategoriesController already returns withFlashSuccess after store. The AJAX submit handler prevented that flashed message from surviving to the page load.