### PR TITLE
fix(subscription): show employee request status feedback

### DIFF
--- a/app/Http/Controllers/Backend/Admin/SubscriptionController.php
+++ b/app/Http/Controllers/Backend/Admin/SubscriptionController.php
@@ -330,13 +330,23 @@ class SubscriptionController extends Controller
         return redirect()->route('admin.subscription.index')->withFlashSuccess(trans('alerts.backend.general.deleted'));
     }
 
-    public function updateStatus()
+    public function updateStatus(Request $request)
     {
-        //dd('sfs');
-        $teacher = SubscribeCourse::find(request('id'));
+        $request->validate([
+            'id' => ['required', 'integer', 'exists:subscribe_courses,id'],
+        ]);
+
+        $teacher = SubscribeCourse::findOrFail($request->id);
         $teacher->status = $teacher->status == 1? 0 : 1;
 
         $status = $teacher->save();
+        if (! $status) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('Unable to update status. Please try again.'),
+            ], 500);
+        }
+
         if($teacher->status == 1) {
             DB::table('course_student')->insert([
                 'course_id' => $teacher->course_id,
@@ -351,6 +361,12 @@ class SubscriptionController extends Controller
                 'user_id' => $teacher->user_id
                ])->delete();
         }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => __('Status updated successfully.'),
+            'updated_status' => $teacher->status,
+        ]);
     }
 
 

--- a/resources/views/backend/subscription/index.blade.php
+++ b/resources/views/backend/subscription/index.blade.php
@@ -8,6 +8,7 @@
 
  
     </style>
+@endpush
 
 @section('content')
 
@@ -23,6 +24,7 @@
         <div class="card-body">
 
             <div class="table-responsive">
+                <div id="subscription-status-message" class="mb-3" aria-live="polite"></div>
                 <div class="d-block">
                     <ul class="list-inline">
                         <li class="list-inline-item">
@@ -74,6 +76,10 @@
 
 @push('after-scripts')
     <script>
+        var subscriptionStatusUpdatedMessage = @json(__('Status updated successfully.'));
+        var subscriptionStatusUpdateFailedMessage = @json(__('Unable to update status. Please try again.'));
+        var subscriptionStatusCloseLabel = @json(__('Close'));
+
         $(document).ready(function() {
             var route = '{{ route('admin.subscription.get_data') }}';
 
@@ -226,8 +232,26 @@
 
         });
 
+        function showSubscriptionStatusMessage(message, type) {
+            var alertClass = type === 'success' ? 'alert-success' : 'alert-danger';
+            var escapedMessage = $('<div>').text(message).html();
+
+            $('#subscription-status-message').html(
+                '<div class="alert ' + alertClass + ' alert-dismissible fade show" role="alert">' +
+                    escapedMessage +
+                    '<button type="button" class="close" data-dismiss="alert" aria-label="' + subscriptionStatusCloseLabel + '">' +
+                        '<span aria-hidden="true">&times;</span>' +
+                    '</button>' +
+                '</div>'
+            );
+        }
+
         $(document).on('click', '.switch-input', function(e) {
-            var id = $(this).data('id');
+            var $switch = $(this);
+            var id = $switch.data('id');
+
+            $switch.prop('disabled', true);
+
             $.ajax({
                 type: "POST",
                 url: "{{ route('admin.subscription.status') }}",
@@ -235,9 +259,23 @@
                     _token: '{{ csrf_token() }}',
                     id: id,
                 },
-            }).done(function() {
+            }).done(function(response) {
+                showSubscriptionStatusMessage(
+                    response.message || subscriptionStatusUpdatedMessage,
+                    'success'
+                );
+
                 var table = $('#myTable').DataTable();
-                table.ajax.reload();
+                table.ajax.reload(null, false);
+            }).fail(function(xhr) {
+                var message = xhr.responseJSON && xhr.responseJSON.message
+                    ? xhr.responseJSON.message
+                    : subscriptionStatusUpdateFailedMessage;
+
+                showSubscriptionStatusMessage(message, 'error');
+
+                var table = $('#myTable').DataTable();
+                table.ajax.reload(null, false);
             });
         })
     </script>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Adds visible feedback after enabling or disabling the status toggle in the Employees Request table.

- Returns a JSON success response from the subscription status endpoint after the server saves the change.
- Displays a dismissible green confirmation alert above the table when the AJAX update succeeds.
- Displays an error alert and reloads the table if the AJAX update fails.
- Closes the missing Blade `after-styles` stack in the Employee Requests view.

Fixes: #611

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1611" height="655" alt="Screenshot_20260517_104541" src="https://github.com/user-attachments/assets/9b40cda9-8b05-4a0c-b696-d42b285f530d" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Ran `php -l app/Http/Controllers/Backend/Admin/SubscriptionController.php` and `git diff --check`. Full Artisan/PHPUnit checks were not run in the isolated worktree because vendor dependencies are not present there.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in with admin credentials.
2. Navigate to Employee Requests from the side menu.
3. Click the status toggle for an employee request.
4. Confirm a green "Status updated successfully." message appears above the table after the server update completes.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project coding guidelines
- [x] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [ ] Ensured the app builds without errors

---

## 🙏 Additional Notes

The fix uses an inline Bootstrap alert instead of adding a new toast dependency, matching the backend layout's existing alert styling.
