### PR TITLE
fix: resolve trainer status toggle sync issue #615

### DIFF
--- a/resources/views/backend/teachers/index.blade.php
+++ b/resources/views/backend/teachers/index.blade.php
@@ -241,42 +241,72 @@ $(function () {
     });
 
     
-    // Status switch with confirmation (matches employee behavior)
-    $(document).on('click', '.switch-input', function (e) {
-        e.preventDefault();
+    // Stable trainer status toggle
+    $(document).on('change', '.switch-input', function (e) {
 
         let checkbox = $(this);
+
+        // Prevent double clicking
+        if (checkbox.data('processing')) {
+            return false;
+        }
+
+        checkbox.data('processing', true);
+
         let id = checkbox.data('id');
-        let isChecked = checkbox.is(':checked');
+        let isChecked = checkbox.prop('checked');
 
         let message = isChecked
             ? '{{ __('admin_pages.teachers.activate_user_confirm') }}'
             : '{{ __('admin_pages.teachers.deactivate_user_confirm') }}';
 
         if (!confirm(message)) {
-            // revert toggle state if cancelled
+
+            // revert immediately if cancelled
             checkbox.prop('checked', !isChecked);
+            checkbox.data('processing', false);
+
             return false;
         }
 
         $.ajax({
             type: "POST",
             url: "{{ route('admin.teachers.status') }}",
+
             data: {
                 _token: "{{ csrf_token() }}",
                 id: id,
+                status: isChecked ? 1 : 0
             },
-            success: function () {
+
+            success: function (response) {
+
+                checkbox.data('processing', false);
+
+                // Keep UI synced
+                checkbox.prop('checked', response.status == 1);
+
+                // Reload table without page refresh
                 table.ajax.reload(null, false);
+
+                // Optional success toast
+                if (typeof toastr !== 'undefined') {
+                    toastr.success('Status updated successfully');
+                }
             },
+
             error: function () {
-                alert('{{ __('admin_pages.teachers.something_went_wrong') }}');
+
+                checkbox.data('processing', false);
+
+                // revert if failed
                 checkbox.prop('checked', !isChecked);
+
+                alert('{{ __('admin_pages.teachers.something_went_wrong') }}');
             }
         });
     });
-
-    });
+});
 </script>
 
 @endpush


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the trainer status toggle synchronization issue in the User Management module.

Previously, the trainer status toggle required multiple attempts before the backend successfully processed the request. The frontend toggle state became out-of-sync due to duplicate event binding and improper AJAX synchronization.

This fix:

* prevents duplicate toggle requests
* ensures backend synchronization on first click
* properly handles AJAX success/error states
* keeps the UI toggle state aligned with backend data
* adds reliable success/error feedback messages

Fixes: #615 

---

## ✅ Type of Change

* [x] Bug fix

---

## 🧪 How Has This Been Tested?

* Verified trainer status toggle updates successfully on first click
* Confirmed no multiple-click issue remains
* Tested success and failure scenarios
* Verified DataTable redraw does not break toggle functionality
* Confirmed UI state remains synchronized after refresh

---

## 📸 Screenshots (if applicable)

<img width="1912" height="997" alt="image" src="https://github.com/user-attachments/assets/2c6472a2-ec2a-496e-a66c-5935708404b4" />

---

## 🚀 Checklist

* [x] Code follows project coding standards
* [x] Existing functionality remains unaffected
* [x] AJAX synchronization verified
* [x] No console or Laravel errors
* [x] Branch created from latest main branch
