### PR TITLE
Fix trainee position column translation

### DIFF
--- a/resources/lang/ar/position_pages.php
+++ b/resources/lang/ar/position_pages.php
@@ -15,6 +15,9 @@ return array(
     'delete_selected' => 'حذف المحدد',
     'no_data_available' => 'لا توجد بيانات متاحة.',
   ),
+  'table' => array(
+    'position_name' => 'اسم المنصب',
+  ),
   'create' => array(
     'title' => 'إنشاء منصب',
     'view_positions' => 'عرض المناصب',

--- a/resources/lang/en/position_pages.php
+++ b/resources/lang/en/position_pages.php
@@ -15,6 +15,9 @@ return array(
     'delete_selected' => 'Delete selected',
     'no_data_available' => 'No Data Is Available.',
   ),
+  'table' => array(
+    'position_name' => 'Position Name',
+  ),
   'create' => array(
     'title' => 'Create Position',
     'view_positions' => 'View Positions',

--- a/resources/lang/es/position_pages.php
+++ b/resources/lang/es/position_pages.php
@@ -15,6 +15,9 @@ return array(
     'delete_selected' => 'Eliminar seleccionados',
     'no_data_available' => 'No hay datos disponibles.',
   ),
+  'table' => array(
+    'position_name' => 'Nombre de posicion',
+  ),
   'create' => array(
     'title' => 'Crear posicion',
     'view_positions' => 'Ver posiciones',

--- a/resources/lang/fr/position_pages.php
+++ b/resources/lang/fr/position_pages.php
@@ -15,6 +15,9 @@ return array(
     'delete_selected' => 'Supprimer la sélection',
     'no_data_available' => 'Aucune donnée disponible.',
   ),
+  'table' => array(
+    'position_name' => 'Nom du poste',
+  ),
   'create' => array(
     'title' => 'Créer un poste',
     'view_positions' => 'Voir les postes',

--- a/resources/lang/it/position_pages.php
+++ b/resources/lang/it/position_pages.php
@@ -15,6 +15,9 @@ return array(
     'delete_selected' => 'Elimina selezionati',
     'no_data_available' => 'Nessun dato disponibile.',
   ),
+  'table' => array(
+    'position_name' => 'Nome posizione',
+  ),
   'create' => array(
     'title' => 'Crea posizione',
     'view_positions' => 'Visualizza posizioni',


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes the Trainees management table header showing the raw translation key `position_pages.table.position_name` instead of a readable label.

- Adds the missing `position_pages.table.position_name` translation entry
- Covers the available locale files for English, Arabic, Spanish, French, and Italian
- Keeps the existing table Blade markup unchanged

Fixes: #605

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1588" height="159" alt="Screenshot_20260517_111240" src="https://github.com/user-attachments/assets/5d5b9cd7-27b6-4535-b3a6-0eff28712929" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Local environment
- [ ] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Ran `php -l` on each modified language file, plus `git diff --check` and `git diff --cached --check`.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in with an admin account.
2. Navigate to User Management > Trainees.
3. Observe the Trainees table headers.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This is a translation-only fix. No database changes are included.
