### PR TITLE
Fix uploaded video buffering with byte-range streaming

### DIFF
--- a/app/Http/Controllers/MediaStreamController.php
+++ b/app/Http/Controllers/MediaStreamController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LessonVideo;
+use App\Models\Media;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+
+class MediaStreamController extends Controller
+{
+    public function media(Request $request, Media $media)
+    {
+        if ($media->type !== 'upload') {
+            abort(404);
+        }
+
+        return $this->streamLocalFile($request, $this->mediaPath($media));
+    }
+
+    public function lessonVideo(Request $request, LessonVideo $lessonVideo)
+    {
+        if ($lessonVideo->type !== 'upload') {
+            abort(404);
+        }
+
+        return $this->streamLocalFile($request, $this->lessonVideoPath($lessonVideo));
+    }
+
+    private function mediaPath(Media $media)
+    {
+        $fileName = $media->file_name;
+
+        if (!$fileName && !empty($media->getRawOriginal('url'))) {
+            $fileName = basename(parse_url($media->getRawOriginal('url'), PHP_URL_PATH));
+        }
+
+        if (!$fileName) {
+            abort(404);
+        }
+
+        return public_path('storage/uploads/' . basename($fileName));
+    }
+
+    private function lessonVideoPath(LessonVideo $lessonVideo)
+    {
+        if ($lessonVideo->file_path) {
+            return storage_path('app/public/' . ltrim($lessonVideo->file_path, '/'));
+        }
+
+        if (!$lessonVideo->url) {
+            abort(404);
+        }
+
+        $urlPath = parse_url($lessonVideo->url, PHP_URL_PATH);
+        if (!$urlPath || strpos($urlPath, '/storage/') === false) {
+            abort(404);
+        }
+
+        return public_path(ltrim($urlPath, '/'));
+    }
+
+    private function streamLocalFile(Request $request, $path)
+    {
+        if (!File::exists($path) || !File::isFile($path)) {
+            abort(404);
+        }
+
+        $size = File::size($path);
+        $start = 0;
+        $end = $size - 1;
+        $status = 200;
+
+        $range = $request->headers->get('Range');
+        if ($range && preg_match('/bytes=(\d*)-(\d*)/', $range, $matches)) {
+            if ($matches[1] !== '') {
+                $start = (int) $matches[1];
+            }
+
+            if ($matches[2] !== '') {
+                $end = min((int) $matches[2], $end);
+            }
+
+            if ($matches[1] === '' && $matches[2] !== '') {
+                $suffixLength = (int) $matches[2];
+                $start = max($size - $suffixLength, 0);
+            }
+
+            if ($start > $end || $start >= $size) {
+                return response('', 416, [
+                    'Accept-Ranges' => 'bytes',
+                    'Content-Range' => 'bytes */' . $size,
+                ]);
+            }
+
+            $status = 206;
+        }
+
+        $length = $end - $start + 1;
+        $headers = [
+            'Accept-Ranges' => 'bytes',
+            'Cache-Control' => 'private, max-age=3600',
+            'Content-Length' => $length,
+            'Content-Type' => File::mimeType($path) ?: 'video/mp4',
+            'X-Content-Type-Options' => 'nosniff',
+        ];
+
+        if ($status === 206) {
+            $headers['Content-Range'] = 'bytes ' . $start . '-' . $end . '/' . $size;
+        }
+
+        return response()->stream(function () use ($path, $start, $length) {
+            $handle = fopen($path, 'rb');
+            fseek($handle, $start);
+
+            $remaining = $length;
+            while ($remaining > 0 && !feof($handle)) {
+                $chunkSize = min(8192, $remaining);
+                echo fread($handle, $chunkSize);
+                flush();
+                $remaining -= $chunkSize;
+            }
+
+            fclose($handle);
+        }, $status, $headers);
+    }
+}

