### PR TITLE
fix: align notification setting toggles with labels #601

### DIFF
--- a/resources/views/backend/settings/notifications.blade.php
+++ b/resources/views/backend/settings/notifications.blade.php
@@ -11,11 +11,35 @@
         margin-bottom: 0px;
         vertical-align: middle;
     }
+    .notification-setting-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px 0;
+        border-bottom: 1px solid #f1f1f1;
+        gap: 20px;
+    }
+
+    .notification-setting-row:last-child {
+        border-bottom: none;
+    }
+
+    .notification-label {
+        font-size: 15px;
+        font-weight: 500;
+        color: #2d3748;
+        margin-bottom: 0;
+    }
+
     .toggle-group {
         display: flex;
-        gap: 20px;
         align-items: center;
-        justify-content: flex-end;
+        justify-content: flex-start;
+        min-width: 60px;
+    }
+
+    .switch.switch-3d {
+        margin-bottom: 0 !important;
     }
     .card {
         margin-bottom: 20px;
@@ -48,19 +72,18 @@
 
         <div class="row mt-4 mb-4">
             <div class="col">
-                <div class="form-group row">
-                    <label class="col-md-6 form-control-label">{{ __('labels.notifications.settings.email_notifications') }}</label>
-                    <div class="col-md-6">
-                        <div class="toggle-group">
-                            <label class="switch switch-3d switch-primary">
-                                <input type="checkbox" class="switch-input channel-master-toggle" data-channel="email" checked>
-                                <span class="switch-label"></span>
-                                <span class="switch-handle"></span>
-                            </label>
-                        </div>
+                <div class="notification-setting-row">
+                    <label class="notification-label">
+                        {{ __('labels.notifications.settings.email_notifications') }}
+                    </label>
+                    <div class="toggle-group">
+                        <label class="switch switch-3d switch-primary">
+                            <input type="checkbox" class="switch-input channel-master-toggle" data-channel="email" checked>
+                            <span class="switch-label"></span>
+                            <span class="switch-handle"></span>
+                        </label>
                     </div>
                 </div>
-
             </div>
         </div>
     </div>
@@ -82,25 +105,27 @@
         <div class="row mt-4 mb-4">
             <div class="col">
                 @foreach($module['events'] as $eventKey => $event)
-                <div class="form-group row">
-                    <label class="col-md-6 form-control-label">{{ $event['label'] }}</label>
-                    <div class="col-md-6">
-                        <div class="toggle-group">
-                            @php $emailChannel = $event['channels']['email'] ?? null; @endphp
-                            @if($emailChannel)
+                <div class="notification-setting-row">
+                    <label class="notification-label">
+                        {{ $event['label'] }}
+                    </label>
+                    <div class="toggle-group">
+                        @php $emailChannel = $event['channels']['email'] ?? null; @endphp
+                        @if($emailChannel)
                             <label class="switch switch-3d switch-primary">
                                 <input type="checkbox"
                                     class="switch-input notification-toggle"
                                     data-module="{{ $moduleKey }}"
                                     data-event="{{ $eventKey }}"
                                     data-channel="email"
-                                    {{ $emailChannel['enabled'] ? 'checked' : '' }}>
+                                    {{ $emailChannel['enabled'] ? 'checked' : '' }}
+                                >
                                 <span class="switch-label"></span>
                                 <span class="switch-handle"></span>
                             </label>
-                            @endif
-                        </div>
+                        @endif
                     </div>
+
                 </div>
                 @endforeach
             </div>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the alignment issue on the Notification Settings page where toggle switches were pushed too far to the right side, causing inconsistent spacing and poor visual association with their corresponding labels.

The layout has been updated using a cleaner flexbox-based structure to properly align toggles next to notification labels while maintaining responsive behavior and consistent UI spacing.

### Fixed Issues

* Excessive horizontal spacing between labels and toggles
* Toggle switches appearing detached from corresponding labels
* Inconsistent notification settings layout

Fixes: #601 

---

## ✅ Type of Change

* [x] Bug fix

---

## 🧪 How Has This Been Tested?

* Verified Notification Settings page manually
* Checked toggle alignment consistency across all sections
* Confirmed responsive layout behavior
* Ensured toggle functionality still works correctly

---

## 📸 Screenshots (if applicable)

<img width="1913" height="930" alt="image" src="https://github.com/user-attachments/assets/d093a2c6-e012-43f8-9700-267c61b99abc" />

---

## ✅ Checklist

* [x] Code follows project coding standards
* [x] UI tested manually
* [x] No unrelated files changed
* [x] Branch created from latest main
* [x] Ready for review
