### PR TITLE
Fix video completion progress tracking

### DIFF
--- a/app/Http/Controllers/LessonsController.php
+++ b/app/Http/Controllers/LessonsController.php
@@ -1157,26 +1157,7 @@ class LessonsController extends Controller
         $percentageCompleted = $video->getProgressPercentage($user->id);
         $percentageToMarkLessonAsCompleted = 90;
         if ($percentageCompleted >= $percentageToMarkLessonAsCompleted) {
-            // mark lesson as completed
-            $lesson = Lesson::find($video->model_id);
-            if ($lesson->chapterStudents()->where('user_id', \Auth::id())->count() == 0) {
-                $lesson->chapterStudents()->create([
-                    'model_type' => get_class($lesson),
-                    'model_id' => $lesson->id,
-                    'user_id' => auth()->user()->id,
-                    'course_id' => $lesson->course->id
-                ]);
-
-                // Save the attendance
-                $data = [
-                    'student_id' => \Auth::id(),
-                    'course_id' => $lesson->course->id,
-                    'lesson_id' => $lesson->id,
-                    'created_at' => date('Y-m-d H:i:s'),
-                    'updated_at' => date('Y-m-d H:i:s')
-                ];
-                AttendanceStudent::create($data);
-            }
+            $this->markVideoLessonCompleted($video, $user);
         }
         return $video_progress->progress;
     }
@@ -1189,7 +1170,8 @@ class LessonsController extends Controller
 
 
         $user = auth()->user();
-        $video = Media::findOrFail($request->vedio_id);
+        $videoId = $request->input('vedio_id', $request->input('video_id', $request->input('video')));
+        $video = Media::findOrFail($videoId);
 
         $lesson = Lesson::find($video->model_id);
         $course_id = $lesson->course->id ?? null;
