### PR TITLE
fix: auto-populate trainer field when navigating from trainer list

### DIFF
--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -68,7 +68,7 @@
                     <select id="filter_teacher" class="form-control">
                         <option value="">{{ __('course_pages.admin_index.all_trainers') }}</option>
                         @foreach($teachers as $id => $name)
-                            <option value="{{ $id }}">{{ $name }}</option>
+                            <option value="{{ $id }}" {{ request('teacher_id') == $id ? 'selected' : '' }}>{{ $name }}</option>
                         @endforeach
                     </select>
                 </div>


### PR DESCRIPTION
When clicking the courses icon on a trainer record, the trainer filter dropdown on the courses page was blank even though the URL contained teacher_id. The option was never marked as selected.


# 📥 Pull Request Template

## 🔧 Description

When clicking the courses icon on a trainer record, the trainer filter dropdown on the courses page was blank even though the URL contained teacher_id. The <option> elements were rendered without checking the request parameter, so no option was ever marked as selected.

Fixes: #725

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1893" height="759" alt="image" src="https://github.com/user-attachments/assets/8ee7fcd8-b8ba-4fcc-a396-4a2a3493d744" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

Navigate to User Management → Trainers
Click the course icon from the action column on any trainer record
Observe the Trainer filter dropdown on the Courses page

Actual: Dropdown is empty, no filter applied.
Expected: Trainer is pre-selected and courses are filtered.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

One-line change in resources/views/backend/courses/index.blade.php — added a selected attribute to the matching <option> when teacher_id is present in the request.