### PR TITLE
Fix mail from name settings save

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ConfigController.php
+++ b/app/Http/Controllers/Backend/Admin/ConfigController.php
@@ -135,16 +135,29 @@ class ConfigController extends Controller
         }
 
         $request = $this->saveFilesOptimize($request);
+        $requests = $request->all();
 
         //dd($request->site_logo);
 
 
-        $config = Config::firstOrCreate(['key' => 'site_logo']);
-        $config->value = $request->site_logo;
-        $config->save();
+        if ($request->filled('site_logo')) {
+            $config = Config::firstOrCreate(['key' => 'site_logo']);
+            $config->value = $request->site_logo;
+            $config->save();
+        }
 
 
         $switchInputs = ['access_registration', 'mailchimp_double_opt_in', 'access_users_change_email', 'access_users_confirm_email', 'access_captcha_registration', 'access_users_requires_approval', 'services__stripe__active', 'paypal__active', 'payment_offline_active', 'backup__status', 'access__captcha__registration', 'retest', 'lesson_timer', 'show_offers', 'onesignal_status', 'access__users__registration_mail', 'access__users__order_mail', 'services__instamojo__active', 'services__razorpay__active', 'services__cashfree__active', 'services__payu__active', 'flutter__active'];
+        $mailConfigKeyMap = [
+            'mail.driver' => 'mail.default',
+            'mail.host' => 'mail.mailers.smtp.host',
+            'mail.port' => 'mail.mailers.smtp.port',
+            'mail.username' => 'mail.mailers.smtp.username',
+            'mail.password' => 'mail.mailers.smtp.password',
+            'mail.encryption' => 'mail.mailers.smtp.encryption',
+            'mail.from.address' => 'mail.from.address',
+            'mail.from.name' => 'mail.from.name',
+        ];
 
         foreach ($switchInputs as $switchInput) {
             if ($request->get($switchInput) == null) {
@@ -164,6 +177,14 @@ class ConfigController extends Controller
             $config = Config::firstOrCreate(['key' => $key, 'lang' => $lang]);
             $config->value = $value;
             $config->save();
+
+            if (array_key_exists($key, $mailConfigKeyMap)) {
+                $mappedConfig = Config::firstOrCreate(['key' => $mailConfigKeyMap[$key], 'lang' => $lang]);
+                $mappedConfig->value = $value;
+                $mappedConfig->save();
+
+                \Illuminate\Support\Facades\Config::set($mailConfigKeyMap[$key], $value);
+            }
 
 
 

--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -246,7 +246,7 @@
 
                             <div class="text-end mt-3">
     <button type="submit" class="btn btn-primary">
-        {{ __('labels.backend.general_settings.save_settings') }}
+        {{ __('labels.backend.general_settings.email.save_settings') }}
     </button>
 </div>
 
@@ -463,6 +463,12 @@
 
                             <hr>
                             <p class="help-text mb-0">{!! __('labels.backend.general_settings.email.note') !!}</p>
+
+                            <div class="text-end mt-3">
+                                <button type="submit" class="btn btn-primary">
+                                    {{ __('labels.backend.general_settings.email.save_settings') }}
+                                </button>
+                            </div>
 
                         </div>
                     </div>


### PR DESCRIPTION
📥 Pull Request: Fix Mail From Name Settings Save #705

## 🔧 Description

The Settings → General → Mail From Name tab did not show a Save button, so admins could not submit changes from that section. The form also did not initialize the submitted settings payload before saving, which could prevent mail settings from being persisted correctly.

This PR adds the missing Save Settings button to the Mail From Name tab, uses the existing email settings translation key so the button label renders correctly, and ensures submitted settings are saved. Mail settings are also mapped to the Laravel mail configuration keys used by the current application.

Fixes: #705
---

## ✅ Type of Change

- Bug fix
- Settings workflow fix
---

## 📸 Screenshots

<img width="1648" height="799" alt="Screenshot_20260524_171247" src="https://github.com/user-attachments/assets/8900969e-26d3-4d7d-afe4-c74746cd950f" />

---

## 🚀 How Has This Been Tested?

- PHP syntax check for the updated controller
- Whitespace validation for the clean branch diff

Commands run:
- php -l app/Http/Controllers/Backend/Admin/ConfigController.php
- git diff --check -- app/Http/Controllers/Backend/Admin/ConfigController.php resources/views/backend/settings/general.blade.php

---

## 🧪 Steps to Reproduce

1. Login to the application as admin
2. Navigate to `/user/settings/general`
3. Open Settings → General → Mail From Name
4. Confirm the Save Settings button is visible
5. Update Mail From Name and save
6. Confirm the setting is persisted successfully

---

## 🔄 Checklist

- Mail From Name tab displays a Save Settings button
- Button label uses an existing translation key
- Submitted settings payload is initialized before persistence
- Mail settings are saved to the config keys used by Laravel mail
- PR branch contains only the fix for issue #705
