### PR TITLE
fix: add validation and save button for stripe payment settings #706

### DIFF
--- a/app/Http/Controllers/Backend/SettingsController.php
+++ b/app/Http/Controllers/Backend/SettingsController.php
@@ -14,7 +14,21 @@ class SettingsController extends Controller
         $request->validate([
             'app_name'   => 'required|string|max:255',
             'app_url'    => 'required|url',
-            'site_logo'  => 'nullable|image|max:10240'
+            'site_logo'  => 'nullable|image|max:10240',
+            // PAYMENT SETTINGS
+            'app__currency' => 'required',
+
+            'services__stripe__key' => 'required_if:services__stripe__active,1',
+
+            'services__stripe__secret' => 'required_if:services__stripe__active,1',
+
+        ], [
+
+            'app__currency.required' =>
+            'Currency field is required.',
+
+            'services__stripe__key.required_if' =>  'Stripe publishable key is required when Stripe is enabled.',
+            'services__stripe__secret.required_if' => 'Stripe secret key is required when Stripe is enabled.',
         ]);
 
         // Save Text Settings
@@ -26,6 +40,26 @@ class SettingsController extends Controller
         Setting::updateOrCreate(
             ['key' => 'app_url'],
             ['value' => $request->app_url]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'app__currency'],
+            ['value' => $request->app__currency]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'services__stripe__active'],
+            ['value' => $request->has('services__stripe__active') ? 1 : 0]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'services__stripe__key'],
+            ['value' => $request->services__stripe__key]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'services__stripe__secret'],
+            ['value' => $request->services__stripe__secret]
         );
 
         // Handle Logo Upload

--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -470,6 +470,7 @@
 
                 <!---Payment Configuration Tab--->
                 <div id="payment_settings" class="tab-pane container fade">
+
     <div class="row mt-4 mb-4">
         <div class="col">
 
@@ -477,65 +478,154 @@
             <div class="form-group row">
                 <label class="col-md-3 form-control-label">
                     {{ __('labels.backend.general_settings.payment_settings.select_currency') }}
+                    <span class="text-danger">*</span>
                 </label>
+
                 <div class="col-md-9">
-                    <select class="form-control" id="app__currency" name="app__currency">
+
+                    <select class="form-control @error('app__currency') is-invalid @enderror"
+                        id="app__currency"
+                        name="app__currency"
+                        required>
+
+                        <option value="">
+                            Select Currency
+                        </option>
+
                         @foreach (config('currencies') as $currency)
+
                             <option value="{{ $currency['short_code'] }}"
-                                {{ config('app.currency') == $currency['short_code'] ? 'selected' : '' }}>
+                                {{ old('app__currency', config('app.currency')) == $currency['short_code'] ? 'selected' : '' }}>
+
                                 {{ $currency['symbol'] }} - {{ $currency['name'] }}
+
                             </option>
+
                         @endforeach
+
                     </select>
+
+                    @error('app__currency')
+                        <span class="invalid-feedback d-block">
+                            {{ $message }}
+                        </span>
+                    @enderror
+
                 </div>
             </div>
 
             <!-- Stripe Activation -->
             <div class="form-group row">
+
                 <label class="col-md-3 form-control-label">
                     {{ __('labels.backend.general_settings.payment_settings.stripe') }}
                 </label>
+
                 <div class="col-md-9">
+
                     <label class="switch switch-sm switch-3d switch-primary">
-                        <input type="checkbox" name="services__stripe__active" class="switch-input" value="1"
-                            {{ config('services.stripe.active') ? 'checked' : '' }}>
+
+                        <input type="checkbox"
+                            name="services__stripe__active"
+                            class="switch-input"
+                            value="1"
+                            {{ old('services__stripe__active', config('services.stripe.active')) ? 'checked' : '' }}>
+
                         <span class="switch-label"></span>
                         <span class="switch-handle"></span>
+
                     </label>
 
