### PR TITLE
fix: wrap backend delete confirmation script #717

### DIFF
--- a/resources/views/backend/feedback/index.blade.php
+++ b/resources/views/backend/feedback/index.blade.php
@@ -97,6 +97,55 @@
 @endsection
 
 @push('after-scripts')
+<script>
+    $(document).on('click', '.js-delete-question', function(e) {
+        e.preventDefault();
+
+        let url = $(this).data('url');
+
+        Swal.fire({
+            title: 'Are you sure?',
+            text: "This record will be deleted permanently.",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#6c757d',
+            confirmButtonText: 'Yes, delete it!',
+            cancelButtonText: 'Cancel'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                $.ajax({
+                    url: url,
+                    type: 'POST',
+                    data: {
+                        _method: 'DELETE',
+                        _token: $('meta[name="csrf-token"]').attr('content')
+                    },
+                    success: function(response) {
+                        Swal.fire({
+                            icon: 'success',
+                            title: 'Deleted!',
+                            text: 'Record deleted successfully.',
+                            timer: 2000,
+                            showConfirmButton: false
+                        });
+
+                        setTimeout(function() {
+                            location.reload();
+                        }, 2000);
+                    },
+                    error: function() {
+                        Swal.fire({
+                            icon: 'error',
+                            title: 'Error!',
+                            text: 'Something went wrong.'
+                        });
+                    }
+                });
+            }
+        });
+    });
+</script>
 <!-- <script>
         $(document).ready(function() {
 

--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -292,53 +292,6 @@
             });
         });
 
-        $(document).on('click', '.js-delete-question', function(e) {
-            e.preventDefault();
-
-            let url = $(this).data('url');
-
-            Swal.fire({
-                title: 'Are you sure?',
-                text: "This record will be deleted permanently.",
-                icon: 'warning',
-                showCancelButton: true,
-                confirmButtonColor: '#d33',
-                cancelButtonColor: '#6c757d',
-                confirmButtonText: 'Yes, delete it!',
-                cancelButtonText: 'Cancel'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    $.ajax({
-                        url: url,
-                        type: 'POST',
-                        data: {
-                            _method: 'DELETE',
-                            _token: '{{ csrf_token() }}'
-                        },
-                        success: function(response) {
-                            Swal.fire({
-                                icon: 'success',
-                                title: 'Deleted!',
-                                text: 'Record deleted successfully.',
-                                timer: 2000,
-                                showConfirmButton: false
-                            });
-
-                            setTimeout(function() {
-                                location.reload();
-                            }, 2000);
-                        },
-                        error: function() {
-                            Swal.fire({
-                                icon: 'error',
-                                title: 'Error!',
-                                text: 'Something went wrong.'
-                            });
-                        }
-                    });
-                }
-            });
-        });
     </script>
     @stack('after-scripts')
 

--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -273,83 +273,73 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
-<script>
-$(document).on('click', '.js-status-toggle', function(e){
-    e.preventDefault();
+    <script>
+        $(document).on('click', '.js-status-toggle', function(e) {
+            e.preventDefault();
 
-    let url = $(this).data('url');
-    let action = $(this).data('action');
+            let url = $(this).data('url');
+            let action = $(this).data('action');
 
-    Swal.fire({
-        title: action === 'activate' ? 'Are you sure you want to ACTIVATE this user?' : 'Are you sure you want to DEACTIVATE this user?',
-        icon: action === 'activate' ? 'question' : 'warning',
-        showCancelButton: true,
-        confirmButtonText: 'Yes'
-    }).then((result) => {
-        if(result.isConfirmed){
-            window.location.href = url;
-        }
-    });
-});
-</script>
-
-    e.preventDefault();
-
-    let url = $(this).data('url');
-
-    Swal.fire({
-        title: 'Are you sure?',
-        text: "This record will be deleted permanently.",
-        icon: 'warning',
-        showCancelButton: true,
-        confirmButtonColor: '#d33',
-        cancelButtonColor: '#6c757d',
-        confirmButtonText: 'Yes, delete it!',
-        cancelButtonText: 'Cancel'
-    }).then((result) => {
-
-        if (result.isConfirmed) {
-
-            $.ajax({
-                url: url,
-                type: 'POST',
-                data: {
-                    _method: 'DELETE',
-                    _token: '{{ csrf_token() }}'
-                },
-
-                success: function(response) {
-
-                    Swal.fire({
-                        icon: 'success',
-                        title: 'Deleted!',
-                        text: 'Record deleted successfully.',
-                        timer: 2000,
-                        showConfirmButton: false
-                    });
-
-                    setTimeout(function () {
-                        location.reload();
-                    }, 2000);
-                },
-
-                error: function() {
-
-                    Swal.fire({
-                        icon: 'error',
-                        title: 'Error!',
-                        text: 'Something went wrong.'
-                    });
-
+            Swal.fire({
+                title: action === 'activate' ? 'Are you sure you want to ACTIVATE this user?' : 'Are you sure you want to DEACTIVATE this user?',
+                icon: action === 'activate' ? 'question' : 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Yes'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    window.location.href = url;
                 }
             });
+        });
 
-        }
+        $(document).on('click', '.js-delete-question', function(e) {
+            e.preventDefault();
 
-    });
+            let url = $(this).data('url');
 
-});
-</script>
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "This record will be deleted permanently.",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#6c757d',
+                confirmButtonText: 'Yes, delete it!',
+                cancelButtonText: 'Cancel'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    $.ajax({
+                        url: url,
+                        type: 'POST',
+                        data: {
+                            _method: 'DELETE',
+                            _token: '{{ csrf_token() }}'
+                        },
+                        success: function(response) {
+                            Swal.fire({
+                                icon: 'success',
+                                title: 'Deleted!',
+                                text: 'Record deleted successfully.',
+                                timer: 2000,
+                                showConfirmButton: false
+                            });
+
+                            setTimeout(function() {
+                                location.reload();
+                            }, 2000);
+                        },
+                        error: function() {
+                            Swal.fire({
+                                icon: 'error',
+                                title: 'Error!',
+                                text: 'Something went wrong.'
+                            });
+                        }
+                    });
+                }
+            });
+        });
+    </script>
     @stack('after-scripts')
 
 </body>


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes backend pages rendering raw SweetAlert delete-confirmation JavaScript at the bottom of the page.

### Issues Fixed

* Repaired the shared backend layout script structure so JavaScript is not rendered as visible page text
* Kept the existing `.js-status-toggle` confirmation behavior in the shared backend layout
* Moved the feedback-question delete confirmation handler out of the shared layout and into `resources/views/backend/feedback/index.blade.php`
* Preserved the `.js-delete-question` SweetAlert confirmation, AJAX DELETE method override, and CSRF token handling
* Avoided registering the feedback delete handler globally on every backend page

Fixes: #717

---

## Type of Change

* [x] Bug fix

---

## How Has This Been Tested?

### Tested Scenarios

* Inspected the shared backend layout and confirmed the feedback delete-confirmation handler no longer lives in the global layout
* Verified the `.js-status-toggle` handler remains registered in the backend layout
* Verified the feedback index page registers the `.js-delete-question` handler through its `after-scripts` stack
* Ran `git diff --check`
* Attempted `php artisan view:cache`, but the PR worktree is missing `vendor/autoload.php`

---

## Screenshots

N/A

---

## Checklist

* [x] Code follows project coding standards
* [x] Broken script markup fixed
* [x] Feedback delete confirmation behavior preserved
* [x] No unrelated workspace changes included in the commit
