### PR TITLE
Mark required fields on create user form

### DIFF
--- a/resources/views/backend/auth/user/create.blade.php
+++ b/resources/views/backend/auth/user/create.blade.php
@@ -21,6 +21,7 @@
             <div class="form-group row">
                 <label for="first_name" class="col-md-2 form-control-label">
                     @lang('validation.attributes.backend.access.users.first_name')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="text" name="first_name" id="first_name" class="form-control @error('first_name') is-invalid @enderror"
@@ -37,6 +38,7 @@
             <div class="form-group row">
                 <label for="last_name" class="col-md-2 form-control-label">
                     @lang('validation.attributes.backend.access.users.last_name')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="text" name="last_name" id="last_name" class="form-control @error('last_name') is-invalid @enderror"
@@ -53,6 +55,7 @@
             <div class="form-group row">
                 <label for="email" class="col-md-2 form-control-label">
                     @lang('validation.attributes.backend.access.users.email')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="email" name="email" id="email" class="form-control @error('email') is-invalid @enderror"
@@ -83,6 +86,7 @@
             <div class="form-group row">
                 <label for="password" class="col-md-2 form-control-label">
                     @lang('validation.attributes.backend.access.users.password')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10 position-relative">
                     <input type="password" name="password" id="password-field" class="form-control @error('password') is-invalid @enderror"
@@ -100,6 +104,7 @@
             <div class="form-group row">
                 <label for="password_confirmation" class="col-md-2 form-control-label">
                     @lang('validation.attributes.backend.access.users.password_confirmation')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="password" name="password_confirmation" id="password_confirmation"
@@ -147,6 +152,7 @@
             <div class="form-group row">
                 <label class="col-md-2 form-control-label">
                     @lang('labels.backend.access.users.table.abilities')
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     @php


### PR DESCRIPTION
📥 Pull Request: Mark Required Fields on Create User Form #689

## 🔧 Description

In the Create User form, mandatory fields were enforced by backend validation but were not visually marked in the UI.

This made it unclear which inputs had to be completed before submission. Users could submit the form without knowing the required fields and only discover the missing data after validation errors appeared.

This PR adds visible red required markers to the labels for fields that are required by the Create User validation request, while leaving optional fields unmarked.

###  Changes Introduced
- Added red `*` indicators to required Create User fields
- Marked First Name, Last Name, Email, Password, Password Confirmation, and Roles/Abilities as mandatory
- Left optional fields such as Active, Confirmed, and Department unmarked
- Matched the indicators to the backend validation rules in `StoreUserRequest`

Fixes: #689
---

## ✅ Type of Change

-  Bug fix
-  UI/UX update
---

## 📸 Screenshots

<img width="1910" height="837" alt="Screenshot_20260524_113608" src="https://github.com/user-attachments/assets/46b7bdcd-6b59-42ac-ac9d-e81a33568278" />

---

## 🚀 How Has This Been Tested?

- Verified the Create User validation rules to identify required fields
- PHP syntax check for the updated Blade file

---

## 🧪 Steps to Reproduce

1. Login with admin credentials
2. Navigate to User Management → Create User
3. Observe the form labels
4. Confirm required fields display a red `*`
5. Confirm optional fields remain unmarked
6. Submit the form without required fields and confirm validation still works as before

---

## 🔄 Checklist

- First Name is marked required
- Last Name is marked required
- Email is marked required
- Password is marked required
- Password Confirmation is marked required
- Roles/Abilities is marked required
- Optional fields remain unmarked
- Syntax check passed
