### PR TITLE
Published status display on test details page #621

### DIFF
--- a/resources/views/backend/tests/show.blade.php
+++ b/resources/views/backend/tests/show.blade.php
@@ -37,7 +37,9 @@
                         </tr>
                         <tr>
                             <th>@lang('labels.backend.tests.fields.published')</th>
-                            <td><input type=\"checkbox\" value=\"1\" @if($test->published == 1) checked @endif disabled></td>
+                            <td>
+                                {{ $test->published ? 'Yes' : 'No' }}
+                            </td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixed incorrect display of the “Published” field on the Test Details page.

Previously, the details view showed a raw/encoded value such as "\1" instead of a user-friendly status.

This PR updates the Test Details UI to display:
- "Yes" when the test is published
- "No" when the test is unpublished

The behavior is now consistent with the Tests listing page.

Fixes: #621 

---

## ✅ Type of Change

- Bug fix

---

## 🧪 How Has This Been Tested?

1. Logged in as admin
2. Navigated to Course Management → Tests
3. Opened Test Details page
4. Verified:
   - Published tests display "Yes"
   - Unpublished tests display "No"

---

## 📸 Screenshots (if applicable)

<img width="1915" height="946" alt="image" src="https://github.com/user-attachments/assets/af31a79e-611e-462d-8b1b-dff94411522d" />
<img width="1916" height="942" alt="image" src="https://github.com/user-attachments/assets/437aad43-97ad-4c0f-bd31-c46822777da8" />

---

## ✅ Checklist

- My code follows the project coding style
- I have tested my changes locally
- I have checked for existing issues/PRs
- No unnecessary files were changed