### PR TITLE
Fix feedback question delete confirmation

### DIFF
--- a/app/Http/Controllers/Backend/Admin/FeedbackController.php
+++ b/app/Http/Controllers/Backend/Admin/FeedbackController.php
@@ -310,25 +310,16 @@ class FeedbackController extends Controller
         }
     }
 
-    public function feedback_questions_delete(Request $request)
+    public function feedback_questions_delete(Request $request, $id = null)
     {
-        // dd('ji');
-        $teacher = FeedbackQuestion::findOrFail($request->id);
+        $questionId = $id ?? $request->input('id');
 
-        if ($teacher->count() > 0) {
-            $teacher->delete();
-            return redirect()->route('admin.feedback_question.index')->withFlashDanger(trans('alerts.backend.general.deleted'));
-        } else {
-            $teacher->delete();
-        }
+        $question = FeedbackQuestion::findOrFail($questionId);
+        $question->delete();
 
-        return json_encode(array(
-            'code' => 200,
-            'message' => 'Question Deleted '
-        ));
-
-        return redirect()->route('admin.feedback_question.index')->withFlashSuccess(trans('alerts.backend.general.deleted'));
-        return view('backend.feedback.feedback-question-create');
+        return redirect()
+            ->route('admin.feedback_question.index')
+            ->withFlashSuccess(trans('alerts.backend.general.deleted'));
     }
 
     // public function storeUserResponses(Request $request)

--- a/resources/views/backend/feedback/index.blade.php
+++ b/resources/views/backend/feedback/index.blade.php
@@ -74,11 +74,9 @@
                                     <a title="{{ __('user_feedback.feedback_questions.edit') }}" class="" href="{{ route('admin.feedback_question.edit', ['id' => $value->id]) }}">
                                         <i class="fa fa-edit" aria-hidden="true"></i>
                                     </a>
-                                    <a href="javascript:void(0)"
-                                        class="js-delete-question"
-                                        data-url="{{ route('admin.questions.destroy', $value->id) }}">
-                                        <i class="fa fa-trash"></i>
-                                    </a>                 
+                                    @include('backend.datatable.action-delete', [
+                                        'route' => route('admin.feedback_question.destroy', $value->id)
+                                    ])
                                 </div>
                             </td>
                         </tr>
@@ -267,25 +265,5 @@
 
         });
     });
-</script>
-
-<script>
-    function delete_client(id) {
-        $.ajax({
-            type: 'post',
-            url: "{{ route('admin.feedback.feedback-question-multiple-delete') }}",
-            data: ({
-                id: id,
-                _token: "{{ csrf_token() }}"
-            }),
-            success: function(response) {
-                window.location.replace("{{ route('admin.feedback_question.index') }}");
-            },
-            error: function(error) {
-                console.log(error);
-            }
-        })
-
-    }
 </script>
 @endpush

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -776,7 +776,7 @@ Route::get('get-feedback-detail/{id}', 'Admin\UserFeebackAnswersController@feedb
 Route::get('feedback-question-multiple/{id?}', 'Admin\FeedbackController@feedback_questions')->name('feedback.feedback-question-multiple');
 Route::post('feedback-question-multiple-store', 'Admin\FeedbackController@feedback_questions_store')->name('feedback.feedback-question-multiple-store');
 Route::post('feedback-question-multiple-delete', 'Admin\FeedbackController@feedback_questions_delete')->name('feedback.feedback-question-multiple-delete');
-
+Route::delete('feedback-question/{id}', 'Admin\FeedbackController@feedback_questions_delete')->name('feedback_question.destroy');
 
 Route::get('send-email-notification', 'Admin\EmailNotificationController@sendEmailNotification');
 Route::post('send-email-notification', 'Admin\EmailNotificationController@sendEmailNotificationPost');


### PR DESCRIPTION
## Description

The Feedback Questions page allowed users to click the delete icon without showing the standard confirmation popup.

This PR updates the Feedback → Questions delete action to use the existing shared backend delete partial. The delete flow now shows the standard confirmation dialog before deleting, and after confirmation the user is redirected back with the normal flash success message shown above the table.

## Fixes: #701

## ✅ Type of Change

* Bug fix
* UI workflow fix

---

## Screenshots

N/A - this change reuses the existing delete confirmation dialog and flash message behavior.

---

## How Has This Been Tested?

* Verified that the delete icon now uses the shared backend delete partial.
* Verified that the old unused Ajax delete handler was removed.
* Verified that the Feedback Question delete route points to the controller delete method.
* Verified PHP syntax for the updated controller.

Commands run:

* `git diff --check`
* `php -l app/Http/Controllers/Backend/Admin/FeedbackController.php`

Note: Full browser testing was not run locally because vendor dependencies are not installed.

---

## Steps to Reproduce

1. Login to the application as admin.
2. Navigate to Feedback → Questions.
3. Click the delete icon for any feedback question.
4. Confirm that the delete confirmation popup is displayed.
5. Click Cancel and verify the question is not deleted.
6. Click Delete/Confirm and verify the question is deleted.
7. Verify the success message is displayed above the table.

---

## Checklist

* Delete action shows a confirmation popup.
* Cancel action prevents deletion.
* Confirm action deletes the feedback question.
* Success message appears above the table using the existing flash message system.
* PR branch contains only the fix for issue #701.