--- a/app/Models/LessonVideo.php
+++ b/app/Models/LessonVideo.php
@@ -24,8 +24,8 @@ class LessonVideo extends Model
     public function getPlaybackUrlAttribute()
     {
         if ($this->type === 'upload') {
-            if ($this->file_path) {
-                return asset('storage/' . ltrim($this->file_path, '/'));
+            if (config('filesystems.default') === 'local' && $this->id && ($this->file_path || $this->url)) {
+                return route('lesson-videos.stream', ['lessonVideo' => $this->id]);
             }
 
             return $this->url;

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -42,6 +42,10 @@ class Media extends Model
         $storage = config('filesystems.default');
 
         if ($storage == 'local') {
+            if ($type === 'upload' && $this->id) {
+                return route('media.stream', ['media' => $this->id]);
+            }
+
             // Backward compatibility: older rows may store only `url` without `aws_url`.
             return $this->aws_url ?: ($this->attributes['url'] ?? $value);
         } else {

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\CalenderController;
 use App\Http\Controllers\CoursesController;
 use App\Http\Controllers\InstallerController;
 use App\Http\Controllers\UserCourseRequestController;
+use App\Http\Controllers\MediaStreamController;
 use App\Jobs\SendEmailJob;
 use App\Models\AssignmentQuestion;
 use Illuminate\Http\Request;
@@ -232,6 +233,8 @@ Route::get('bundles/review/{id}/delete', ['uses' => 'BundlesController@deleteRev
 
 
 Route::group(['middleware' => 'auth'], function () {
+    Route::get('media/{media}/stream', [MediaStreamController::class, 'media'])->name('media.stream');
+    Route::get('lesson-videos/{lessonVideo}/stream', [MediaStreamController::class, 'lessonVideo'])->name('lesson-videos.stream');
     Route::get('lesson/{course_id}/{slug}/quiz', ['uses' => 'LessonsController@showLessonQuiz', 'as' => 'lessons.lesson_quiz.show']);
     Route::get('lesson/{course_id}/{slug?}/', ['uses' => 'LessonsController@show', 'as' => 'lessons.show']);
     Route::post('lesson/{slug}/test', ['uses' => 'LessonsController@test', 'as' => 'lessons.test']);

--- a/tests/Feature/MediaStreamTest.php
+++ b/tests/Feature/MediaStreamTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Auth\User;
+use App\Models\Lesson;
+use App\Models\LessonVideo;
+use App\Models\Media;
+use Tests\TestCase;
+
+class MediaStreamTest extends TestCase
+{
+    private $createdFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function uploaded_media_streams_requested_byte_ranges()
+    {
+        config(['filesystems.default' => 'local']);
+
+        $filename = 'media-range-test.mp4';
+        $path = public_path('storage/uploads/' . $filename);
+        $this->createStreamFile($path, '0123456789');
+
+        $media = Media::create([
+            'model_type' => Lesson::class,
+            'model_id' => 1,
+            'name' => $filename,
+            'url' => asset('storage/uploads/' . $filename),
+            'aws_url' => asset('storage/uploads/' . $filename),
+            'type' => 'upload',
+            'file_name' => $filename,
+            'size' => 10,
+        ]);
+
+        $this->actingAs(factory(User::class)->create());
+
+        $this->assertSame(route('media.stream', ['media' => $media->id]), $media->fresh()->url);
+
+        $response = $this->withHeaders(['Range' => 'bytes=2-5'])
+            ->get(route('media.stream', ['media' => $media->id]));
+
+        $response->assertStatus(206);
+        $response->assertHeader('Accept-Ranges', 'bytes');
+        $response->assertHeader('Content-Range', 'bytes 2-5/10');
+        $response->assertHeader('Content-Length', 4);
+        $this->assertSame('2345', $this->streamedContent($response));
+    }
+
+    /** @test */
+    public function lesson_video_uploads_stream_requested_byte_ranges()
+    {
+        config(['filesystems.default' => 'local']);
+
+        $filename = 'lesson-video-range-test.mp4';
+        $relativePath = 'lesson_videos/' . $filename;
+        $path = storage_path('app/public/' . $relativePath);
+        $this->createStreamFile($path, 'abcdefghij');
+
+        $lesson = Lesson::create(['title' => 'Streaming lesson']);
+        $lessonVideo = LessonVideo::create([
+            'lesson_id' => $lesson->id,
+            'title' => 'Range video',
+            'type' => 'upload',
+            'file_path' => $relativePath,
+            'sort_order' => 0,
+            'is_preview' => 0,
+        ]);
+
+        $this->actingAs(factory(User::class)->create());
+
+        $this->assertSame(route('lesson-videos.stream', ['lessonVideo' => $lessonVideo->id]), $lessonVideo->playback_url);
+
+        $response = $this->withHeaders(['Range' => 'bytes=3-6'])
+            ->get(route('lesson-videos.stream', ['lessonVideo' => $lessonVideo->id]));
+
+        $response->assertStatus(206);
+        $response->assertHeader('Accept-Ranges', 'bytes');
+        $response->assertHeader('Content-Range', 'bytes 3-6/10');
+        $response->assertHeader('Content-Length', 4);
+        $this->assertSame('defg', $this->streamedContent($response));
+    }
+
+    private function createStreamFile($path, $content)
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+
+        file_put_contents($path, $content);
+        $this->createdFiles[] = $path;
+    }
+
+    private function streamedContent($response)
+    {
+        ob_start();
+        $response->baseResponse->sendContent();
+
+        return ob_get_clean();
+    }
+}


### PR DESCRIPTION
📥 Pull Request: Fix Video Buffering During Playback #693

## 🔧 Description

While reviewing the video buffering report, locally uploaded videos were found to be served through direct storage URLs. In environments where static delivery does not consistently support HTTP byte-range requests, browsers can buffer or seek inefficiently during playback.

This PR adds a dedicated streaming endpoint for local uploaded videos and serves both legacy Media uploads and newer LessonVideo uploads with HTTP Range / 206 Partial Content support. External providers such as YouTube, Vimeo, embeds, and S3-backed videos keep their existing delivery behavior.

Note: during local testing, I did not observe the reported buffering problem in my own environment. This change should still help affected environments where buffering is caused by missing or inconsistent byte-range handling for local uploaded videos.

### Changes Introduced
- Added a MediaStreamController that streams local video files in byte ranges
- Added authenticated routes for Media and LessonVideo video streaming
- Updated uploaded Media video URLs to use the streaming endpoint on local storage
- Updated uploaded LessonVideo playback URLs to use the streaming endpoint on local storage
- Preserved existing behavior for YouTube, Vimeo, embeds, and S3 video URLs
- Added feature tests for range responses on uploaded Media and LessonVideo playback

Fixes: #693
---

## ✅ Type of Change

- Bug fix
- Backend workflow update
- UI/UX improvement
---

## 📸 Screenshots

N/A - this change updates backend video delivery behavior.

---

## 🚀 How Has This Been Tested?

- Local environment testing
- PHP syntax checks
- Focused feature test for HTTP byte-range streaming
- Confirmed I did not reproduce the original buffering issue locally, but verified the new stream endpoints return proper partial-content responses

---

## 🧪 Steps to Reproduce

1. Login to the application as a student
2. Navigate to a course lesson with uploaded video content
3. Start video playback
4. Seek through the video or continue watching under normal network conditions
5. Confirm the video is served through the stream endpoint with byte-range support
6. Confirm playback can request partial ranges instead of requiring full-file delivery

---

## 🔄 Checklist

- Local uploaded Media videos use byte-range streaming
- Local uploaded LessonVideo videos use byte-range streaming
- External video providers remain unchanged
- Invalid or missing local video files return 404
- Invalid byte ranges return 416
- Syntax checks passed
- Focused tests passed