-                    <a class="float-right font-weight-bold font-italic" 
-                       href="https://stripe.com/docs/keys" target="_blank">
+                    <a class="float-right font-weight-bold font-italic"
+                        href="https://stripe.com/docs/keys"
+                        target="_blank">
+
                         {{ __('labels.backend.general_settings.payment_settings.how_to_stripe') }}
+
                     </a>
 
-                    <small><i>{{ __('labels.backend.general_settings.payment_settings.stripe_note') }}</i></small>
+                    <small>
+                        <i>
+                            {{ __('labels.backend.general_settings.payment_settings.stripe_note') }}
+                        </i>
+                    </small>
+
                 </div>
             </div>
 
             <!-- Stripe Keys -->
             <div class="switch-content {{ config('services.stripe.active') ? '' : 'd-none' }}">
+
+                <!-- Stripe Key -->
                 <div class="form-group row">
+
                     <label class="col-md-2 form-control-label">
                         {{ __('labels.backend.general_settings.payment_settings.key') }}
+                        <span class="text-danger">*</span>
                     </label>
+
                     <div class="col-md-8">
-                        <input type="text" name="services__stripe__key" class="form-control"
-                               value="{{ config('services.stripe.key') }}">
+
+                        <input type="text"
+                            name="services__stripe__key"
+                            class="form-control @error('services__stripe__key') is-invalid @enderror"
+                            value="{{ old('services__stripe__key', config('services.stripe.key')) }}"
+                            placeholder="Enter Stripe Publishable Key">
+
+                        @error('services__stripe__key')
+                            <span class="invalid-feedback d-block">
+                                {{ $message }}
+                            </span>
+                        @enderror
+
                     </div>
                 </div>
 
+                <!-- Stripe Secret -->
                 <div class="form-group row">
+
                     <label class="col-md-2 form-control-label">
                         {{ __('labels.backend.general_settings.payment_settings.secret') }}
+                        <span class="text-danger">*</span>
                     </label>
+
                     <div class="col-md-8">
-                        <input type="text" name="services__stripe__secret" class="form-control"
-                               value="{{ config('services.stripe.secret') }}">
+
+                        <input type="text"
+                            name="services__stripe__secret"
+                            class="form-control @error('services__stripe__secret') is-invalid @enderror"
+                            value="{{ old('services__stripe__secret', config('services.stripe.secret')) }}"
+                            placeholder="Enter Stripe Secret Key">
+
+                        @error('services__stripe__secret')
+                            <span class="invalid-feedback d-block">
+                                {{ $message }}
+                            </span>
+                        @enderror
+
                     </div>
                 </div>
+
             </div>
+
+            <!-- SAVE BUTTON -->
+            <div class="form-group row mt-4">
+
+                <div class="col-md-12 text-right">
+
+                    <button type="submit" class="btn btn-primary">
+
+                        <i class="fa fa-save"></i> Save Settings
+
+                    </button>
+
+                </div>
+
+            </div>
+
         </div>
     </div>
+
 </div>
 
 <div id="language_settings" class="tab-pane container fade language-workflow">


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes issues in the Settings → General → Stripe Payment Method section.

### Issues Fixed

* Added required field validation for Stripe configuration fields
* Added validation error messages for invalid/empty inputs
* Added missing Save button in Stripe Payment Method tab
* Enabled successful submission and saving of Stripe settings

Fixes: #706 

---

## ✅ Type of Change

* [x] Bug fix


---

## 🧪 How Has This Been Tested?

### Tested Scenarios

* Validation shown when currency is empty
* Save button visible and functional
* Stripe settings save successfully
* Validation errors displayed correctly

---

## 📸 Screenshots (if applicable)

<img width="1915" height="947" alt="image" src="https://github.com/user-attachments/assets/7e41a867-627b-42ce-80fd-aa83b6b54aa5" />
<img width="1916" height="941" alt="image" src="https://github.com/user-attachments/assets/d4e5884b-a365-409d-865b-e7ce1ef768d4" />

---

## ✅ Checklist

* [x] Code follows project coding standards
* [x] Validation added
* [x] Save functionality tested
* [x] No console errors
* [x] Changes tested locally
