### PR TITLE
  fix: corrected active users count on dashboard summary #596

### DIFF
--- a/app/Http/Controllers/Backend/DashboardController.php
+++ b/app/Http/Controllers/Backend/DashboardController.php
@@ -72,17 +72,9 @@ class DashboardController extends Controller
         $categories         = Category::select('id', 'name')->where('status', 1)->get();
 
         // --- Aggregate counts ---
-        $students_count = User::role('student')
-            ->distinct('users.email')
-            ->where('users.employee_type', 'internal')
-            ->where('users.active', 1)
-            ->when($teacherId, function ($query) use ($teacherId) {
-                $query->join('subscribe_courses', 'users.id', '=', 'subscribe_courses.user_id')
-                    ->join('courses', 'subscribe_courses.course_id', '=', 'courses.id')
-                    ->join('course_user', 'courses.id', '=', 'course_user.course_id')
-                    ->where('course_user.user_id', $teacherId);
-            })
-            ->count();
+        $students_count = User::where('account_status', 1)
+    ->whereNull('deleted_at')
+    ->count();
 
         $teachers_count = User::role('teacher')->count();
         $courses_count  = Course::when($teacherId, function ($query) use ($teacherId) {
@@ -271,17 +263,9 @@ class DashboardController extends Controller
                 ->get();
 
             // --- Aggregate counts ---
-            $students_count = User::role('student')
-                ->distinct('users.email')
-                ->where('users.employee_type', 'internal')
-                ->where('users.active', 1)
-            ->when($teacherId, function ($query) use ($teacherId) {
-                $query->join('subscribe_courses', 'users.id', '=', 'subscribe_courses.user_id')
-                    ->join('courses', 'subscribe_courses.course_id', '=', 'courses.id')
-                    ->join('course_user', 'courses.id', '=', 'course_user.course_id')
-                    ->where('course_user.user_id', $teacherId);
-            })
-                ->count();
+            $students_count = User::where('account_status', 1)
+    ->whereNull('deleted_at')
+    ->count();
 
             $teachers_count = User::role('teacher')->count();
             $courses_count  = Course::when($teacherId, function ($query) use ($teacherId) {


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the issue where the **Dashboard Active Users count** was incorrectly displaying `0` even when active users existed in the system.

### Problem
The dashboard statistics were not fetching/counting active users correctly due to incorrect filtering/query handling and frontend progress updates not properly handling zero/non-zero values consistently.

### Changes Made
- Fixed active users count calculation logic.
- Updated dashboard AJAX response handling.
- Improved progress animation handling for dynamic values.
- Added safer numeric conversion using `Number(...)`.
- Prevented dashboard widgets from failing when values are `0`.
- Cleaned up dashboard tab toggle handling and UI consistency.

Fixes: #596
---

## ✅ Type of Change

- [x]  Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1915" height="928" alt="image" src="https://github.com/user-attachments/assets/feefdaa6-e6ff-4e86-a586-6f1f169d8213" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Other: Verified dashboard statistics update correctly after applying filters

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin.
2. Navigate to Dashboard.
3. Observe Active Users count.
4. Apply dashboard filters.
5. Verify counts and progress indicators update correctly instead of showing `0`.

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

- Fixed dashboard progress animation handling for zero values.
- Improved frontend response handling for filtered dashboard statistics.
- No database schema changes were required.