### PR TITLE
Fix disabled language toggle persistence

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ConfigController.php
+++ b/app/Http/Controllers/Backend/Admin/ConfigController.php
@@ -234,7 +234,7 @@ class ConfigController extends Controller
         }
 
         if (Str::startsWith($action, 'toggle:')) {
-            return $this->handleLanguageToggle($action);
+            return $this->handleLanguageToggle($action, $request);
         }
 
         return back()->withErrors(['Unsupported language action requested.']);
@@ -326,7 +326,7 @@ class ConfigController extends Controller
             ->withFlashSuccess('Language library uploaded successfully.');
     }
 
-    protected function handleLanguageToggle($toggleAction)
+    protected function handleLanguageToggle($toggleAction, Request $request)
     {
         $parts = explode(':', (string) $toggleAction);
         if (count($parts) !== 3) {
@@ -335,6 +335,10 @@ class ConfigController extends Controller
 
         $localeCode = strtolower(trim($parts[1]));
         $targetEnabled = (int) $parts[2] === 1 ? 1 : 0;
+
+        if (!Schema::hasColumn('locales', 'is_enabled')) {
+            return back()->withErrors(['Language status cannot be updated because the locales.is_enabled column is missing.']);
+        }
 
         $localeModel = Locale::where('short_name', $localeCode)->first();
         if (!$localeModel) {
@@ -345,15 +349,22 @@ class ConfigController extends Controller
             return back()->withErrors(['Default language cannot be disabled.']);
         }
 
-        if (Schema::hasColumn('locales', 'is_enabled')) {
-            if ($targetEnabled === 0) {
-                $enabledCount = Locale::where('is_enabled', 1)->count();
-                if ($enabledCount <= 1) {
-                    return back()->withErrors(['At least one language must remain enabled.']);
-                }
+        if ($targetEnabled === 0) {
+            $enabledCount = Locale::where('is_enabled', 1)->count();
+            if ($enabledCount <= 1) {
+                return back()->withErrors(['At least one language must remain enabled.']);
             }
-            $localeModel->is_enabled = $targetEnabled;
-            $localeModel->save();
+        }
+
+        Locale::whereKey($localeModel->getKey())->update(['is_enabled' => $targetEnabled]);
+        $localeModel->refresh();
+
+        if ((int) $localeModel->is_enabled !== $targetEnabled) {
+            return back()->withErrors(['Language status could not be updated. Please try again.']);
+        }
+
+        if ($targetEnabled === 0 && strtolower((string) $request->session()->get('locale')) === $localeCode) {
+            $request->session()->forget(['locale', 'display_type', 'lang-rtl']);
         }
 
         $message = $targetEnabled ? 'Language enabled successfully.' : 'Language disabled successfully.';

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,6 +22,7 @@ use App\Resolvers\SocialUserResolver;
 use Coderello\SocialGrant\Resolvers\SocialUserResolverInterface;
 use App\Helpers\CustomHelper;
 use App\Services\NotificationSettingsService;
+use App\Services\LocaleService;
 
 /**
  * Class AppServiceProvider.
@@ -201,13 +202,7 @@ if (
             $locales = [];
             $appCurrency = getCurrency(config('app.currency'));
 
-            if ($this->hasTableSafely('locales')) {
-                $localeQuery = Locale::query();
-                if ($this->hasColumnSafely('locales', 'is_enabled')) {
-                    $localeQuery->where('is_enabled', 1);
-                }
-                $locales = $localeQuery->pluck('short_name as locale')->toArray();
-            }
+            $locales = app(LocaleService::class)->supportedLocales();
             //            $view->with(compact('locales', 'appCurrency'));
 
             //        });

--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -676,8 +676,8 @@
                                         </a>
                                         <button type="submit"
                                                 class="btn btn-sm btn-{{ $isEnabled ? 'outline-warning' : 'success' }}"
-                                                name="language_action"
-                                                value="toggle:{{ $lang->short_name }}:{{ $toggleTo }}"
+                                                form="language-toggle-form-{{ $lang->id }}"
+                                                formnovalidate
                                                 @if ($isDefault && $isEnabled) disabled @endif>
                                             {{ $toggleLabel }}
                                         </button>
@@ -925,6 +925,20 @@
         </div>
     </div>
     </form>
+    @foreach ($app_locales as $lang)
+        @php
+            $isEnabled = isset($lang->is_enabled) ? (int) $lang->is_enabled : 1;
+            $toggleTo = $isEnabled ? 0 : 1;
+        @endphp
+        <form id="language-toggle-form-{{ $lang->id }}"
+              method="POST"
+              action="{{ route('admin.general-settings') }}"
+              class="d-none">
+            @csrf
+            <input type="hidden" name="active_tab" value="language_settings">
+            <input type="hidden" name="language_action" value="toggle:{{ $lang->short_name }}:{{ $toggleTo }}">
+        </form>
+    @endforeach
 @endsection
 
 

--- a/tests/Feature/SwitchLanguageTest.php
+++ b/tests/Feature/SwitchLanguageTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\Locale;
+use App\Services\LocaleService;
+use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
 
 class SwitchLanguageTest extends TestCase
@@ -14,10 +16,86 @@ class SwitchLanguageTest extends TestCase
             'name' => 'German',
             'short_name' => 'de',
             'display_type' => 'ltr',
+            'is_enabled' => 1,
         ]);
 
         $response = $this->get('/lang/de');
 
         $response->assertSessionHas('locale', 'de');
+    }
+
+    /** @test */
+    public function disabled_languages_are_not_supported()
+    {
+        Locale::create([
+            'name' => 'English',
+            'short_name' => 'en',
+            'display_type' => 'ltr',
+            'is_default' => 1,
+            'is_enabled' => 1,
+        ]);
+
+        Locale::create([
+            'name' => 'German',
+            'short_name' => 'de',
+            'display_type' => 'ltr',
+            'is_enabled' => 0,
+        ]);
+
+        $this->assertSame(['en'], app(LocaleService::class)->supportedLocales());
+    }
+
+    /** @test */
+    public function disabled_languages_cannot_be_selected_from_the_swap_route()
+    {
+        Locale::create([
+            'name' => 'English',
+            'short_name' => 'en',
+            'display_type' => 'ltr',
+            'is_default' => 1,
+            'is_enabled' => 1,
+        ]);
+
+        Locale::create([
+            'name' => 'German',
+            'short_name' => 'de',
+            'display_type' => 'ltr',
+            'is_enabled' => 0,
+        ]);
+
+        $response = $this->get('/lang/de');
+
+        $response->assertSessionHas('locale', 'en');
+    }
+
+    /** @test */
+    public function language_settings_toggle_persists_disabled_status()
+    {
+        $admin = $this->loginAsAdmin();
+        $admin->givePermissionTo(factory(Permission::class)->create(['name' => 'trainer_access']));
+
+        Locale::create([
+            'name' => 'English',
+            'short_name' => 'en',
+            'display_type' => 'ltr',
+            'is_default' => 1,
+            'is_enabled' => 1,
+        ]);
+
+        Locale::create([
+            'name' => 'German',
+            'short_name' => 'de',
+            'display_type' => 'ltr',
+            'is_enabled' => 1,
+        ]);
+
+        $this->post(route('admin.general-settings'), [
+            'language_action' => 'toggle:de:0',
+        ]);
+
+        $this->assertDatabaseHas('locales', [
+            'short_name' => 'de',
+            'is_enabled' => 0,
+        ]);
     }
 }


### PR DESCRIPTION
📥 Pull Request: Fix Disabled Language Toggle Persistence #688

## 🔧 Description

Disabling a language from General Settings → Translations showed a success message, but the language could remain enabled in practice.

The issue came from two weak points in the flow:

- The language Disable/Enable button was submitted from inside the large General Settings form, so browser form behavior and unrelated form state could interfere with the intended language toggle payload.
- The backend returned a success message even when the language status update path did not prove that `locales.is_enabled` was actually persisted.

This PR makes the language toggle action submit through its own small dedicated form, updates the locale row directly, verifies the saved `is_enabled` value before reporting success, and uses the shared `LocaleService` as the single source for enabled languages in the top navigation dropdown and swap route.

###  Changes Introduced
- Moved each language Enable/Disable row action to a dedicated hidden form outside the main General Settings form
- Added `formnovalidate` to the language toggle button so unrelated settings fields cannot block the action
- Updated the language toggle controller path to require the `locales.is_enabled` column before reporting status changes
- Persisted language status with a direct row update and refreshed verification before showing success
- Cleared the current session locale if the user disables the language currently selected in their session
- Switched the navbar language list to `LocaleService::supportedLocales()` so disabled languages are filtered consistently
- Added feature coverage for supported-locale filtering, blocked disabled language selection, and settings toggle persistence

Fixes: #688
---

## ✅ Type of Change

-  Bug fix
-  Backend workflow update
-  UI behavior fix
---

## 📸 Screenshots

Not applicable. This is a settings persistence and dropdown-filtering behavior fix.

---

## 🚀 How Has This Been Tested?

- Local environment testing on the General Settings → Translations page
- PHP syntax checks
- Focused feature test for language switching and settings toggle persistence

---

## 🧪 Steps to Reproduce

1. Login with admin credentials
2. Navigate to General Settings → Translations
3. Pick any enabled non-default language
4. Click Disable
5. Confirm the page returns to the Translations tab with the language shown as Disabled
6. Open the top navigation language dropdown
7. Confirm the disabled language is not listed
8. Attempt direct `/lang/{disabled-locale}` selection
9. Confirm the disabled language is not applied

---

## 🔄 Checklist

- Language Disable/Enable action submits independently from the large General Settings form
- `locales.is_enabled` is persisted before success is reported
- Default language cannot be disabled
- At least one language must remain enabled
- Current disabled session locale is cleared
- Top navigation dropdown only lists enabled languages
- Disabled languages cannot be selected through the swap route
- Syntax checks passed
- Focused feature test passed
