### PR TITLE
Fix live course section header contrast

### DIFF
--- a/resources/views/backend/courses/create.blade.php
+++ b/resources/views/backend/courses/create.blade.php
@@ -62,10 +62,35 @@
     }
 
     span.course-type-desc {
+        display: block;
+        width: 100%;
+        color: #343a40;
         padding: 0 0 0 20px;
         font-size: 12px;
         font-weight: bold;
         font-style: italic;
+    }
+
+    .course-live-online-section {
+        display: block;
+        width: 100%;
+        font-style: normal;
+    }
+
+    .course-live-online-section .card-header {
+        background: #eef3f8 !important;
+        border: 1px solid #d8e2ef;
+        border-left: 4px solid #233e74;
+        color: #233e74 !important;
+        padding-left: 1.25rem;
+    }
+
+    .course-live-online-section .card-header h5,
+    .course-live-online-section .card-header i {
+        color: #233e74 !important;
+        font-weight: 600;
+        margin-left: 0.5em;
+        margin-top: 0.5em;
     }
 
     .create_done {
@@ -431,7 +456,7 @@
                         <span id="e-learning">
                             {{ __('course_pages.admin_create.e_learning_desc') }}
                         </span>
-                        <span id="live-online" style="display: none;">
+                        <span id="live-online" class="course-live-online-section" style="display: none;">
                             {{ __('course_pages.admin_create.live_online_desc') }}
                             @if(count($enabledMeetingProviders ?? []))
                                 {{-- Meeting Provider & Timezone (always visible for Live-Online) --}}
@@ -886,7 +911,7 @@
 
             } else if (type === 'Offline') { // Live-Online
                 $('#e-learning').hide();
-                $('#live-online').show();
+                $('#live-online').show().css('display', 'block');
                 $('#live-classroom').hide();
 
                 $('#main-flow').hide();

--- a/resources/views/backend/courses/edit.blade.php
+++ b/resources/views/backend/courses/edit.blade.php
@@ -62,10 +62,35 @@
     }
 
     span.course-type-desc {
+        display: block;
+        width: 100%;
+        color: #343a40;
         padding: 0 0 0 20px;
         font-size: 12px;
         font-weight: bold;
         font-style: italic;
+    }
+
+    .course-live-online-section {
+        display: block;
+        width: 100%;
+        font-style: normal;
+    }
+
+    .course-live-online-section .card-header {
+        background: #eef3f8 !important;
+        border: 1px solid #d8e2ef;
+        border-left: 4px solid #233e74;
+        color: #233e74 !important;
+        padding-left: 1.25rem;
+    }
+
+    .course-live-online-section .card-header h5,
+    .course-live-online-section .card-header i {
+        color: #233e74 !important;
+        font-weight: 600;
+        margin-left: 0.5em;
+        margin-top: 0.5em;
     }
 
     .create_done {
@@ -417,7 +442,7 @@
                         <span id="e-learning">
                             E-Learning type course is a course which can be taken online.
                         </span>
-                        <span id="live-online" style="display: none;">
+                        <span id="live-online" class="course-live-online-section" style="display: none;">
                             Live-Online type course is a course can be done on goole meet/Zoom link.
                             @if(count($enabledMeetingProviders ?? []))
                                 <div class="card mt-3" id="meeting-provider-section">
@@ -997,7 +1022,7 @@
             } else {
                 // Live Courses
                 $('#e-learning').hide();
-                type === 'Offline' ? $('#live-online').show() : $('#live-classroom').show();
+                type === 'Offline' ? $('#live-online').show().css('display', 'block') : $('#live-classroom').show();
 
                 $('#date-fields').show();
                 $('#start_date, #expire_at').prop('required', true);
@@ -1052,7 +1077,7 @@
 
             // course description
             $('#e-learning').toggle(type === 'Online');
-            $('#live-online').toggle(type === 'Offline');
+            $('#live-online').toggle(type === 'Offline').css('display', type === 'Offline' ? 'block' : 'none');
             $('#live-classroom').toggle(type === 'Live-Classroom');
         }
 


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes Live Online course creation/edit section headers that could render as white text on a white background, making the section titles invisible.

- Adds scoped Live Online section styling with explicit header contrast
- Keeps the Live Online content block-level when shown
- Adds spacing between the section title/icon and the left accent border
- Applies the same fix to course create and edit workflows

Fixes: #646

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1283" height="368" alt="Screenshot_20260517_112317" src="https://github.com/user-attachments/assets/bee6b63c-541e-48a7-bf42-cc436da5d4e8" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Ran `git diff --check` and `git diff --cached --check`.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in with an admin account.
2. Navigate to Course Management > Courses > Add Course.
3. Select the Live Online course type.
4. Observe the Meeting Configuration and Live Session Scheduling section headers.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This is a view/CSS-only fix. No database changes are included.