@@ -1206,19 +1188,35 @@ class LessonsController extends Controller
         if ($already_completed == 0) {
             $video_progress = VideoProgress::where('user_id', '=', $user->id)->where('media_id', '=', $video->id)->first() ?: new VideoProgress();
 
+            $duration = max((float) $request->duration, 0);
+            $progress = max((float) $request->progress, 0);
+            $watchPoint = max((float) $request->watchPoint, 0);
+            $clientCompleted = $request->boolean('completed');
+
+            if ($clientCompleted && $duration > 0 && $watchPoint >= 99) {
+                $progress = $duration;
+                $watchPoint = 100;
+            }
+
             $video_progress->media_id = $video->id;
             $video_progress->user_id = $user->id;
-            $video_progress->progress_per = $request->watchPoint;
-            if ($video_progress->progress_per == '100') {
+            $video_progress->progress_per = min(100, round($watchPoint, 2));
+            $video_progress->duration = $video_progress->duration ?: round($duration, 2);
+            $video_progress->progress = round($progress, 2);
+
+            if ($video_progress->duration > 0 && $video_progress->duration - $video_progress->progress < 5) {
+                $video_progress->progress = $video_progress->duration;
+                $video_progress->progress_per = 100;
                 $video_progress->complete = 1;
             }
 
-            $video_progress->duration = $video_progress->duration ?: round($request->duration, 2);
-            $video_progress->progress = round($request->progress, 2);
+            if ((float) $video_progress->progress_per >= 100) {
+                $video_progress->complete = 1;
+            }
             $video_progress->save();
 
             // progress update for user
-            $video = Media::findOrFail($request->vedio_id);
+            $video = Media::findOrFail($video->id);
 
             $course_id = null;
             /**
@@ -1230,44 +1228,8 @@ class LessonsController extends Controller
 
 
 
-            //if ($percentageCompleted >= $percentageToMarkLessonAsCompleted) {
             if ($percentageCompleted >= $percentageToMarkLessonAsCompleted) {
-
-
-                // mark lesson as completed
-                $lesson = Lesson::find($video->model_id);
-
-                $course_id = $lesson->course->id ?? null;
-
-                //dd($course_id);
-
-                //dd($lesson->chapterStudents()->get());
-                if ($lesson->chapterStudents()->where('user_id', \Auth::id())->count() == 0) {
-                    $lesson->chapterStudents()->create([
-                        'model_type' => get_class($lesson),
-                        'model_id' => $lesson->id,
-                        'user_id' => auth()->user()->id,
-                        'course_id' => $lesson->course->id
-                    ]);
-
-                    // Save the attendance
-                    $data = [
-                        'student_id' => \Auth::id(),
-                        'course_id' => $lesson->course->id,
-                        'lesson_id' => $lesson->id,
-                        'created_at' => date('Y-m-d H:i:s'),
-                        'updated_at' => date('Y-m-d H:i:s')
-                    ];
-                    AttendanceStudent::create($data);
-
-                    //dd($lesson->course->id);
-
-                    if ($lesson->course->id) {
-
-                        //dd($lesson->course->id, \Auth::id());
-                        $progressdata = CustomHelper::updateUserProgress(\Auth::id(), $lesson->course->id);
-                    }
-                }
+                $this->markVideoLessonCompleted($video, $user);
             }
 
 
@@ -1341,6 +1303,54 @@ class LessonsController extends Controller
         CustomHelper::updateUserProgress(\Auth::id(), $lesson->course->id);
 
         return true;
+    }
+
+    private function markVideoLessonCompleted(Media $video, User $user): void
+    {
+        $lesson = Lesson::find($video->model_id);
+        if (! $lesson || ! $lesson->course) {
+            return;
+        }
+
+        $alreadyCompleted = $lesson->chapterStudents()
+            ->where('user_id', $user->id)
+            ->exists();
+
+        if (! $alreadyCompleted) {
+            $lesson->chapterStudents()->create([
+                'model_type' => get_class($lesson),
+                'model_id' => $lesson->id,
+                'user_id' => $user->id,
+                'course_id' => $lesson->course->id,
+            ]);
+
+            AttendanceStudent::firstOrCreate([
+                'student_id' => $user->id,
+                'course_id' => $lesson->course->id,
+                'lesson_id' => $lesson->id,
+            ]);
+        }
+
+        CustomHelper::updateUserProgress($user->id, $lesson->course->id);
+
+        $subscription = SubscribeCourse::where('course_id', $lesson->course->id)
+            ->where('user_id', $user->id)
+            ->first();
+
+        if ($subscription) {
+            $progress = (int) $subscription->assignment_progress;
+            $status = (int) $subscription->course_progress_status;
+
+            if ((int) $subscription->is_completed === 1 || $progress >= 100) {
+                $status = 2;
+            } elseif ($progress > 0) {
+                $status = 1;
+            }
+
+            if ((int) $subscription->course_progress_status !== $status) {
+                $subscription->update(['course_progress_status' => $status]);
+            }
+        }
     }
 
     public function bookSlot(Request $request)

--- a/resources/views/frontend-rtl/courses/lesson.blade.php
+++ b/resources/views/frontend-rtl/courses/lesson.blade.php
@@ -1058,11 +1058,17 @@
         let lastRecordedTime = current_progress ?? 0;
         let watchDuration = 0;
         let lastCalledTime = 0;
+        var lessonAlreadyCompleted = false;
 
         player.on('timeupdate', () => {
             const currentTime = player.currentTime;
+            const videoDuration = player.duration;
+            if (!Number.isFinite(videoDuration) || videoDuration <= 0) {
+                return;
+            }
+
             const playbackRate = player.media.playbackRate;
-            var watchPoint = Math.floor((currentTime / player.duration) * 100);
+            var watchPoint = Math.floor((currentTime / videoDuration) * 100);
 
             // Check if the user is watching continuously (no skipping)
             if (Math.abs(currentTime - lastRecordedTime) <= 1) {
@@ -1075,14 +1081,24 @@
 
             // Check if 2 seconds have passed since the last progress update
             if (currentTime - lastCalledTime >= 2) {
-                time(watchPoint, watchDuration, player.duration)
+                time(watchPoint, watchDuration, videoDuration, false)
 
                 // Update lastCalledTime to the current time
                 lastCalledTime = currentTime;
             }
         });
 
-        function time(watchPoint, progress, videoDuration) {
+        player.on('ended', () => {
+            const videoDuration = player.duration;
+            if (!Number.isFinite(videoDuration) || videoDuration <= 0) {
+                return;
+            }
+
+            watchDuration = Math.max(watchDuration, videoDuration);
+            time(100, watchDuration, videoDuration, true);
+        });
+
+        function time(watchPoint, progress, videoDuration, completed) {
             //alert("hi")
             var id = "{{ $lesson->id }}";
             var video = $('#player').parents('.video-container').data('id');
@@ -1095,7 +1111,14 @@
                     'vedio_id': parseInt(video),
                     'watchPoint': watchPoint,
                     'duration': parseInt(videoDuration),
-                    'progress': parseInt(progress)
+                    'progress': parseInt(progress),
+                    'completed': completed ? 1 : 0
+                },
+                success: function(response) {
+                    if (response.lesson_completed && !lessonAlreadyCompleted) {
+                        lessonAlreadyCompleted = true;
+                        window.location.reload();
+                    }
                 },
             });
         }

--- a/resources/views/frontend/courses/lesson.blade.php
+++ b/resources/views/frontend/courses/lesson.blade.php
@@ -1059,11 +1059,17 @@
         let lastRecordedTime = current_progress ?? 0;
         let watchDuration = 0;
         let lastCalledTime = 0;
+        var lessonAlreadyCompleted = false;
 
         player.on('timeupdate', () => {
             const currentTime = player.currentTime;
+            const videoDuration = player.duration;
+            if (!Number.isFinite(videoDuration) || videoDuration <= 0) {
+                return;
+            }
+
             const playbackRate = player.media.playbackRate;
-            var watchPoint = Math.floor((currentTime / player.duration) * 100);
+            var watchPoint = Math.floor((currentTime / videoDuration) * 100);
 
             // Check if the user is watching continuously (no skipping)
             if (Math.abs(currentTime - lastRecordedTime) <= 1) {
@@ -1076,16 +1082,24 @@
 
             // Check if 2 seconds have passed since the last progress update
             if (currentTime - lastCalledTime >= 2) {
-                time(watchPoint, watchDuration, player.duration)
+                time(watchPoint, watchDuration, videoDuration, false)
 
                 // Update lastCalledTime to the current time
                 lastCalledTime = currentTime;
             }
         });
 
-        var lessonAlreadyCompleted = false;
+        player.on('ended', () => {
+            const videoDuration = player.duration;
+            if (!Number.isFinite(videoDuration) || videoDuration <= 0) {
+                return;
+            }
 
-        function time(watchPoint, progress, videoDuration) {
+            watchDuration = Math.max(watchDuration, videoDuration);
+            time(100, watchDuration, videoDuration, true);
+        });
+
+        function time(watchPoint, progress, videoDuration, completed) {
             //alert("hi")
             var id = "{{ $lesson->id }}";
             var video = $('#player').parents('.video-container').data('id');
@@ -1098,7 +1112,8 @@
                     'vedio_id': parseInt(video),
                     'watchPoint': watchPoint,
                     'duration': parseInt(videoDuration),
-                    'progress': parseInt(progress)
+                    'progress': parseInt(progress),
+                    'completed': completed ? 1 : 0
                 },
                 success: function(response) {
                     if (response.lesson_completed && !lessonAlreadyCompleted) {

--- a/tests/Feature/VideoCompletionProgressTest.php
+++ b/tests/Feature/VideoCompletionProgressTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Auth\User;
+use App\Models\Course;
+use App\Models\Lesson;
+use App\Models\Media;
+use App\Models\Stripe\SubscribeCourse;
+use App\Models\VideoProgress;
+use Tests\TestCase;
+
+class VideoCompletionProgressTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.key' => 'base64:' . base64_encode(str_repeat('a', 32))]);
+
+        $this->withoutMiddleware([
+            \App\Http\Middleware\RedirectIfNotInstalled::class,
+            \App\Http\Middleware\CheckInstallation::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+        ]);
+
+        $pdo = $this->app['db']->connection()->getPdo();
+        if (method_exists($pdo, 'sqliteCreateFunction')) {
+            $pdo->sqliteCreateFunction('FIND_IN_SET', function ($needle, $haystack) {
+                if ($needle === null || $haystack === null) {
+                    return 0;
+                }
+
+                $values = array_map('trim', explode(',', (string) $haystack));
+                $index = array_search((string) $needle, $values, true);
+
+                return $index === false ? 0 : $index + 1;
+            }, 2);
+        }
+    }
+
+    public function test_video_completion_marks_lesson_complete_and_updates_course_progress()
+    {
+        $user = factory(User::class)->create();
+        $course = $this->createCourse();
+        $lesson = $this->createLesson($course);
+        $this->createLesson($course, ['title' => 'Second lesson', 'slug' => 'second-lesson']);
+        $media = $this->createVideo($lesson);
+
+        SubscribeCourse::create([
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'status' => 1,
+            'assignment_progress' => 0,
+            'has_assesment' => 0,
+            'has_feedback' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->postJson(route('video.progress.update'), [
+            'vedio_id' => $media->id,
+            'watchPoint' => 100,
+            'duration' => 120,
+            'progress' => 120,
+            'completed' => 1,
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'progress_per' => 100,
+                'lesson_completed' => true,
+            ]);
+
+        $this->assertDatabaseHas('video_progresses', [
+            'media_id' => $media->id,
+            'user_id' => $user->id,
+            'complete' => 1,
+        ]);
+
+        $this->assertDatabaseHas('chapter_students', [
+            'model_type' => Lesson::class,
+            'model_id' => $lesson->id,
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+        ]);
+
+        $this->assertDatabaseHas('attendance_student', [
+            'student_id' => $user->id,
+            'course_id' => $course->id,
+            'lesson_id' => $lesson->id,
+        ]);
+
+        $this->assertDatabaseHas('subscribe_courses', [
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'assignment_progress' => 50,
+        ]);
+    }
+
+    public function test_video_completion_recalculates_course_progress_for_existing_lesson_completion()
+    {
+        $user = factory(User::class)->create();
+        $course = $this->createCourse();
+        $lesson = $this->createLesson($course);
+        $media = $this->createVideo($lesson);
+
+        SubscribeCourse::create([
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'status' => 1,
+            'assignment_progress' => 0,
+            'has_assesment' => 0,
+            'has_feedback' => 0,
+        ]);
+
+        $lesson->chapterStudents()->create([
+            'model_type' => Lesson::class,
+            'model_id' => $lesson->id,
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+        ]);
+
+        VideoProgress::unguarded(function () use ($media, $user) {
+            VideoProgress::create([
+                'media_id' => $media->id,
+                'user_id' => $user->id,
+                'duration' => 120,
+                'progress' => 110,
+                'progress_per' => 92,
+                'complete' => 0,
+            ]);
+        });
+
+        $response = $this->actingAs($user)->postJson(route('video.progress.update'), [
+            'vedio_id' => $media->id,
+            'watchPoint' => 100,
+            'duration' => 120,
+            'progress' => 120,
+            'completed' => 1,
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'progress_per' => 100,
+                'lesson_completed' => true,
+            ]);
+
+        $this->assertDatabaseHas('subscribe_courses', [
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'assignment_progress' => 100,
+            'course_progress_status' => 2,
+            'is_completed' => 1,
+        ]);
+    }
+
+    private function createCourse(array $attributes = []): Course
+    {
+        return Course::create(array_merge([
+            'title' => 'Video progress course',
+            'slug' => 'video-progress-course',
+            'category_id' => 1,
+            'description' => 'Course used for video progress tests.',
+            'published' => 1,
+            'is_online' => 'Online',
+        ], $attributes));
+    }
+
+    private function createLesson(Course $course, array $attributes = []): Lesson
+    {
+        return Lesson::create(array_merge([
+            'course_id' => $course->id,
+            'title' => 'Video lesson',
+            'slug' => 'video-lesson',
+            'position' => 1,
+            'free_lesson' => 1,
+            'published' => 1,
+            'full_text' => 'Lesson content.',
+        ], $attributes));
+    }
+
+    private function createVideo(Lesson $lesson): Media
+    {
+        return Media::create([
+            'model_type' => Lesson::class,
+            'model_id' => $lesson->id,
+            'name' => 'lesson-video.mp4',
+            'url' => 'lesson-video.mp4',
+            'type' => 'upload',
+            'file_name' => 'lesson-video.mp4',
+            'size' => 120,
+        ]);
+    }
+}


### PR DESCRIPTION
📥 Pull Request: Fix Video Completion Progress Tracking #695

## 🔧 Description

Video playback completion was not reliably persisted because the lesson page only sent periodic progress updates and did not send a guaranteed final update when Plyr fired the ended event. On the backend, course progress was recalculated only when a new chapter_students row was created, so users who already had a lesson completion row could still remain at 0% course progress.

This PR makes video completion idempotently mark the lesson complete, record attendance once, recalculate the subscribed course progress every time completion is detected, and normalize the subscribed course progress status. The lesson player now sends an explicit final completion ping when playback ends for both LTR and RTL course lesson pages.

Fixes: #695
---

## ✅ Type of Change

- Bug fix
- Backend workflow update
- UI/UX improvement
---

## 📸 Screenshots

N/A - this change updates progress tracking behavior.

---

## 🚀 How Has This Been Tested?

- Local focused feature test for video completion progress tracking
- PHP syntax checks for the updated controller and feature test
- Verified completion creates video progress, lesson completion, attendance, and subscribed course progress updates

Commands run:
- php -l app/Http/Controllers/LessonsController.php
- php -l tests/Feature/VideoCompletionProgressTest.php
- vendor/bin/phpunit tests/Feature/VideoCompletionProgressTest.php

---

## 🧪 Steps to Reproduce

1. Login to the application as a student
2. Navigate to a course lesson with video content
3. Play the video through to the end
4. Wait for playback completion
5. Navigate to the course progress or dashboard view
6. Confirm the video lesson is marked complete and course progress increases from 0%

---

## 🔄 Checklist

- Video ended event sends a final completion progress update
- LTR and RTL lesson pages send the same completion payload
- Backend accepts legacy and corrected video id payload keys
- Lesson completion creation is idempotent
- Course progress is recalculated even when the lesson was already marked complete
- Course progress status is normalized after video completion
- Focused tests passed