### PR TITLE
fix: prevent trainer schedule overlaps #735

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -542,11 +542,11 @@ class CoursesController extends Controller
 
         $internalStudents = \App\Models\Auth\User::whereHas('roles', function ($q) {
             $q->where('role_id', 3)->where('employee_type', 'internal');
-        })->get()->pluck('name', 'id');
+        })->get()->pluck('name', 'id')->toArray();
 
         $externalStudents = \App\Models\Auth\User::whereHas('roles', function ($q) {
             $q->where('role_id', 3)->where('employee_type', 'external');
-        })->get()->pluck('name', 'id');
+        })->get()->pluck('name', 'id')->toArray();
 
         $categories = Category::where('status', '=', 1)->pluck('name', 'id');
         $departments = Department::all();
@@ -590,65 +590,16 @@ class CoursesController extends Controller
              'price' => $request->course_payment_type === 'Paid' ? 'required|numeric|min:1' : 'nullable|numeric'
         ]);
 
-        if ($request->course_type === 'Offline' && in_array($request->meeting_provider, ['zoom', 'teams', 'google-meet-integration', 'google_meet'])) {
+        if ($request->course_type === 'Offline' && $request->schedule_type && in_array($request->schedule_type, ['daily', 'weekly', 'custom'])) {
 
             $teacherId = \Auth::user()->isAdmin()
                 ? $request->input('teacher_id')
                 : \Auth::user()->id;
             $teachers = [$teacherId]; // force single teacher
 
-            $meetingStart = \Carbon\Carbon::parse($request->meeting_start_at);
-            // Cast meeting_duration to int to avoid TypeError in Carbon::addUnit
-            $meetingDuration = (int)$request->meeting_duration;
-            $meetingEnd = $meetingStart->copy()->addMinutes($meetingDuration);
-
-            $overlappingMeetings = \DB::table('courses')
-                ->join('course_user', 'courses.id', '=', 'course_user.course_id')
-                ->whereIn('course_user.user_id', $teachers)
-                ->whereNotNull('courses.meeting_start_at')
-                ->whereNotNull('courses.meeting_duration')
-                ->where(function ($query) use ($meetingStart, $meetingEnd) {
-                    $query->whereRaw('? < DATE_ADD(courses.meeting_start_at, INTERVAL courses.meeting_duration MINUTE)', [$meetingStart])
-                          ->whereRaw('? > courses.meeting_start_at', [$meetingEnd]);
-                })
-                ->exists();
-
-            if ($overlappingMeetings) {
-                throw \Illuminate\Validation\ValidationException::withMessages([
-                    'meeting_start_at' => ['Overlapping date, time, and duration for the same teacher is not allowed.']
-                ]);
-            }
-            // Validate based on schedule type
-            if ($request->schedule_type && in_array($request->schedule_type, ['daily', 'weekly', 'custom'])) {
-                // Schedule-based validation
-                if ($request->schedule_type === 'daily') {
-                    $request->validate([
-                        'daily_time' => 'required',
-                        'daily_duration' => 'required|integer|min:1',
-                        'daily_repeat' => 'required|in:every_day,weekdays',
-                    ]);
-                } elseif ($request->schedule_type === 'weekly') {
-                    $request->validate([
-                        'weekly_days' => 'required|array|min:1',
-                        'weekly_days.*' => 'integer|between:0,6',
-                        'weekly_time' => 'required',
-                        'weekly_duration' => 'required|integer|min:1',
-                    ], [
-                        'weekly_days.required' => 'Please select at least one day for weekly sessions.',
-                    ]);
-                } elseif ($request->schedule_type === 'custom') {
-                    $request->validate([
-                        'custom_dates' => 'required|array|min:1',
-                        'custom_dates.*' => 'required|date',
-                        'custom_times' => 'required|array|min:1',
-                        'custom_times.*' => 'required',
-                        'custom_durations' => 'required|array|min:1',
-                        'custom_durations.*' => 'required|integer|min:1',
-                    ], [
-                        'custom_dates.required' => 'Please add at least one session.',
-                    ]);
-                }
-            } else {
+            $this->validateScheduleRequest($request);
+            $this->validateTrainerScheduleAvailability($request, $teachers);
+        } elseif ($request->course_type === 'Offline' && in_array($request->meeting_provider, ['zoom', 'teams', 'google-meet-integration', 'google_meet'])) {
                 // Original single-meeting validation
                 $request->validate([
                     'meeting_start_at' => 'required|date|after:now',
@@ -657,28 +608,18 @@ class CoursesController extends Controller
                     'meeting_start_at.after' => 'Meeting start date must be from the current date and time must be from the current time. Past time is not allowed.',
                 ]);
 
-                $teachers = \Auth::user()->isAdmin() ? array_filter((array)$request->input('teachers')) : [\Auth::user()->id];
+                $teachers = array_filter(\Auth::user()->isAdmin() ? [$request->input('teacher_id')] : [\Auth::user()->id]);
                 $meetingStart = \Carbon\Carbon::parse($request->meeting_start_at);
                 $meetingDuration = (int)$request->meeting_duration;
                 $meetingEnd = $meetingStart->copy()->addMinutes($meetingDuration);
 
-                $overlappingMeetings = \DB::table('courses')
-                    ->join('course_user', 'courses.id', '=', 'course_user.course_id')
-                    ->whereIn('course_user.user_id', $teachers)
-                    ->whereNotNull('courses.meeting_start_at')
-                    ->whereNotNull('courses.meeting_duration')
-                    ->where(function ($query) use ($meetingStart, $meetingEnd) {
-                        $query->whereRaw('? < DATE_ADD(courses.meeting_start_at, INTERVAL courses.meeting_duration MINUTE)', [$meetingStart])
-                              ->whereRaw('? > courses.meeting_start_at', [$meetingEnd]);
-                    })
-                    ->exists();
+                $overlap = $this->findTrainerOverlappingSession($teachers, $meetingStart, $meetingEnd);
 
-                if ($overlappingMeetings) {
+                if ($overlap) {
                     throw \Illuminate\Validation\ValidationException::withMessages([
-                        'meeting_start_at' => ['Overlapping date, time, and duration for the same teacher is not allowed.']
+                        'meeting_start_at' => [$this->formatTrainerOverlapMessage($overlap, $meetingStart, $meetingEnd)]
                     ]);
                 }
-            }
         }
         DB::beginTransaction();
 
@@ -1035,11 +976,11 @@ $teachers = [$teacherId];
 
         $internalStudents = \App\Models\Auth\User::whereHas('roles', function ($q) {
             $q->where('role_id', 3)->where('employee_type', 'internal');
-        })->get()->pluck('name', 'id');
+        })->get()->pluck('name', 'id')->toArray();
 
         $externalStudents = \App\Models\Auth\User::whereHas('roles', function ($q) {
             $q->where('role_id', 3)->where('employee_type', 'external');
-        })->get()->pluck('name', 'id');
+        })->get()->pluck('name', 'id')->toArray();
 
         $already_assigned_internal_users = SubscribeCourse::where('course_id', $id)->get()->pluck('user_id');
 
