### PR TITLE
Fix: Resolve employee edit 404 error by reordering routes (#604)

### DIFF
--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -124,24 +124,23 @@ Route::group(['middleware' => 'permission:trainer_access'], function () {
     Route::get('external-employee', 'Admin\EmployeeController@externalIndex')->name('employee.external_index');
     Route::get('employee/create', 'Admin\EmployeeController@create')->name('employee.create');
     Route::post('employee/store', 'Admin\EmployeeController@store')->name('employee.store');
-    Route::get('employee/{id}', 'Admin\EmployeeController@show')->name('employee.show');
     Route::get('employee/edit/{id}', 'Admin\EmployeeController@edit')->name('employee.edit');
-    Route::delete('employee/destroy/{id}', 'Admin\EmployeeController@destroy')->name('employee.destroy');
     Route::post('employee/update/{id}', 'Admin\EmployeeController@update')->name('employee.update');
+    Route::delete('employee/destroy/{id}', 'Admin\EmployeeController@destroy')->name('employee.destroy');
     Route::post('employee/import', 'Admin\EmployeeController@import')->name('employee.import');
     Route::get('employee/external/create', 'Admin\EmployeeController@external_employee_create')->name('employee.external.create');
     Route::post('employee/external/store', 'Admin\EmployeeController@external_employee_store')->name('employee.external.store');
+    Route::get('employee/reset_pass/{id}', 'Admin\EmployeeController@reset_pass')->name('employee.reset-pass');
+    Route::post('employee/change-password', 'Admin\EmployeeController@changepassword')->name('employee.change-password');
+    Route::post('employee_restore/{id}', ['uses' => 'Admin\EmployeeController@restore', 'as' => 'employee.restore']);
+    Route::delete('employee_perma_del/{id}', ['uses' => 'Admin\EmployeeController@perma_del', 'as' => 'employee.perma_del']);
+    Route::get('employee/{id}', 'Admin\EmployeeController@show')->name('employee.show');
 
     Route::get('get-employee-data', ['uses' => 'Admin\EmployeeController@getData', 'as' => 'employee.get_data']);
     Route::get('get-external-data', ['uses' => 'Admin\EmployeeController@getExternalData', 'as' => 'employee.get_external_data']);
 
     Route::post('employee_mass_destroy', ['uses' => 'Admin\EmployeeController@massDestroy', 'as' => 'employee.mass_destroy']);
-    Route::post('employee_restore/{id}', ['uses' => 'Admin\EmployeeController@restore', 'as' => 'employee.restore']);
-    Route::delete('employee_perma_del/{id}', ['uses' => 'Admin\EmployeeController@perma_del', 'as' => 'employee.perma_del']);
     Route::post('employee/status', ['uses' => 'Admin\EmployeeController@updateStatus', 'as' => 'employee.status']);
-
-    Route::get('employee/reset_pass/{id}', 'Admin\EmployeeController@reset_pass')->name('employee.reset-pass');
-    Route::post('employee/change-password', 'Admin\EmployeeController@changepassword')->name('employee.change-password');
 
     //===== FORUMS Routes =====//
     Route::resource('forums-category', 'Admin\ForumController');


### PR DESCRIPTION
## Summary
The catch-all route 'employee/{id}' was being matched before the more specific 'employee/edit/{id}' route, causing edit requests to be routed to the show() method instead of edit(). This fix reorders the routes to ensure correct route matching.

## Problem
When administrators tried to edit a trainee record, Laravel's router matched the catch-all `employee/{id}` route first, treating 'edit' as an ID value and calling the show() method instead of the edit() method, resulting in a 404 error.

## Solution
Moved all specific routes with additional path segments before the catch-all parameter route to ensure correct route matching order.

## Related Issue
Fixes #604

## Files Changed
- `routes/backend/admin.php` - reordered employee routes

## Checklist
- [x] Route order is correct
- [x] All employee routes are properly configured
- [x] No breaking changes