### PR TITLE
Fix feedback questions export downloads

### DIFF
--- a/resources/views/backend/feedback/index.blade.php
+++ b/resources/views/backend/feedback/index.blade.php
@@ -198,7 +198,90 @@
 
 <script>
     $(document).ready(function() {
-        $('#myTable').dataTable({
+        const exportColumns = [
+            @json(__('user_feedback.feedback_questions.id')),
+            @json(__('user_feedback.feedback_questions.question_text')),
+            @json(__('user_feedback.feedback_questions.question_type'))
+        ];
+        const exportFilename = 'feedback-questions';
+
+        function stripHtml(value) {
+            return $('<div>').html(value || '').text().trim();
+        }
+
+        function getExportRows(table) {
+            return table.rows({ search: 'applied' }).data().toArray().map(function(row) {
+                return [
+                    stripHtml(row[0]),
+                    stripHtml(row[1]),
+                    stripHtml(row[2])
+                ];
+            });
+        }
+
+        function downloadCsv(rows) {
+            const csvRows = [exportColumns].concat(rows).map(function(row) {
+                return row.map(function(value) {
+                    return '"' + String(value).replace(/"/g, '""') + '"';
+                }).join(',');
+            });
+            const blob = new Blob([csvRows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+
+            link.href = url;
+            link.download = exportFilename + '.csv';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        }
+
+        function downloadPdf(rows) {
+            if (typeof pdfMake === 'undefined') {
+                alert('PDF export is unavailable. Please refresh and try again.');
+                return;
+            }
+
+            pdfMake.createPdf({
+                pageOrientation: 'landscape',
+                content: [
+                    { text: @json(__('user_feedback.feedback_questions.title')), style: 'header' },
+                    {
+                        table: {
+                            headerRows: 1,
+                            widths: ['auto', '*', 'auto'],
+                            body: [exportColumns].concat(rows)
+                        }
+                    }
+                ],
+                styles: {
+                    header: {
+                        fontSize: 14,
+                        bold: true,
+                        margin: [0, 0, 0, 10]
+                    }
+                }
+            }).download(exportFilename + '.pdf');
+        }
+
+        function exportFeedbackQuestions(table, type) {
+            const rows = getExportRows(table);
+
+            if (!rows.length) {
+                alert('No feedback questions available to export.');
+                return;
+            }
+
+            if (type === 'csv') {
+                downloadCsv(rows);
+                return;
+            }
+
+            downloadPdf(rows);
+        }
+
+        const table = $('#myTable').DataTable({
             "paginate": true,
             "sort": true,
             "language": {
@@ -221,17 +304,15 @@
                     text: '<i class="fa fa-download icon-styles"></i>',
                     className: '',
                     buttons: [{
-                            extend: 'csv',
                             text: '{{ trans('datatable.csv') }}',
-                            exportOptions: {
-                                columns: [1, 2, 3, 4, 5]
+                            action: function() {
+                                exportFeedbackQuestions(table, 'csv');
                             }
                         },
                         {
-                            extend: 'pdf',
                             text: '{{ trans('datatable.pdf') }}',
-                            exportOptions: {
-                                columns: [1, 2, 3, 4, 5]
+                            action: function() {
+                                exportFeedbackQuestions(table, 'pdf');
                             }
                         }
                     ]


### PR DESCRIPTION
📥 Pull Request: Fix Feedback Questions Export Downloads #700

## 🔧 Description

The Feedback Questions management page export dropdown did not download CSV or PDF files because the DataTables export configuration targeted non-existent columns on the table. The action failed silently, leaving users with no download and no feedback.

This PR replaces the broken CSV/PDF export button handlers with explicit client-side download actions. CSV export now creates and downloads a Blob directly, and PDF export uses the already-loaded pdfMake library to generate and download a PDF. The exported data includes the useful table columns only: ID, question text, and question type.

Fixes: #700
---

## ✅ Type of Change

- Bug fix
- UI workflow fix
---

## 📸 Screenshots

N/A - this change fixes export download behavior.

---

## 🚀 How Has This Been Tested?

- Verified locally that CSV and PDF downloads work from `/user/feedback-questions`
- Whitespace validation for the clean branch diff

Commands run:
- git diff --check -- resources/views/backend/feedback/index.blade.php

---

## 🧪 Steps to Reproduce

1. Login to the application as admin
2. Navigate to `/user/feedback-questions`
3. Click the export icon
4. Select CSV and confirm `feedback-questions.csv` downloads
5. Select PDF and confirm `feedback-questions.pdf` downloads

---

## 🔄 Checklist

- CSV export triggers a real file download
- PDF export triggers a real file download
- Export excludes the action column
- Empty exports show user feedback
- PR branch contains only the fix for issue #700