@@ -1075,8 +1016,16 @@ $teachers = [$teacherId];
         }
         $course = Course::findOrFail($id);
 
-        // Initialize teachers with empty array - will be updated based on course type
-        $teachers = [];
+        $teacherId = \Auth::user()->isAdmin()
+            ? $request->input('teacher_id', optional($course->teachers->first())->id)
+            : \Auth::user()->id;
+        $teachers = array_filter([$teacherId]);
+
+        if ($request->course_type === 'Offline' && ! $request->filled('meeting_provider') && $course->meeting_provider) {
+            $request->merge([
+                'meeting_provider' => $course->meeting_provider,
+            ]);
+        }
 
         if ($request->course_type !== 'Online') {
             $request->validate([
@@ -1104,50 +1053,11 @@ $teachers = [$teacherId];
             return back()->withFlashDanger(__('alerts.backend.general.slug_exist'));
         }
 
-        if ($request->course_type === 'Offline' && in_array($request->meeting_provider, ['zoom', 'teams', 'google-meet-integration', 'google_meet'])) {
+        if ($request->course_type === 'Offline' && $request->schedule_type && in_array($request->schedule_type, ['daily', 'weekly', 'custom'])) {
 
-            // For update, the request might contain teachers -> fallback to auth user if admin
-            $teacherId = \Auth::user()->isAdmin()
-    ? $request->input('teacher_id')
-    : \Auth::user()->id;
-
-$teachers = [$teacherId];
-
-            // If empty (teachers not passed in request), try to grab existing teachers
-            if(empty($teacherId)){
-                $teacherId = optional($course->teachers->first())->id;
-            }
-            $teachers = [$teacherId];
-            if ($request->schedule_type && in_array($request->schedule_type, ['daily', 'weekly', 'custom'])) {
-                // Schedule-based validation
-                if ($request->schedule_type === 'daily') {
-                    $request->validate([
-                        'daily_time' => 'required',
-                        'daily_duration' => 'required|integer|min:1',
-                        'daily_repeat' => 'required|in:every_day,weekdays',
-                    ]);
-                } elseif ($request->schedule_type === 'weekly') {
-                    $request->validate([
-                        'weekly_days' => 'required|array|min:1',
-                        'weekly_days.*' => 'integer|between:0,6',
-                        'weekly_time' => 'required',
-                        'weekly_duration' => 'required|integer|min:1',
-                    ], [
-                        'weekly_days.required' => 'Please select at least one day for weekly sessions.',
-                    ]);
-                } elseif ($request->schedule_type === 'custom') {
-                    $request->validate([
-                        'custom_dates' => 'required|array|min:1',
-                        'custom_dates.*' => 'required|date',
-                        'custom_times' => 'required|array|min:1',
-                        'custom_times.*' => 'required',
-                        'custom_durations' => 'required|array|min:1',
-                        'custom_durations.*' => 'required|integer|min:1',
-                    ], [
-                        'custom_dates.required' => 'Please add at least one session.',
-                    ]);
-                }
-            } else {
+            $this->validateScheduleRequest($request);
+            $this->validateTrainerScheduleAvailability($request, $teachers, $course->id);
+        } elseif ($request->course_type === 'Offline' && in_array($request->meeting_provider, ['zoom', 'teams', 'google-meet-integration', 'google_meet'])) {
                 // Original single-meeting validation
                 $request->validate([
                     'meeting_start_at' => 'required|date|after:now',
@@ -1156,7 +1066,7 @@ $teachers = [$teacherId];
                     'meeting_start_at.after' => 'Meeting start date must be from the current date and time must be from the current time. Past time is not allowed.',
                 ]);
 
-                $teachers = \Auth::user()->isAdmin() ? array_filter((array)$request->input('teachers')) : [\Auth::user()->id];
+                $teachers = array_filter(\Auth::user()->isAdmin() ? [$teacherId] : [\Auth::user()->id]);
                 if(empty($teachers)){
                    $teachers = $course->teachers->pluck('id')->toArray();
                 }
@@ -1165,22 +1075,11 @@ $teachers = [$teacherId];
                 $meetingDuration = (int)$request->meeting_duration;
                 $meetingEnd = $meetingStart->copy()->addMinutes($meetingDuration);
 
-                $overlappingMeetings = \DB::table('courses')
-                    ->join('course_user', 'courses.id', '=', 'course_user.course_id')
-                    ->whereIn('course_user.user_id', $teachers)
-                    ->where('courses.id', '!=', $course->id)
-                    ->whereNotNull('courses.meeting_start_at')
-                    ->whereNotNull('courses.meeting_duration')
-                    ->where(function ($query) use ($meetingStart, $meetingEnd) {
-                        $query->whereRaw('? < DATE_ADD(courses.meeting_start_at, INTERVAL courses.meeting_duration MINUTE)', [$meetingStart])
-                              ->whereRaw('? > courses.meeting_start_at', [$meetingEnd]);
-                    })
-                    ->exists();
+                $overlap = $this->findTrainerOverlappingSession($teachers, $meetingStart, $meetingEnd, $course->id);
 
-                if ($overlappingMeetings) {
-                    return back()->withFlashDanger('Overlapping date, time, and duration for the same teacher is not allowed.')->withInput();
+                if ($overlap) {
+                    return back()->withFlashDanger($this->formatTrainerOverlapMessage($overlap, $meetingStart, $meetingEnd))->withInput();
                 }
-            }
         }
 
 
@@ -1274,6 +1173,26 @@ $teachers = [$teacherId];
         $course->update($request->all());
 
         $course->teachers()->sync($teachers);
+
+        if (\Auth::user()->isAdmin() && ($request->has('internalStudents') || $request->has('externalStudents'))) {
+            $internalStudents = (array)$request->input('internalStudents', []);
+            $externalStudents = (array)$request->input('externalStudents', []);
+            $students = array_values(array_unique(array_filter(array_merge($internalStudents, $externalStudents))));
+
+            $course->students()->sync($students);
+
+            foreach ($students as $studentId) {
+                SubscribeCourse::updateOrCreate(
+                    [
+                        'user_id' => $studentId,
+                        'course_id' => $course->id,
+                    ],
+                    [
+                        'status' => 1,
+                    ]
+                );
+            }
+        }
         
         $course->is_online = $request->course_type ?? 'Online';
 
@@ -1292,6 +1211,13 @@ $teachers = [$teacherId];
             if ($failedCount > 0) {
                 \Session::flash('flash_danger', "Course updated, but {$failedCount} session(s) failed to create meeting links. Please check your {$request->meeting_provider} credentials in External Apps settings. You can regenerate missing links using the button below.");
             }
+        } elseif ($request->course_type !== 'Offline') {
+            $course->liveSessions()->delete();
+            $course->forceFill([
+                'schedule_type' => null,
+                'schedule_days' => null,
+                'last_session_date' => null,
+            ])->save();
         }
 
         if (($request->slug == "") || $request->slug == null) {
@@ -1817,17 +1743,15 @@ $teachers = [$teacherId];
         return Excel::download(new CourseAssignmentReportExport, 'course-assignment-report.csv');
     }
 
-    private function generateLiveSessions(Course $course, Request $request): int
+    private function buildRequestedLiveSessions(Course $course, Request $request): array
     {
-        // Delete any existing sessions for this course
-        $course->liveSessions()->delete();
-
-        $provider = $request->meeting_provider;
-        $timezone = $request->meeting_timezone ?? 'Asia/Riyadh';
         $scheduleType = $request->schedule_type;
 
-        $startDate = \Carbon\Carbon::parse($course->getRawOriginal('start_date'));
-        $endDate = \Carbon\Carbon::parse($course->getRawOriginal('expire_at'));
+        $startDateValue = $course->getRawOriginal('start_date') ?: ($course->getAttributes()['start_date'] ?? $request->start_date);
+        $endDateValue = $course->getRawOriginal('expire_at') ?: ($course->getAttributes()['expire_at'] ?? $request->expire_at);
+
+        $startDate = \Carbon\Carbon::parse($startDateValue);
+        $endDate = \Carbon\Carbon::parse($endDateValue);
 
         $sessions = [];
 
@@ -1881,6 +1805,161 @@ $teachers = [$teacherId];
                 ];
             }
         }
+
+        return $sessions;
+    }
+
+    private function validateScheduleRequest(Request $request): void
+    {
+        if ($request->schedule_type === 'daily') {
+            $request->validate([
+                'daily_time' => 'required',
+                'daily_duration' => 'required|integer|min:1',
+                'daily_repeat' => 'required|in:every_day,weekdays',
+            ]);
+        } elseif ($request->schedule_type === 'weekly') {
+            $request->validate([
+                'weekly_days' => 'required|array|min:1',
+                'weekly_days.*' => 'integer|between:0,6',
+                'weekly_time' => 'required',
+                'weekly_duration' => 'required|integer|min:1',
+            ], [
+                'weekly_days.required' => 'Please select at least one day for weekly sessions.',
+            ]);
+        } elseif ($request->schedule_type === 'custom') {
+            $request->validate([
+                'custom_dates' => 'required|array|min:1',
+                'custom_dates.*' => 'required|date',
+                'custom_times' => 'required|array|min:1',
+                'custom_times.*' => 'required',
+                'custom_durations' => 'required|array|min:1',
+                'custom_durations.*' => 'required|integer|min:1',
+            ], [
+                'custom_dates.required' => 'Please add at least one session.',
+            ]);
+        }
+    }
+
+    private function validateTrainerScheduleAvailability(Request $request, array $teacherIds, ?int $ignoreCourseId = null): void
+    {
+        $course = new Course();
+        $course->start_date = $request->start_date;
+        $course->expire_at = $request->expire_at;
+
+        foreach ($this->buildRequestedLiveSessions($course, $request) as $session) {
+            $sessionStart = \Carbon\Carbon::parse($session['date'] . ' ' . $session['time']);
+            $sessionEnd = $sessionStart->copy()->addMinutes((int)$session['duration']);
+
+            $overlap = $this->findTrainerOverlappingSession($teacherIds, $sessionStart, $sessionEnd, $ignoreCourseId);
+
+            if ($overlap) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'schedule_type' => [$this->formatTrainerOverlapMessage($overlap, $sessionStart, $sessionEnd)],
+                ]);
+            }
+        }
+    }
+
+    private function trainerHasOverlappingSession(array $teacherIds, \Carbon\Carbon $start, \Carbon\Carbon $end, ?int $ignoreCourseId = null): bool
+    {
+        return $this->findTrainerOverlappingSession($teacherIds, $start, $end, $ignoreCourseId) !== null;
+    }
+
+    private function findTrainerOverlappingSession(array $teacherIds, \Carbon\Carbon $start, \Carbon\Carbon $end, ?int $ignoreCourseId = null): ?array
+    {
+        $teacherIds = array_filter($teacherIds);
+
+        if (empty($teacherIds)) {
+            return null;
+        }
+
+        $singleMeetings = \DB::table('courses')
+            ->join('course_user', 'courses.id', '=', 'course_user.course_id')
+            ->whereIn('course_user.user_id', $teacherIds)
+            ->whereNotNull('courses.meeting_start_at')
+            ->whereNotNull('courses.meeting_duration');
+
+        if ($ignoreCourseId) {
+            $singleMeetings->where('courses.id', '!=', $ignoreCourseId);
+        }
+
+        foreach ($singleMeetings->select('courses.id as course_id', 'courses.title as course_title', 'courses.meeting_start_at', 'courses.meeting_duration')->get() as $meeting) {
+            $meetingStart = \Carbon\Carbon::parse($meeting->meeting_start_at);
+            $meetingEnd = $meetingStart->copy()->addMinutes((int)$meeting->meeting_duration);
+
+            if ($this->timeRangesOverlap($start, $end, $meetingStart, $meetingEnd)) {
+                return [
+                    'course_id' => $meeting->course_id,
+                    'course_title' => $meeting->course_title,
+                    'session_start' => $meetingStart,
+                    'session_end' => $meetingEnd,
+                    'duration' => (int)$meeting->meeting_duration,
+                    'source' => 'course_meeting',
+                ];
+            }
+        }
+
+        $liveSessions = \DB::table('live_sessions')
+            ->join('course_user', 'live_sessions.course_id', '=', 'course_user.course_id')
+            ->join('courses', 'courses.id', '=', 'live_sessions.course_id')
+            ->whereIn('course_user.user_id', $teacherIds);
+
+        if ($ignoreCourseId) {
+            $liveSessions->where('live_sessions.course_id', '!=', $ignoreCourseId);
+        }
+
+        foreach ($liveSessions->select('live_sessions.course_id', 'courses.title as course_title', 'live_sessions.id as live_session_id', 'live_sessions.session_date', 'live_sessions.session_time', 'live_sessions.duration')->get() as $session) {
+            $sessionDate = \Carbon\Carbon::parse($session->session_date)->format('Y-m-d');
+            $sessionStart = \Carbon\Carbon::parse($sessionDate . ' ' . $session->session_time);
+            $sessionEnd = $sessionStart->copy()->addMinutes((int)$session->duration);
+
+            if ($this->timeRangesOverlap($start, $end, $sessionStart, $sessionEnd)) {
+                return [
+                    'course_id' => $session->course_id,
+                    'course_title' => $session->course_title,
+                    'live_session_id' => $session->live_session_id,
+                    'session_start' => $sessionStart,
+                    'session_end' => $sessionEnd,
+                    'duration' => (int)$session->duration,
+                    'source' => 'live_session',
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    private function timeRangesOverlap(\Carbon\Carbon $startA, \Carbon\Carbon $endA, \Carbon\Carbon $startB, \Carbon\Carbon $endB): bool
+    {
+        return $startA->lt($endB) && $endA->gt($startB);
+    }
+
+    private function formatTrainerOverlapMessage(array $overlap, \Carbon\Carbon $requestedStart, \Carbon\Carbon $requestedEnd): string
+    {
+        $courseTitle = $overlap['course_title'] ?? 'another course';
+        $existingStart = $overlap['session_start'];
+        $existingEnd = $overlap['session_end'];
+
+        return sprintf(
+            'Trainer is already assigned for another course at this time. Conflict with "%s" on %s from %s to %s. Requested session: %s to %s.',
+            $courseTitle,
+            $existingStart->format('Y-m-d'),
+            $existingStart->format('H:i'),
+            $existingEnd->format('H:i'),
+            $requestedStart->format('Y-m-d H:i'),
+            $requestedEnd->format('H:i')
+        );
+    }
+
+    private function generateLiveSessions(Course $course, Request $request): int
+    {
+        // Delete any existing sessions for this course
+        $course->liveSessions()->delete();
+
+        $provider = $request->meeting_provider;
+        $timezone = $request->meeting_timezone ?? 'Asia/Riyadh';
+        $scheduleType = $request->schedule_type;
+        $sessions = $this->buildRequestedLiveSessions($course, $request);
 
         $lastSessionDate = null;
         $failedCount = 0;

--- a/resources/views/backend/courses/edit.blade.php
+++ b/resources/views/backend/courses/edit.blade.php
@@ -209,7 +209,7 @@
                                             class="form-control custom-select-box select2 js-example-placeholder-single"
                                             required>
                                             @foreach($teachers as $id => $name)
-                                                <option value="{{ $id }}" @if(old('teacher_id') == $id) selected @endif>
+                                                <option value="{{ $id }}" @if(old('teacher_id', optional($course->teachers->first())->id) == $id) selected @endif>
                                                     {{ $name }}
                                                 </option>
                                             @endforeach
@@ -320,30 +320,30 @@
 
 
                 @if (Auth::user()->isAdmin())
-                    {{-- <div class="row">
+                    <div class="row">
                         <div class="col-10 form-group">
                             {!! Form::label('internal_students', trans('labels.backend.courses.fields.internal_students'), [
                             'class' => 'control-label',
                             ]) !!}
-                            {!! Form::select('internalStudents[]', $internalStudents, old('internalStudents'), [
+                            {!! Form::select('internalStudents[]', $internalStudents, old('internalStudents', $already_assigned_internal_users->toArray()), [
                             'class' => 'form-control select2 js-example-internal-student-placeholder-multiple',
                             'multiple' => 'multiple',
                             'required' => false,
                             ]) !!}
                         </div>
-                    </div> --}}
+                    </div>
                 @endif
 
                 @if (Auth::user()->isAdmin())
-                    {{-- <div class="row">
+                    <div class="row">
                         <div class="col-10 form-group">
                             {!! Form::label('external_students',trans('labels.backend.courses.fields.external_students'),
                             ['class' => 'control-label']) !!}
-                            {!! Form::select('externalStudents[]', $externalStudents, old('externalStudents'), ['class' =>
+                            {!! Form::select('externalStudents[]', $externalStudents, old('externalStudents', $already_assigned_internal_users->toArray()), ['class' =>
                             'form-control select2 js-example-external-student-placeholder-multiple', 'multiple' =>
                             'multiple', 'required' => false]) !!}
                         </div>
-                    </div> --}}
+                    </div>
                 @endif
 
                 <div class="row">
@@ -454,6 +454,9 @@
                                             <div class="col-md-6 form-group">
                                                 <label for="meeting_provider">Meeting Provider *</label>
                                                 <select name="meeting_provider" id="meeting_provider" class="form-control">
+                                                    @if($course->meeting_provider && !array_key_exists($course->meeting_provider, $enabledMeetingProviders ?? []))
+                                                        <option value="{{ $course->meeting_provider }}" selected>{{ ucfirst(str_replace(['-', '_'], ' ', $course->meeting_provider)) }}</option>
+                                                    @endif
                                                     @foreach($enabledMeetingProviders as $key => $label)
                                                         <option value="{{ $key }}" {{ $course->meeting_provider == $key ? 'selected' : '' }}>{{ $label }}</option>
                                                     @endforeach
@@ -495,8 +498,16 @@
                                     </div>
                                 </div>
                             @endif
+                            @if(!count($enabledMeetingProviders ?? []) && $course->meeting_provider)
+                                <input type="hidden" name="meeting_provider" value="{{ $course->meeting_provider }}">
+                            @endif
 
                             {{-- Live Session Scheduling Section --}}
+                            @php
+                                $firstLiveSession = $course->liveSessions->first();
+                                $savedSessionTime = old('weekly_time', old('daily_time', optional($firstLiveSession)->session_time ? \Carbon\Carbon::parse($firstLiveSession->session_time)->format('H:i') : null));
+                                $savedSessionDuration = old('weekly_duration', old('daily_duration', optional($firstLiveSession)->duration ?? 60));
+                            @endphp
                             <div class="card mt-3" id="schedule-section">
                                 <div class="card-header bg-success text-white">
                                     <h5 class="mb-0"><i class="fa fa-calendar mr-2"></i> Live Session Scheduling</h5>
@@ -520,12 +531,12 @@
                                             <div class="col-md-4 form-group">
                                                 <label>Session Time *</label>
                                                 <input type="time" name="daily_time" id="daily_time"
-                                                    class="form-control">
+                                                    class="form-control" value="{{ old('daily_time', ($course->schedule_type ?? '') == 'daily' ? $savedSessionTime : null) }}">
                                             </div>
                                             <div class="col-md-4 form-group">
                                                 <label>Duration (mins) *</label>
                                                 <input type="number" name="daily_duration" id="daily_duration"
-                                                    class="form-control" value="60" min="1">
+                                                    class="form-control" value="{{ old('daily_duration', ($course->schedule_type ?? '') == 'daily' ? $savedSessionDuration : 60) }}" min="1">
                                             </div>
                                             <div class="col-md-4 form-group">
                                                 <label>Repeat *</label>
@@ -567,12 +578,12 @@
                                             <div class="col-md-4 form-group">
                                                 <label>Session Time *</label>
                                                 <input type="time" name="weekly_time" id="weekly_time"
-                                                    class="form-control">
+                                                    class="form-control" value="{{ old('weekly_time', ($course->schedule_type ?? '') == 'weekly' ? $savedSessionTime : null) }}">
                                             </div>
                                             <div class="col-md-4 form-group">
                                                 <label>Duration (mins) *</label>
                                                 <input type="number" name="weekly_duration" id="weekly_duration"
-                                                    class="form-control" value="60" min="1">
+                                                    class="form-control" value="{{ old('weekly_duration', ($course->schedule_type ?? '') == 'weekly' ? $savedSessionDuration : 60) }}" min="1">
                                             </div>
                                         </div>
                                         <small class="text-muted">Sessions will repeat on selected days between course
@@ -582,6 +593,33 @@
                                     {{-- Custom Options --}}
                                     <div id="schedule-custom" class="schedule-panel" style="display:none;">
                                         <div id="custom-sessions-container">
+                                            @if(($course->schedule_type ?? '') == 'custom' && $course->liveSessions->count())
+                                                @foreach($course->liveSessions as $index => $session)
+                                                    <div class="row custom-session-row mb-2">
+                                                        <div class="col-md-4 form-group">
+                                                            <label>Date *</label>
+                                                            <input type="date" name="custom_dates[]"
+                                                                class="form-control custom-session-date"
+                                                                value="{{ old('custom_dates.' . $index, $session->session_date->format('Y-m-d')) }}">
+                                                        </div>
+                                                        <div class="col-md-3 form-group">
+                                                            <label>Time *</label>
+                                                            <input type="time" name="custom_times[]" class="form-control"
+                                                                value="{{ old('custom_times.' . $index, \Carbon\Carbon::parse($session->session_time)->format('H:i')) }}">
+                                                        </div>
+                                                        <div class="col-md-3 form-group">
+                                                            <label>Duration (mins) *</label>
+                                                            <input type="number" name="custom_durations[]" class="form-control"
+                                                                value="{{ old('custom_durations.' . $index, $session->duration) }}" min="1">
+                                                        </div>
+                                                        <div class="col-md-2 form-group d-flex align-items-end">
+                                                            <button type="button"
+                                                                class="btn btn-danger btn-sm remove-session-btn"
+                                                                style="{{ $course->liveSessions->count() > 1 ? '' : 'display:none;' }}">&times; Remove</button>
+                                                        </div>
+                                                    </div>
+                                                @endforeach
+                                            @else
                                             <div class="row custom-session-row mb-2">
                                                 <div class="col-md-4 form-group">
                                                     <label>Date *</label>
@@ -603,6 +641,7 @@
                                                         style="display:none;">&times; Remove</button>
                                                 </div>
                                             </div>
+                                            @endif
                                         </div>
                                         <button type="button" class="btn btn-outline-primary btn-sm mt-2"
                                             id="add-session-btn">
@@ -1124,7 +1163,7 @@
             nxt_url_val = $(this).val();
             $('#submit-btn').val(nxt_url_val)
         });
-        $('#editCourse').on('submit', function (e) {
+        $('#updateCourse').on('submit', function (e) {
             var $form = $(this);
 
             function enableButtons() {

--- a/tests/Feature/Backend/CourseTrainerScheduleOverlapTest.php
+++ b/tests/Feature/Backend/CourseTrainerScheduleOverlapTest.php
@@ -1,0 +1,436 @@
+<?php
+
+namespace Tests\Feature\Backend;
+
+use App\Http\Controllers\Backend\Admin\CoursesController;
+use App\Models\Auth\User;
+use App\Models\Course;
+use App\Models\LiveSession;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class CourseTrainerScheduleOverlapTest extends TestCase
+{
+    private CoursesController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = app(CoursesController::class);
+    }
+
+    /** @test */
+    public function it_blocks_exact_live_session_overlap_for_the_same_trainer(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasOverlap($trainer, '2026-05-29 12:00:00', '2026-05-29 13:30:00');
+    }
+
+    /** @test */
+    public function it_blocks_partial_live_session_overlap_starting_inside_existing_session(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasOverlap($trainer, '2026-05-29 12:45:00', '2026-05-29 13:15:00');
+    }
+
+    /** @test */
+    public function it_blocks_partial_live_session_overlap_ending_inside_existing_session(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasOverlap($trainer, '2026-05-29 11:30:00', '2026-05-29 12:30:00');
+    }
+
+    /** @test */
+    public function it_blocks_new_session_that_fully_contains_existing_session(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasOverlap($trainer, '2026-05-29 11:00:00', '2026-05-29 14:00:00');
+    }
+
+    /** @test */
+    public function it_allows_adjacent_session_starting_when_existing_session_ends(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasNoOverlap($trainer, '2026-05-29 13:30:00', '2026-05-29 14:30:00');
+    }
+
+    /** @test */
+    public function it_allows_adjacent_session_ending_when_existing_session_starts(): void
+    {
+        [$trainer] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasNoOverlap($trainer, '2026-05-29 11:00:00', '2026-05-29 12:00:00');
+    }
+
+    /** @test */
+    public function it_allows_same_time_for_a_different_trainer(): void
+    {
+        $firstTrainer = factory(User::class)->create();
+        $secondTrainer = factory(User::class)->create();
+        $this->courseWithTrainerAndLiveSession($firstTrainer, '2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasNoOverlap($secondTrainer, '2026-05-29 12:00:00', '2026-05-29 13:30:00');
+    }
+
+    /** @test */
+    public function it_ignores_sessions_from_the_course_being_updated(): void
+    {
+        [$trainer, $course] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $this->assertTrainerHasNoOverlap($trainer, '2026-05-29 12:00:00', '2026-05-29 13:30:00', $course->id);
+    }
+
+    /** @test */
+    public function it_blocks_overlap_against_legacy_single_meeting_courses(): void
+    {
+        $trainer = factory(User::class)->create();
+        $course = $this->course([
+            'meeting_start_at' => '2026-05-29 12:00:00',
+            'meeting_duration' => 90,
+        ]);
+        DB::table('course_user')->insert(['course_id' => $course->id, 'user_id' => $trainer->id]);
+
+        $this->assertTrainerHasOverlap($trainer, '2026-05-29 12:30:00', '2026-05-29 13:00:00');
+    }
+
+    /** @test */
+    public function it_blocks_weekly_schedule_generation_when_any_generated_session_overlaps(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'weekly',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-06-12',
+            'weekly_days' => [5],
+            'weekly_time' => '12:30',
+            'weekly_duration' => 60,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+    }
+
+    /** @test */
+    public function overlap_validation_message_includes_conflicting_course_and_session_details(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90, [
+            'title' => 'Health and Safety Fundamentals',
+        ]);
+
+        $request = new Request([
+            'schedule_type' => 'weekly',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-06-12',
+            'weekly_days' => [5],
+            'weekly_time' => '12:30',
+            'weekly_duration' => 60,
+        ]);
+
+        try {
+            $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+            $this->fail('Expected overlap validation to fail.');
+        } catch (ValidationException $exception) {
+            $message = $exception->errors()['schedule_type'][0];
+
+            $this->assertStringContainsString('Trainer is already assigned for another course at this time.', $message);
+            $this->assertStringContainsString('Health and Safety Fundamentals', $message);
+            $this->assertStringContainsString('2026-05-29', $message);
+            $this->assertStringContainsString('12:00', $message);
+            $this->assertStringContainsString('13:30', $message);
+            $this->assertStringContainsString('Requested session: 2026-05-29 12:30 to 13:30', $message);
+        }
+    }
+
+    /** @test */
+    public function it_allows_weekly_schedule_generation_when_generated_sessions_do_not_overlap(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-29', '12:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'weekly',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-06-12',
+            'weekly_days' => [5],
+            'weekly_time' => '14:00',
+            'weekly_duration' => 60,
+        ]);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function it_blocks_daily_schedule_when_any_generated_session_overlaps_same_trainer(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-30', '09:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'daily',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'daily_time' => '09:30',
+            'daily_duration' => 60,
+            'daily_repeat' => 'every_day',
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+    }
+
+    /** @test */
+    public function it_allows_daily_schedule_when_generated_sessions_do_not_overlap_same_trainer(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-30', '09:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'daily',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'daily_time' => '11:00',
+            'daily_duration' => 60,
+            'daily_repeat' => 'every_day',
+        ]);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function daily_weekdays_only_does_not_generate_weekend_sessions_that_would_overlap(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-30', '09:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'daily',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'daily_time' => '09:30',
+            'daily_duration' => 60,
+            'daily_repeat' => 'weekdays',
+        ]);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function it_blocks_custom_schedule_when_one_custom_session_overlaps_same_trainer(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-30', '09:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'custom',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'custom_dates' => ['2026-05-29', '2026-05-30'],
+            'custom_times' => ['15:00', '09:30'],
+            'custom_durations' => [60, 60],
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+    }
+
+    /** @test */
+    public function it_allows_custom_schedule_when_all_custom_sessions_are_clear_same_trainer(): void
+    {
+        [$trainer, $existingCourse] = $this->trainerWithLiveSession('2026-05-30', '09:00:00', 90);
+
+        $request = new Request([
+            'schedule_type' => 'custom',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'custom_dates' => ['2026-05-29', '2026-05-30'],
+            'custom_times' => ['15:00', '11:00'],
+            'custom_durations' => [60, 60],
+        ]);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $existingCourse->id + 1]);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function it_blocks_daily_schedule_against_legacy_single_meeting_for_same_trainer(): void
+    {
+        $trainer = factory(User::class)->create();
+        $course = $this->course([
+            'meeting_start_at' => '2026-05-30 09:00:00',
+            'meeting_duration' => 90,
+        ]);
+        DB::table('course_user')->insert(['course_id' => $course->id, 'user_id' => $trainer->id]);
+
+        $request = new Request([
+            'schedule_type' => 'daily',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'daily_time' => '09:30',
+            'daily_duration' => 60,
+            'daily_repeat' => 'every_day',
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->invokePrivate('validateTrainerScheduleAvailability', [$request, [$trainer->id], $course->id + 1]);
+    }
+
+    /** @test */
+    public function daily_schedule_generation_creates_expected_every_day_sessions(): void
+    {
+        $request = new Request([
+            'schedule_type' => 'daily',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'daily_time' => '10:00',
+            'daily_duration' => 45,
+            'daily_repeat' => 'every_day',
+        ]);
+
+        $course = new Course();
+        $course->start_date = $request->start_date;
+        $course->expire_at = $request->expire_at;
+
+        $sessions = $this->invokePrivate('buildRequestedLiveSessions', [$course, $request]);
+
+        $this->assertSame([
+            ['date' => '2026-05-29', 'time' => '10:00', 'duration' => 45],
+            ['date' => '2026-05-30', 'time' => '10:00', 'duration' => 45],
+            ['date' => '2026-05-31', 'time' => '10:00', 'duration' => 45],
+        ], $sessions);
+    }
+
+    /** @test */
+    public function custom_schedule_generation_ignores_sessions_outside_course_date_range(): void
+    {
+        $request = new Request([
+            'schedule_type' => 'custom',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-05-31',
+            'custom_dates' => ['2026-05-28', '2026-05-30', '2026-06-01'],
+            'custom_times' => ['10:00', '11:00', '12:00'],
+            'custom_durations' => [30, 45, 60],
+        ]);
+
+        $course = new Course();
+        $course->start_date = $request->start_date;
+        $course->expire_at = $request->expire_at;
+
+        $sessions = $this->invokePrivate('buildRequestedLiveSessions', [$course, $request]);
+
+        $this->assertSame([
+            ['date' => '2026-05-30', 'time' => '11:00', 'duration' => 45],
+        ], $sessions);
+    }
+
+    /** @test */
+    public function weekly_schedule_generation_uses_request_dates_when_validating_unsaved_course_data(): void
+    {
+        $request = new Request([
+            'schedule_type' => 'weekly',
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-06-12',
+            'weekly_days' => [5],
+            'weekly_time' => '14:00',
+            'weekly_duration' => 60,
+        ]);
+
+        $course = new Course();
+        $course->start_date = $request->start_date;
+        $course->expire_at = $request->expire_at;
+
+        $sessions = $this->invokePrivate('buildRequestedLiveSessions', [$course, $request]);
+
+        $this->assertSame([
+            ['date' => '2026-05-29', 'time' => '14:00', 'duration' => 60],
+            ['date' => '2026-06-05', 'time' => '14:00', 'duration' => 60],
+            ['date' => '2026-06-12', 'time' => '14:00', 'duration' => 60],
+        ], $sessions);
+    }
+
+    private function assertTrainerHasOverlap(User $trainer, string $start, string $end, ?int $ignoreCourseId = null): void
+    {
+        $this->assertTrue($this->trainerHasOverlap($trainer, $start, $end, $ignoreCourseId));
+    }
+
+    private function assertTrainerHasNoOverlap(User $trainer, string $start, string $end, ?int $ignoreCourseId = null): void
+    {
+        $this->assertFalse($this->trainerHasOverlap($trainer, $start, $end, $ignoreCourseId));
+    }
+
+    private function trainerHasOverlap(User $trainer, string $start, string $end, ?int $ignoreCourseId = null): bool
+    {
+        return $this->invokePrivate('trainerHasOverlappingSession', [
+            [$trainer->id],
+            Carbon::parse($start),
+            Carbon::parse($end),
+            $ignoreCourseId,
+        ]);
+    }
+
+    private function trainerWithLiveSession(string $date, string $time, int $duration, array $courseAttributes = []): array
+    {
+        $trainer = factory(User::class)->create();
+        $course = $this->courseWithTrainerAndLiveSession($trainer, $date, $time, $duration, $courseAttributes);
+
+        return [$trainer, $course];
+    }
+
+    private function courseWithTrainerAndLiveSession(User $trainer, string $date, string $time, int $duration, array $courseAttributes = []): Course
+    {
+        $course = $this->course($courseAttributes);
+        DB::table('course_user')->insert(['course_id' => $course->id, 'user_id' => $trainer->id]);
+
+        LiveSession::create([
+            'course_id' => $course->id,
+            'provider' => 'seed',
+            'session_date' => $date,
+            'session_time' => $time,
+            'duration' => $duration,
+            'recurrence_type' => 'weekly',
+            'created_by' => $trainer->id,
+        ]);
+
+        return $course;
+    }
+
+    private function course(array $attributes = []): Course
+    {
+        return factory(Course::class)->create(array_merge([
+            'title' => 'Overlap Test Course ' . uniqid(),
+            'slug' => 'overlap-test-course-' . uniqid(),
+            'category_id' => 1,
+            'course_image' => 'placeholder-1.jpg',
+            'description' => 'Overlap detection test course.',
+            'price' => 0,
+            'start_date' => '2026-05-29',
+            'expire_at' => '2026-06-12',
+            'published' => 1,
+            'is_online' => 'Offline',
+        ], $attributes));
+    }
+
+    private function invokePrivate(string $method, array $args = [])
+    {
+        $reflection = new ReflectionMethod($this->controller, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($this->controller, $args);
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the issue where a trainer can be assigned to overlapping Live-Online course sessions.

### Problem
The course create/update flow did not consistently validate trainer availability across generated live sessions. Overlaps could happen when weekly, daily, or custom schedules created sessions at the same time for the same trainer, especially when the meeting provider was missing, disabled, or not one of the explicitly checked providers.

### Changes Made
- Added cross-course trainer schedule validation for daily, weekly, and custom Live-Online sessions.
- Validates overlaps against both generated `live_sessions` and legacy single-course `meeting_start_at` meetings.
- Preserves the selected trainer during course updates instead of clearing trainer assignment when some course types skip meeting-provider logic.
- Falls back to an existing meeting provider when editing scheduled courses and the provider is not submitted by the form.
- Shows detailed validation errors with the conflicting course name, existing session time, and requested session time.
- Reworked overlap checks to use Carbon interval comparisons instead of MySQL-specific date functions.
- Added regression tests covering weekly, daily, custom, legacy meeting, same-course update, trainer isolation, and boundary conditions.

Fixes: #735
---

## ✅ Type of Change

- [x]  Bug fix

---

## 📸 Screenshots (if applicable)

Not applicable. Backend validation and automated test coverage update.

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Other: `vendor/bin/phpunit tests/Feature/Backend/CourseTrainerScheduleOverlapTest.php`
- [x] Other: `php -l app/Http/Controllers/Backend/Admin/CoursesController.php`
- [x] Other: `php -l tests/Feature/Backend/CourseTrainerScheduleOverlapTest.php`

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin.
2. Create or edit a Live-Online course assigned to a trainer.
3. Add a scheduled session, for example Friday at `12:00` for `90` minutes.
4. Create or edit another Live-Online course assigned to the same trainer.
5. Add a daily, weekly, custom, or single meeting session that overlaps the existing session.
6. Save the course.
7. Verify the save is blocked and the validation message identifies the conflicting course and session time.

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

- Existing overlapping records are not automatically migrated or deleted; the fix prevents new overlaps during create/update.
- Adjacent sessions are allowed when one session ends exactly when the next starts.
