### PR TITLE
Fix required marker on lesson course field

### DIFF
--- a/resources/views/backend/lessons/create.blade.php
+++ b/resources/views/backend/lessons/create.blade.php
@@ -127,11 +127,11 @@
                             <div class="col-md-6">
                                 <div class="form-group">
                                     <div for="course_id" class="form-control-label">
-                                        {{ trans('labels.backend.lessons.fields.course') }}
+                                        {{ trans('labels.backend.lessons.fields.course') }} *
                                     </div>
                                     <div class="mt-2 custom-select-wrapper">
                                         <select id="course_id" name="course_id"
-                                            class="form-control custom-select-box course_id select2">
+                                            class="form-control custom-select-box course_id select2" required>
                                             @foreach ($courses as $key => $course)
                                                 <option value="{{ $key }}"
                                                     {{ old('course_id') == $key || request('course_id') == $key ? 'selected' : '' }}>


### PR DESCRIPTION
# Pull Request Template

## Description

- Marks the Create Lesson form Course field as required by displaying the same asterisk used on the Title field.
- Adds the `required` attribute to the Course dropdown so the client-side markup matches the existing server-side validation.
- Keeps the change scoped to the lesson creation view.

Fixes: #619

---

## Type of Change

Select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [x] UI/UX update
- [ ] Security improvement
- [ ] Other (please describe):

---

## Screenshots (if applicable)

<img width="779" height="436" alt="Screenshot_20260515_173855" src="https://github.com/user-attachments/assets/d814db76-12e4-492f-a195-3f656699978e" />


---

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: `git diff --check`

---

## Steps to Reproduce (for bug fixes)

1. Log in as an admin.
2. Navigate to Course Management > Lesson > Add Lesson.
3. Observe the Course dropdown label in the Create Lesson form.

---

## Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [x] Updated documentation (if needed)
- [x] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [ ] Ensured the app builds without errors

---

## Additional Notes

Only `resources/views/backend/lessons/create.blade.php` is included in this PR.
