### PR TITLE
fix: render completed certificates from certificate template #715

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ConfigController.php
+++ b/app/Http/Controllers/Backend/Admin/ConfigController.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use LdapRecord\Container;
+use App\Support\CertificateTemplate;
 
 class ConfigController extends Controller
 {
@@ -700,26 +701,8 @@ class ConfigController extends Controller
 
     public function getCertificateTemplateSettings()
     {
-        $settings = Config::where('key', 'certificate_template_settings')->first();
-        if ($settings) {
-            $settings = json_decode($settings->value, true);
-        } else {
-            $settings = [
-                'template' => 'classic-dark',
-                'primary_color' => '#d4af37',
-                'secondary_color' => '#f5d670',
-                'bg_color' => '#1a1a2e',
-                'text_color' => '#ffffff',
-                'cert_label' => 'Certificate of Completion',
-                'cert_title' => 'Achievement Award',
-                'show_badge' => 1,
-                'show_seal' => 1,
-                'show_signature' => 1,
-                'logo_image' => null,
-                'seal_image' => null,
-                'signature_image' => null,
-            ];
-        }
+        $settings = CertificateTemplate::settings();
+
         return view('backend.settings.certificate-template', compact('settings'));
     }
 

--- a/app/Http/Controllers/Backend/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Backend/Admin/EmployeeController.php
@@ -32,6 +32,7 @@ use App\Imports\UsersImport;
 use App\Jobs\GenerateInternalAttendanceReport;
 use App\Jobs\SendEmailJob;
 use App\Notifications\Backend\UserAuthNotification;
+use App\Services\CertificatePdfRenderer;
 use App\Services\NotificationSettingsService;
 use Illuminate\Support\Facades\Hash;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
@@ -874,10 +875,7 @@ class EmployeeController extends Controller
             $certificate->url = $certificate_name;
             $certificate->save();
             if ($certificate->id) {
-                // $html = view('certificate.index', ['data'=> $data]);
-
-                $pdf = \PDF::loadView('certificate.index', compact('data'))->setPaper('A3', 'portrait');
-                $pdf->save(public_path('storage/certificates/' . $certificate_name));
+                app(CertificatePdfRenderer::class)->renderTo($data, public_path('storage/certificates/' . $certificate_name));
                 // return true;
 
                 UserCourseDetail::where('course_id', $course->id)->where('user_id', $user->id)->update(

--- a/app/Http/Controllers/Backend/CertificateController.php
+++ b/app/Http/Controllers/Backend/CertificateController.php
@@ -7,13 +7,11 @@ use App\Models\{Certificate, CertificateHistory, courseAssignment, UserCourseDet
 use App\Models\Course;
 use App\Models\Auth\User;
 use App\Models\Stripe\SubscribeCourse;
+use App\Services\CertificatePdfRenderer;
 use Carbon\Carbon;
 use CustomHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Response;
-use PDF;
-use SimpleSoftwareIO\QrCode\Facades\QrCode;
 use Yajra\DataTables\Facades\DataTables;
 use App\Notifications\Backend\CertificateNotification;
 
@@ -352,24 +350,19 @@ class CertificateController extends Controller
             'course_name' => $metadata['course_title'] ?? optional($certificate->course)->title ?? $course->title ?? 'Course Title',
             'date' => Carbon::parse($metadata['completion_date'] ?? $certificate->created_at)->format('d M, Y'),
             'certificate_id' => $certificate->certificate_id,
-            'qr' => base64_encode(
-                QrCode::size(150)
-                    ->format('svg')
-                    ->margin(1)
-                    ->generate(url('/certificate-verification?validation_hash=' . trim($certificate->validation_hash)))
-            ),
         ];
 
-        $pdf = PDF::loadView('certificate.index', compact('data'));
-        $pdf->setPaper('A4', 'landscape');
-
         $fileName = "Certificate-{$certificate->certificate_id}.pdf";
+        $pdfPath = app(CertificatePdfRenderer::class)->render($data);
 
         if ($request->boolean('download')) {
-            return $pdf->download($fileName);
+            return response()->download($pdfPath, $fileName)->deleteFileAfterSend(true);
         }
 
-        return $pdf->stream($fileName);
+        return response()->file($pdfPath, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . $fileName . '"',
+        ])->deleteFileAfterSend(true);
     }
 
     /**
@@ -395,13 +388,12 @@ class CertificateController extends Controller
             'course_name' => $metadata['course_title'] ?? optional($certificate->course)->title ?? 'Course Title',
             'date' => Carbon::parse($metadata['completion_date'] ?? $certificate->created_at)->format('d M, Y'),
             'certificate_id' => $certificate->certificate_id,
-            'qr' => base64_encode(QrCode::size(150)->format('svg')->margin(1)->generate(url("/certificate-verification?validation_hash=" . trim($certificate->validation_hash)))),
         ];
 
-        $pdf = PDF::loadView('certificate.index', compact('data'));
-        $pdf->setPaper('A4', 'landscape');
+        $fileName = "Certificate-{$certificate->certificate_id}.pdf";
+        $pdfPath = app(CertificatePdfRenderer::class)->render($data);
 
-        return $pdf->download("Certificate-{$certificate->certificate_id}.pdf");
+        return response()->download($pdfPath, $fileName)->deleteFileAfterSend(true);
     }
 
 

--- a/app/Http/Controllers/CoursesController.php
+++ b/app/Http/Controllers/CoursesController.php
@@ -21,6 +21,7 @@ use Carbon\Carbon;
 use Auth;
 use CustomHelper;
 use App\Models\UserLearningPathway;
+use App\Services\CertificatePdfRenderer;
 use Yajra\DataTables\Facades\DataTables;
 
 class CoursesController extends Controller
@@ -75,9 +76,8 @@ class CoursesController extends Controller
             ];
             $certificate_name = 'Certificate-' . $course->id . '-' . $user_id . '.pdf';
 
-            //return view('certificate.index', compact('data'));
-            $pdf = \PDF::loadView('certificate.index', compact('data'))->setPaper('', 'landscape');;
-            $pdf->save(public_path('storage/certificates/' . $certificate_name));
+            app(CertificatePdfRenderer::class)->renderTo($data, public_path('storage/certificates/' . $certificate_name));
+
             return response()->file(public_path('storage/certificates/' . $certificate_name));
             //return back()->withFlashSuccess(trans('alerts.frontend.course.completed'));
         }
@@ -1348,5 +1348,4 @@ if ($this->isLiveCourse($course) && $subscribe_data && $subscribe_data->due_date
 }
 
 }
-
 

--- a/app/Http/Controllers/v1/ApiController.php
+++ b/app/Http/Controllers/v1/ApiController.php
@@ -33,6 +33,7 @@ use App\Models\Question;
 use App\Models\QuestionsOption;
 use App\Models\Reason;
 use App\Models\Review;
+use App\Services\CertificatePdfRenderer;
 use App\Models\Sponsor;
 use App\Models\Stripe\StripePlan;
 use App\Models\System\Session;
@@ -998,9 +999,7 @@ class ApiController extends Controller
             $certificate->url = $certificate_name;
             $certificate->save();
 
-            $pdf = \PDF::loadView('certificate.index', compact('data'))->setPaper('', 'landscape');
-
-            $pdf->save(public_path('storage/certificates/' . $certificate_name));
+            app(CertificatePdfRenderer::class)->renderTo($data, public_path('storage/certificates/' . $certificate_name));
 
             return response()->json(['status' => 'success']);
         }

--- a/app/Services/CertificatePdfRenderer.php
+++ b/app/Services/CertificatePdfRenderer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services;
+
+use App\Support\CertificateTemplate;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class CertificatePdfRenderer
+{
+    public function render(array $data): string
+    {
+        $directory = storage_path('app/certificates/rendered');
+        File::ensureDirectoryExists($directory);
+
+        $id = (string) Str::uuid();
+        $htmlPath = $directory . "/certificate-{$id}.html";
+        $pdfPath = $directory . "/certificate-{$id}.pdf";
+
+        $html = view('certificate.pdf', [
+            'data' => $data,
+            'settings' => CertificateTemplate::settings(),
+        ])->render();
+
+        File::put($htmlPath, $html);
+
+        try {
+            $process = new Process([
+                $this->chromiumBinary(),
+                '--headless',
+                '--disable-gpu',
+                '--disable-dev-shm-usage',
+                '--no-sandbox',
+                '--allow-file-access-from-files',
+                '--no-pdf-header-footer',
+                '--print-to-pdf-no-header',
+                '--print-to-pdf=' . $pdfPath,
+                'file://' . $htmlPath,
+            ]);
+            $process->setTimeout(60);
+            $process->run();
+
+            if (! $process->isSuccessful() || ! File::exists($pdfPath)) {
+                throw new RuntimeException(trim($process->getErrorOutput() ?: $process->getOutput()));
+            }
+        } finally {
+            File::delete($htmlPath);
+        }
+
+        return $pdfPath;
+    }
+
+    public function renderTo(array $data, string $targetPath): string
+    {
+        File::ensureDirectoryExists(dirname($targetPath));
+
+        if (File::exists($targetPath)) {
+            File::delete($targetPath);
+        }
+
+        $pdfPath = $this->render($data);
+        File::move($pdfPath, $targetPath);
+
+        return $targetPath;
+    }
+
+    private function chromiumBinary(): string
+    {
+        $candidates = array_filter([
+            env('CHROME_BIN'),
+            env('CHROMIUM_PATH'),
+            '/usr/bin/chromium-browser',
+            '/snap/bin/chromium',
+            '/usr/bin/chromium',
+            '/usr/bin/google-chrome',
+            '/usr/bin/google-chrome-stable',
+        ]);
+
+        foreach ($candidates as $candidate) {
+            if (File::exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        throw new RuntimeException('Chromium is required to render certificate PDFs. Set CHROME_BIN or CHROMIUM_PATH.');
+    }
+}

--- a/app/Support/CertificateTemplate.php
+++ b/app/Support/CertificateTemplate.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Config;
+
+class CertificateTemplate
+{
+    public static function defaults(): array
+    {
+        return [
+            'template' => 'classic-dark',
+            'bg_texture' => '',
+            'primary_color' => '#d4af37',
+            'secondary_color' => '#f5d670',
+            'bg_color' => '#1a1a2e',
+            'text_color' => '#ffffff',
+            'cert_label' => 'Certificate of Completion',
+            'cert_title' => 'Achievement Award',
+            'show_badge' => 1,
+            'show_seal' => 1,
+            'show_signature' => 1,
+            'logo_image' => null,
+            'seal_image' => null,
+            'signature_image' => null,
+        ];
+    }
+
+    public static function settings(): array
+    {
+        try {
+            $record = Config::where('key', 'certificate_template_settings')->first();
+        } catch (\Throwable $e) {
+            return self::defaults();
+        }
+
+        if (! $record) {
+            return self::defaults();
+        }
+
+        $settings = json_decode($record->value, true);
+
+        if (! is_array($settings)) {
+            return self::defaults();
+        }
+
+        return array_merge(self::defaults(), $settings);
+    }
+}

--- a/resources/views/backend/settings/certificate-template.blade.php
+++ b/resources/views/backend/settings/certificate-template.blade.php
@@ -384,6 +384,8 @@
         cursor: pointer;
         background: none;
     }
+
+    @include('certificate.partials.template-styles', ['settings' => $settings])
 </style>
 @endpush
 
@@ -416,52 +418,11 @@
                         </div>
                     </div>
 
-                    <div id="certificate-preview" class="certificate-preview {{ $settings['template'] ?? 'classic-dark' }}">
-                        <div id="texture-overlay" class="texture-overlay {{ $settings['bg_texture'] ?? '' }}"></div>
-                        <div class="border-ornament"></div>
-                        
-                        <div class="logo-container" id="preview-logo-container">
-                            @if($settings['logo_image'] ?? null)
-                                <img src="{{ asset($settings['logo_image'] ?? '') }}" alt="{{ __('certificate_template.logo') }}" style="max-height: 60px;">
-                            @endif
-                        </div>
-
-                        <div class="cert-badge" id="preview-cert-badge" style="{{ ($settings['show_badge'] ?? 1) ? '' : 'display:none;' }}">
-                            <i class="fas fa-trophy"></i>
-                        </div>
-
-                        <div class="cert-label" id="preview-cert-label">{{ $settings['cert_label'] ?? __('certificate_template.default_cert_label') }}</div>
-                        <div class="cert-title" id="preview-cert-title">{{ $settings['cert_title'] ?? __('certificate_template.default_cert_title') }}</div>
-                        <div class="cert-divider"></div>
-
-                        <div class="cert-presented-to">{{ __('certificate_template.presented_to') }}</div>
-                        <div class="cert-recipient-name">{{ __('certificate_template.sample_recipient_name') }}</div>
-
-                        <div class="cert-course-label">{{ __('certificate_template.completed_label') }}</div>
-                        <div class="cert-course-name">{{ __('certificate_template.sample_course_name') }}</div>
-
-                        <div class="cert-footer">
-                            <div class="cert-signature-block">
-                                <div class="cert-signature-wrapper" id="preview-signature-wrapper" style="{{ ($settings['show_signature'] ?? 1) ? '' : 'display:none;' }}">
-                                    <div class="cert-signature-label">{{ __('certificate_template.instructor') }}</div>
-                                </div>
-                            </div>
-
-                            <div class="cert-signature-block">
-                                <div class="cert-signature-wrapper">
-                                    <div class="cert-signature-label">{{ __('certificate_template.date_issued') }}</div>
-                                </div>
-                            </div>
-
-                            <div class="cert-seal" id="preview-cert-seal" style="{{ ($settings['show_seal'] ?? 1) ? '' : 'display:none;' }}">
-                                @if($settings['seal_image'] ?? null)
-                                    <img src="{{ asset($settings['seal_image'] ?? '') }}" alt="{{ __('certificate_template.seal') }}" style="max-width: 100%; border-radius: 50%;">
-                                @else
-                                    <i class="fas fa-certificate"></i>
-                                @endif
-                            </div>
-                        </div>
-                    </div>
+                    @include('certificate.partials.template', [
+                        'settings' => $settings,
+                        'data' => [],
+                        'elementId' => 'certificate-preview',
+                    ])
 
                     <div class="card-footer bg-white">
                         <div class="text-muted" style="font-size:13px;">

--- a/resources/views/certificate/partials/template-styles.blade.php
+++ b/resources/views/certificate/partials/template-styles.blade.php
@@ -1,0 +1,299 @@
+:root {
+    --primary-color: {{ $settings['primary_color'] ?? '#d4af37' }};
+    --secondary-color: {{ $settings['secondary_color'] ?? '#f5d670' }};
+    --bg-color: {{ $settings['bg_color'] ?? '#1a1a2e' }};
+    --text-color: {{ $settings['text_color'] ?? '#ffffff' }};
+}
+
+.certificate-preview {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 297 / 210;
+    min-height: 420px;
+    box-sizing: border-box;
+    background: var(--bg-color);
+    padding: 40px 50px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-color);
+    font-family: Georgia, serif;
+    transition: all 0.3s ease;
+    overflow: hidden;
+}
+
+.certificate-preview,
+.certificate-preview * {
+    box-sizing: border-box;
+}
+
+.certificate-preview > *:not(.texture-overlay):not(.border-ornament) {
+    position: relative;
+    z-index: 2;
+}
+
+.certificate-preview.modern-light {
+    border: 25px solid #f8f9fa;
+    font-family: Inter, Poppins, Arial, sans-serif;
+}
+
+.certificate-preview.elegant-gold {
+    border: 20px solid var(--primary-color);
+    border-image: linear-gradient(135deg, #d4af37, #f5d670, #8e6d10) 1;
+    background: #fffcf0;
+}
+
+.logo-container {
+    min-height: 1px;
+    margin-bottom: 15px;
+}
+
+.logo-container img {
+    max-height: 60px;
+    max-width: 220px;
+}
+
+.texture-overlay {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0.2;
+    background-repeat: repeat;
+    background-position: center;
+}
+
+.texture-noise {
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+}
+
+.texture-dots {
+    background-image: radial-gradient(currentColor 1px, transparent 1px);
+    background-size: 15px 15px;
+}
+
+.texture-lines {
+    background-image: repeating-linear-gradient(45deg, transparent, transparent 10px, currentColor 10px, currentColor 11px);
+}
+
+.certificate-preview .border-ornament {
+    position: absolute;
+    inset: 12px;
+    border: 2px solid var(--primary-color);
+    opacity: 0.5;
+    border-radius: 6px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.certificate-preview .border-ornament::before,
+.certificate-preview .border-ornament::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border-color: var(--primary-color);
+    border-style: solid;
+}
+
+.certificate-preview .border-ornament::before {
+    top: -2px;
+    left: -2px;
+    border-width: 3px 0 0 3px;
+}
+
+.certificate-preview .border-ornament::after {
+    right: -2px;
+    bottom: -2px;
+    border-width: 0 3px 3px 0;
+}
+
+.certificate-preview.modern-light .border-ornament {
+    display: none;
+}
+
+.cert-badge {
+    width: 70px;
+    height: 70px;
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.cert-badge i,
+.cert-badge svg {
+    width: 32px;
+    height: 32px;
+    color: var(--bg-color);
+}
+
+.cert-label {
+    font-size: 11px;
+    letter-spacing: 4px;
+    text-transform: uppercase;
+    color: var(--primary-color);
+    margin-bottom: 6px;
+}
+
+.cert-title {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--text-color);
+    margin-bottom: 12px;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.certificate-preview.modern-light .cert-title {
+    font-weight: 300;
+    letter-spacing: 8px;
+}
+
+.certificate-preview.elegant-gold .cert-title {
+    font-family: Georgia, serif;
+    color: #8e6d10;
+}
+
+.cert-divider {
+    width: 80px;
+    height: 2px;
+    background: linear-gradient(to right, transparent, var(--primary-color), transparent);
+    margin: 12px auto;
+}
+
+.cert-presented-to {
+    font-size: 13px;
+    color: var(--text-color);
+    opacity: 0.7;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+}
+
+.cert-recipient-name {
+    max-width: 86%;
+    font-size: 26px;
+    font-style: italic;
+    color: var(--secondary-color);
+    margin-bottom: 10px;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow-wrap: anywhere;
+}
+
+.certificate-preview.modern-light .cert-recipient-name {
+    font-family: Inter, Poppins, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    text-transform: uppercase;
+    border-bottom: 2px solid var(--primary-color);
+    display: inline-block;
+    padding-bottom: 5px;
+}
+
+.certificate-preview.elegant-gold .cert-recipient-name {
+    color: #8e6d10;
+}
+
+.cert-course-label {
+    font-size: 11px;
+    color: var(--text-color);
+    opacity: 0.6;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin-bottom: 4px;
+}
+
+.cert-course-name {
+    max-width: 88%;
+    font-size: 16px;
+    color: var(--text-color);
+    font-weight: 600;
+    margin-bottom: 20px;
+    overflow-wrap: anywhere;
+}
+
+.cert-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    width: 100%;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.cert-signature-block {
+    text-align: center;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.cert-signature-wrapper {
+    display: inline-block;
+    border-top: 1px solid var(--primary-color);
+    padding-top: 6px;
+    min-width: 100px;
+}
+
+.cert-signature-label {
+    font-size: 10px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--text-color);
+    opacity: 0.7;
+}
+
+.cert-seal {
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.05), 0 0 0 8px rgba(0, 0, 0, 0.02);
+    flex-shrink: 0;
+    margin: 0 20px;
+    overflow: hidden;
+}
+
+.cert-seal img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.cert-seal i,
+.cert-seal svg {
+    width: 24px;
+    height: 24px;
+    color: var(--bg-color);
+}
+
+.certificate-print-page {
+    width: 297mm;
+    height: 210mm;
+    overflow: hidden;
+    background: var(--bg-color);
+}
+
+.certificate-print-page .certificate-preview {
+    width: 297mm;
+    height: 210mm;
+    min-height: 0;
+    aspect-ratio: auto;
+    border-radius: 0;
+    transition: none;
+}

--- a/resources/views/certificate/partials/template.blade.php
+++ b/resources/views/certificate/partials/template.blade.php
@@ -1,0 +1,80 @@
+@php
+    $settings = array_merge(\App\Support\CertificateTemplate::defaults(), $settings ?? []);
+    $data = $data ?? [];
+    $embedAssets = $embedAssets ?? false;
+    $elementId = $elementId ?? 'certificate-preview';
+
+    $imageSrc = function ($path) use ($embedAssets) {
+        if (! $path) {
+            return null;
+        }
+
+        if (\Illuminate\Support\Str::startsWith($path, ['http://', 'https://', 'data:'])) {
+            return $path;
+        }
+
+        $relativePath = ltrim($path, '/');
+        $absolutePath = public_path($relativePath);
+
+        if ($embedAssets && is_file($absolutePath)) {
+            $mimeType = mime_content_type($absolutePath) ?: 'image/png';
+            return 'data:' . $mimeType . ';base64,' . base64_encode(file_get_contents($absolutePath));
+        }
+
+        return asset($relativePath);
+    };
+
+    $logoSrc = $imageSrc($settings['logo_image'] ?? null);
+    $sealSrc = $imageSrc($settings['seal_image'] ?? null);
+@endphp
+
+<div id="{{ $elementId }}" class="certificate-preview {{ $settings['template'] ?? 'classic-dark' }}">
+    <div id="texture-overlay" class="texture-overlay {{ $settings['bg_texture'] ?? '' }}"></div>
+    <div class="border-ornament"></div>
+
+    <div class="logo-container" id="preview-logo-container">
+        @if($logoSrc)
+            <img src="{{ $logoSrc }}" alt="{{ __('certificate_template.logo') }}">
+        @endif
+    </div>
+
+    <div class="cert-badge" id="preview-cert-badge" style="{{ ($settings['show_badge'] ?? 1) ? '' : 'display:none;' }}">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path fill="currentColor" d="M18 2H6v3H3v3c0 2.21 1.79 4 4 4h.26A6.02 6.02 0 0 0 11 15.92V19H7v3h10v-3h-4v-3.08A6.02 6.02 0 0 0 16.74 12H17c2.21 0 4-1.79 4-4V5h-3V2ZM5 8V7h1v2.83A2.01 2.01 0 0 1 5 8Zm14 0c0 .73-.4 1.37-1 1.72V7h1v1Z"/>
+        </svg>
+    </div>
+
+    <div class="cert-label" id="preview-cert-label">{{ $settings['cert_label'] ?? __('certificate_template.default_cert_label') }}</div>
+    <div class="cert-title" id="preview-cert-title">{{ $settings['cert_title'] ?? __('certificate_template.default_cert_title') }}</div>
+    <div class="cert-divider"></div>
+
+    <div class="cert-presented-to">{{ __('certificate_template.presented_to') }}</div>
+    <div class="cert-recipient-name">{{ $data['name'] ?? __('certificate_template.sample_recipient_name') }}</div>
+
+    <div class="cert-course-label">{{ __('certificate_template.completed_label') }}</div>
+    <div class="cert-course-name">{{ $data['course_name'] ?? __('certificate_template.sample_course_name') }}</div>
+
+    <div class="cert-footer">
+        <div class="cert-signature-block">
+            <div class="cert-signature-wrapper" id="preview-signature-wrapper" style="{{ ($settings['show_signature'] ?? 1) ? '' : 'display:none;' }}">
+                <div class="cert-signature-label">{{ __('certificate_template.instructor') }}</div>
+            </div>
+        </div>
+
+        <div class="cert-signature-block">
+            <div class="cert-signature-wrapper">
+                <div class="cert-signature-label">{{ $data['date'] ?? __('certificate_template.date_issued') }}</div>
+            </div>
+        </div>
+
+        <div class="cert-seal" id="preview-cert-seal" style="{{ ($settings['show_seal'] ?? 1) ? '' : 'display:none;' }}">
+            @if($sealSrc)
+                <img src="{{ $sealSrc }}" alt="{{ __('certificate_template.seal') }}">
+            @else
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path fill="currentColor" d="m12 2 2.2 2.1 3-.5.8 2.9 2.8 1.3-1.4 2.7 1.4 2.7-2.8 1.3-.8 2.9-3-.5L12 19l-2.2-2.1-3 .5-.8-2.9-2.8-1.3 1.4-2.7-1.4-2.7L6 6.5l.8-2.9 3 .5L12 2Zm-2.1 9.5-1.4-1.4-1.4 1.4 2.8 2.8 6-6-1.4-1.4-4.6 4.6Z"/>
+                </svg>
+            @endif
+        </div>
+    </div>
+</div>

--- a/resources/views/certificate/pdf.blade.php
+++ b/resources/views/certificate/pdf.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $settings['cert_label'] ?? __('certificate_template.default_cert_label') }} - {{ $data['name'] ?? '' }}</title>
+    <style>
+        @page {
+            size: A4 landscape;
+            margin: 0;
+        }
+
+        html,
+        body {
+            width: 297mm;
+            height: 210mm;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            background: {{ $settings['bg_color'] ?? '#1a1a2e' }};
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        @include('certificate.partials.template-styles', ['settings' => $settings])
+    </style>
+</head>
+<body>
+    <main class="certificate-print-page">
+        @include('certificate.partials.template', [
+            'settings' => $settings,
+            'data' => $data,
+            'embedAssets' => true,
+            'elementId' => 'certificate-preview',
+        ])
+    </main>
+</body>
+</html>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the completed-course certificate PDF flow so the downloaded certificate uses the same template layout configured and previewed at `/user/settings/certificate-template`.

### Issues Fixed

* Extracted the certificate preview HTML/CSS into shared Blade partials
* Reused the same template partials for the settings preview and generated PDF
* Replaced the certificate Dompdf rendering path with server-side Chromium HTML/CSS-to-PDF rendering
* Updated completed-course, direct download, API, and admin issue-certificate paths to use the shared certificate renderer
* Embedded uploaded certificate assets for PDF rendering and replaced preview-only icon font usage with inline SVG icons
* Kept generated PDFs independent of the learner's browser, including Firefox, Opera, Chrome, and Safari

Fixes: #715

---

## ✅ Type of Change

* [x] Bug fix

---

## 🧪 How Has This Been Tested?

### Tested Scenarios

* Verified completed-course certificate controllers no longer reference the legacy `certificate.index` Dompdf template
* Verified certificate template preview and PDF rendering use the same shared Blade/CSS partials
* Ran PHP syntax checks on changed PHP files
* Ran `composer validate --strict`
* Rendered a sample certificate PDF through `CertificatePdfRenderer` using server-side headless Chromium
* Confirmed the generated PDF is one-page A4 landscape

---

## 📸 Screenshots (if applicable)

<img width="1920" height="843" alt="Screenshot_20260525_110921" src="https://github.com/user-attachments/assets/23e34210-9d03-42ca-8213-ad8a69664002" />

<img width="1920" height="843" alt="Screenshot_20260525_111239" src="https://github.com/user-attachments/assets/f024eecb-f0a7-4b5b-81e4-ec4b964aba5f" />

---



---

## ✅ Checklist

* [x] Code follows project coding standards
* [x] Certificate preview template reused for generated PDFs
* [x] Completed-course certificate download path updated
* [x] Changes tested locally
* [x] No unrelated workspace changes included in the commit
