### PR TITLE
Fix course timeline completed badge overlap

### DIFF
--- a/public/assets-rtl/css/style.css
+++ b/public/assets-rtl/css/style.css
@@ -5186,6 +5186,10 @@ ul.product-tab li.active:after {
     color: #333;
 }
 
+.affiliate-market-accordion .panel-group .panel-title .btn-link {
+    padding-left: 150px;
+}
+
 .affiliate-market-accordion .panel-group .panel-title h3:before {
     display: none;
 }
@@ -5237,6 +5241,18 @@ ul.product-tab li.active:after {
 
 .affiliate-market-accordion .panel-group .btn-link.collapsed:after {
     color: #d9d9d9;
+}
+
+.affiliate-market-accordion .course-timeline-completed-badge {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 8px;
+    position: relative;
+    z-index: 2;
+}
+
+.affiliate-market-accordion .course-timeline-panel-completed .panel-title .btn-link {
+    padding-left: 70px;
 }
 
 .course-by {

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -4102,6 +4102,9 @@ ul.product-tab li.active:after {
 .affiliate-market-accordion .panel-group .panel-title .btn-link span {
   color: #17d0cf; }
 
+.affiliate-market-accordion .panel-group .panel-title .btn-link {
+  padding-right: 150px; }
+
 .affiliate-market-accordion .leanth-course {
   position: absolute;
   right: 60px;
@@ -4117,6 +4120,16 @@ ul.product-tab li.active:after {
 
 .affiliate-market-accordion .panel-group .btn-link.collapsed:after {
   color: #d9d9d9; }
+
+.affiliate-market-accordion .course-timeline-completed-badge {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 2; }
+
+.affiliate-market-accordion .course-timeline-panel-completed .panel-title .btn-link {
+  padding-right: 70px; }
 
 .course-by {
   font-weight: 700;

--- a/public/css/frontend-rtl.css
+++ b/public/css/frontend-rtl.css
@@ -5162,6 +5162,10 @@ ul.product-tab li.active:after {
   color: #333;
 }
 
+.affiliate-market-accordion .panel-group .panel-title .btn-link {
+  padding-right: 150px;
+}
+
 .affiliate-market-accordion .panel-group .panel-title h3:before {
   display: none;
 }
@@ -5212,6 +5216,18 @@ ul.product-tab li.active:after {
 
 .affiliate-market-accordion .panel-group .btn-link.collapsed:after {
   color: #d9d9d9;
+}
+
+.affiliate-market-accordion .course-timeline-completed-badge {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 2;
+}
+
+.affiliate-market-accordion .course-timeline-panel-completed .panel-title .btn-link {
+  padding-right: 70px;
 }
 
 .course-by {
@@ -5926,4 +5942,3 @@ ul.product-tab li.active:after {
   
 
 }
-

--- a/public/css/frontend.css
+++ b/public/css/frontend.css
@@ -5533,6 +5533,10 @@ ul.product-tab li.active:after {
   color: #333;
 }
 
+.affiliate-market-accordion .panel-group .panel-title .btn-link {
+  padding-right: 150px;
+}
+
 .affiliate-market-accordion .panel-group .panel-title h3:before {
   display: none;
 }
@@ -5587,6 +5591,18 @@ ul.product-tab li.active:after {
 
 .affiliate-market-accordion .panel-group .btn-link.collapsed:after {
   color: #d9d9d9;
+}
+
+.affiliate-market-accordion .course-timeline-completed-badge {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 2;
+}
+
+.affiliate-market-accordion .course-timeline-panel-completed .panel-title .btn-link {
+  padding-right: 70px;
 }
 
 .course-by {

--- a/resources/sass/frontend-rtl/_course.scss
+++ b/resources/sass/frontend-rtl/_course.scss
@@ -146,6 +146,9 @@
 	.panel-group .panel-body {
 		color:  #333;
 	}
+	.panel-group .panel-title .btn-link {
+		padding-right: 150px;
+	}
 	.panel-group .panel-title h3:before {
 		display: none;
 	}
@@ -194,6 +197,16 @@
 	}
 	.panel-group .btn-link.collapsed:after {
 		color: #d9d9d9;
+	}
+	.course-timeline-completed-badge {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 8px;
+		position: relative;
+		z-index: 2;
+	}
+	.course-timeline-panel-completed .panel-title .btn-link {
+		padding-right: 70px;
 	}
 }
 .course-by {

--- a/resources/sass/frontend/gc-theme/_course.scss
+++ b/resources/sass/frontend/gc-theme/_course.scss
@@ -159,6 +159,9 @@
 	.panel-group .panel-body {
 		color:  #333;
 	}
+	.panel-group .panel-title .btn-link {
+		padding-right: 150px;
+	}
 	.panel-group .panel-title h3:before {
 		display: none;
 	}
@@ -210,6 +213,16 @@
 	}
 	.panel-group .btn-link.collapsed:after {
 		color: #d9d9d9;
+	}
+	.course-timeline-completed-badge {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 8px;
+		position: relative;
+		z-index: 2;
+	}
+	.course-timeline-panel-completed .panel-title .btn-link {
+		padding-right: 70px;
 	}
 }
 .course-by {

--- a/resources/views/frontend-rtl/courses/course.blade.php
+++ b/resources/views/frontend-rtl/courses/course.blade.php
@@ -133,10 +133,10 @@ $subscribe_status = CustomHelper::courseStatus($course->id);
                                             @php $count++ @endphp
 
 
-                                            <div class="panel position-relative">
+                                            <div class="panel position-relative @if(auth()->check() && in_array($lesson->model->id,$completed_lessons)) course-timeline-panel-completed @endif">
                                             @if(auth()->check())
                                                 @if(in_array($lesson->model->id,$completed_lessons))
-                                                    <div class="position-absolute" style="right: 0;top:0px">
+                                                    <div class="course-timeline-completed-badge">
                                                         <span class="gradient-bg p-1 text-white font-weight-bold completed">@lang('labels.frontend.course.completed')</span>
                                                     </div>
                                                 @endif

--- a/resources/views/frontend/courses/course.blade.php
+++ b/resources/views/frontend/courses/course.blade.php
@@ -161,10 +161,10 @@ $subscribe_status = CustomHelper::courseStatus($course->id);
                                     @foreach($lessons as $key=> $lesson)
                                         @if($lesson->model && $lesson->model->published == 1)
                                             @php $count++ @endphp
-                                            <div class="panel position-relative">
+                                            <div class="panel position-relative @if(auth()->check() && in_array($lesson->model->id,$completed_lessons)) course-timeline-panel-completed @endif">
                                                 @if(auth()->check())
                                                     @if(in_array($lesson->model->id,$completed_lessons))
-                                                        <div class="position-absolute" style="right: 0;top:0px">
+                                                        <div class="course-timeline-completed-badge">
                                                             <span class="gradient-bg p-1 text-white font-weight-bold completed">@lang('labels.frontend.course.completed')</span>
                                                         </div>
                                                     @endif

--- a/resources/views/frontend/department/course.blade.php
+++ b/resources/views/frontend/department/course.blade.php
@@ -125,10 +125,10 @@ $subscribe_status = CustomHelper::courseStatus($course->id);
                                         @if($lesson->model && $lesson->model->published == 1)
                                             @php $count++ @endphp
 
-                                            <div class="panel position-relative">
+                                            <div class="panel position-relative @if(auth()->check() && in_array($lesson->model->id,$completed_lessons)) course-timeline-panel-completed @endif">
                                                 @if(auth()->check())
                                                     @if(in_array($lesson->model->id,$completed_lessons))
-                                                        <div class="position-absolute" style="right: 0;top:0px">
+                                                        <div class="course-timeline-completed-badge">
                                                             <span class="gradient-bg p-1 text-white font-weight-bold completed">@lang('labels.frontend.course.completed')</span>
                                                         </div>
                                                     @endif


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes the Course Timeline completed-state layout so the Completed badge no longer overlaps the accordion button text or status icon.

- Moves the completed badge out of absolute overlap with the lesson title
- Adds a completed-panel class to reserve clean spacing for completed timeline rows
- Updates LTR, RTL, Sass source, and compiled frontend CSS assets

Fixes: #641

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="873" height="285" alt="Screenshot_20260517_105525" src="https://github.com/user-attachments/assets/57e8f563-1370-4a38-8b53-0d003be3ad36" />

---

<img width="887" height="278" alt="Screenshot_20260517_105556" src="https://github.com/user-attachments/assets/b1cebebe-fa68-4ff8-94d4-51acc4191070" />


---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Ran `git diff --check` and `git diff --cached --check`.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to the Course module.
2. Open a course with completed lessons, for example the Java course.
3. Open the first completed lesson and observe the Course Timeline labels.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This is a CSS/view-only fix.
