### PR TITLE
fix: restrict trainer question visibility

### DIFF
--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -28,21 +28,17 @@ class TestQuestionController extends Controller
 
     public function index(Request $request)
     {
+        $test_questions = DB::table('test_questions')
+            ->select('test_questions.*', 'tests.title', 'courses.title as course_title')
+            ->leftjoin('tests', 'tests.id', '=', 'test_questions.test_id')
+            ->leftjoin('courses', 'courses.id', '=', 'tests.course_id')
+            ->where('test_questions.is_deleted', '=', 0);
+
         if ($request->test_id) {
-            $test_questions = DB::table('test_questions')
-                ->select('test_questions.*', 'tests.title', 'courses.title as course_title')
-                ->leftjoin('tests', 'tests.id', '=', 'test_questions.test_id')
-                ->leftjoin('courses', 'courses.id', '=', 'tests.course_id')
-                ->where('test_questions.is_deleted', '=', 0)
-                ->where('test_questions.test_id', '=', $request->test_id);
-        } else {
-            $test_questions = DB::table('test_questions')
-                ->select('test_questions.*', 'tests.title', 'courses.title as course_title')
-                ->leftjoin('tests', 'tests.id', '=', 'test_questions.test_id')
-                ->leftjoin('courses', 'courses.id', '=', 'tests.course_id')
-                ->where('test_questions.is_deleted', '=', 0);
+            $test_questions = $test_questions->where('test_questions.test_id', '=', $request->test_id);
         }
 
+        $this->scopeQuestionsToAssignedTrainerCourses($test_questions);
 
         if ($request->course_id != "") {
             $test_questions = $test_questions->where('tests.course_id', (int)$request->course_id);
@@ -503,6 +499,36 @@ class TestQuestionController extends Controller
         
         return $hasAtLeastOneSelected;
         
+    }
+
+    private function scopeQuestionsToAssignedTrainerCourses($query): void
+    {
+        if (!$this->currentUserIsTrainer()) {
+            return;
+        }
+
+        $query->whereExists(function ($subQuery) {
+            $subQuery->select(DB::raw(1))
+                ->from('course_user')
+                ->whereColumn('course_user.course_id', 'tests.course_id')
+                ->where('course_user.user_id', auth()->id());
+        });
+    }
+
+    private function currentUserIsTrainer(): bool
+    {
+        if (!auth()->check()) {
+            return false;
+        }
+
+        $user = auth()->user();
+
+        if ($user->isAdmin()) {
+            return false;
+        }
+
+        return $user->hasRole('teacher')
+            || $user->roles()->where('name', 'teacher')->exists();
     }
 
 

--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -38,7 +38,7 @@ class TestQuestionController extends Controller
             $test_questions = $test_questions->where('test_questions.test_id', '=', $request->test_id);
         }
 
-        $this->scopeQuestionsToAssignedTrainerCourses($test_questions);
+        $this->scopeQuestionsToAssignedCoursesForNonAdmins($test_questions);
 
         if ($request->course_id != "") {
             $test_questions = $test_questions->where('tests.course_id', (int)$request->course_id);
@@ -501,9 +501,9 @@ class TestQuestionController extends Controller
         
     }
 
-    private function scopeQuestionsToAssignedTrainerCourses($query): void
+    private function scopeQuestionsToAssignedCoursesForNonAdmins($query): void
     {
-        if (!$this->currentUserIsTrainer()) {
+        if (!$this->shouldScopeQuestionsToAssignedCourses()) {
             return;
         }
 
@@ -515,20 +515,13 @@ class TestQuestionController extends Controller
         });
     }
 
-    private function currentUserIsTrainer(): bool
+    private function shouldScopeQuestionsToAssignedCourses(): bool
     {
         if (!auth()->check()) {
             return false;
         }
 
-        $user = auth()->user();
-
-        if ($user->isAdmin()) {
-            return false;
-        }
-
-        return $user->hasRole('teacher')
-            || $user->roles()->where('name', 'teacher')->exists();
+        return !auth()->user()->isAdmin();
     }
 
 

--- a/tests/Feature/Backend/TestQuestionVisibilityTest.php
+++ b/tests/Feature/Backend/TestQuestionVisibilityTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Backend;
+
+use App\Http\Controllers\Backend\Admin\TestQuestionController;
+use App\Models\Auth\Role;
+use App\Models\Auth\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class TestQuestionVisibilityTest extends TestCase
+{
+    public function test_new_trainer_without_assigned_courses_sees_no_existing_questions(): void
+    {
+        $this->seedQuestionForCourse('Existing course question');
+        $trainer = $this->createTrainer();
+
+        $this->actingAs($trainer->fresh());
+
+        $questions = $this->questionIndexData();
+
+        $this->assertCount(0, $questions);
+    }
+
+    public function test_trainer_sees_only_questions_for_assigned_courses(): void
+    {
+        $assignedCourseId = $this->createCourse('Assigned course');
+        $unassignedCourseId = $this->createCourse('Unassigned course');
+        $assignedQuestionId = $this->seedQuestionForCourse('Assigned question', $assignedCourseId);
+        $this->seedQuestionForCourse('Unassigned question', $unassignedCourseId);
+
+        $trainer = $this->createTrainer();
+        DB::table('course_user')->insert([
+            'course_id' => $assignedCourseId,
+            'user_id' => $trainer->id,
+        ]);
+
+        $this->actingAs($trainer->fresh());
+
+        $questions = $this->questionIndexData();
+
+        $this->assertCount(1, $questions);
+        $this->assertSame($assignedQuestionId, (int) $questions->first()->id);
+    }
+
+    public function test_admin_question_visibility_is_not_restricted_by_trainer_scope(): void
+    {
+        $this->seedQuestionForCourse('First admin-visible question');
+        $this->seedQuestionForCourse('Second admin-visible question');
+
+        $this->actingAs($this->createAdmin());
+
+        $questions = $this->questionIndexData();
+
+        $this->assertCount(2, $questions);
+    }
+
+    private function questionIndexData()
+    {
+        $response = app(TestQuestionController::class)->index(Request::create('/admin/test_questions', 'GET'));
+
+        return $response->getData()['test_questions'];
+    }
+
+    private function createTrainer(): User
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $role = Role::firstOrCreate([
+            'name' => 'teacher',
+            'guard_name' => 'web',
+        ]);
+
+        $trainer = factory(User::class)->create();
+        $trainer->assignRole($role);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        return $trainer;
+    }
+
+    private function seedQuestionForCourse(string $questionText, ?int $courseId = null): int
+    {
+        $courseId = $courseId ?: $this->createCourse($questionText . ' course');
+        $testId = DB::table('tests')->insertGetId([
+            'course_id' => $courseId,
+            'title' => $questionText . ' test',
+            'published' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return DB::table('test_questions')->insertGetId([
+            'test_id' => $testId,
+            'question_type' => 1,
+            'question_text' => $questionText,
+            'marks' => 1,
+            'is_deleted' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createCourse(string $title): int
+    {
+        $categoryId = DB::table('categories')->insertGetId([
+            'name' => $title . ' category',
+            'slug' => Str::slug($title . ' category'),
+            'status' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return DB::table('courses')->insertGetId([
+            'category_id' => $categoryId,
+            'title' => $title,
+            'slug' => Str::slug($title),
+            'published' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Backend/TestQuestionVisibilityTest.php
+++ b/tests/Feature/Backend/TestQuestionVisibilityTest.php
@@ -46,6 +46,27 @@ class TestQuestionVisibilityTest extends TestCase
         $this->assertSame($assignedQuestionId, (int) $questions->first()->id);
     }
 
+    public function test_non_admin_question_visibility_is_scoped_even_without_teacher_role(): void
+    {
+        $assignedCourseId = $this->createCourse('Assigned course without teacher role');
+        $unassignedCourseId = $this->createCourse('Unassigned course without teacher role');
+        $assignedQuestionId = $this->seedQuestionForCourse('Assigned question without teacher role', $assignedCourseId);
+        $this->seedQuestionForCourse('Unassigned question without teacher role', $unassignedCourseId);
+
+        $user = factory(User::class)->create();
+        DB::table('course_user')->insert([
+            'course_id' => $assignedCourseId,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($user->fresh());
+
+        $questions = $this->questionIndexData();
+
+        $this->assertCount(1, $questions);
+        $this->assertSame($assignedQuestionId, (int) $questions->first()->id);
+    }
+
     public function test_admin_question_visibility_is_not_restricted_by_trainer_scope(): void
     {
         $this->seedQuestionForCourse('First admin-visible question');


### PR DESCRIPTION
When a newly created trainer opened Course Management -> Questions, the table showed all existing questions because the controller query bypassed the existing trainer course scope used by the course dropdown.


# 📥 Pull Request Template

## 🔧 Description

When a trainer views the Questions page, the table query now restricts records to questions whose tests belong to courses explicitly assigned to that trainer through `course_user`. Trainers with no assigned courses now see an empty table, while admins keep the full question list.

Fixes: #726

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

N/A

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [ ] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [x] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as an admin.
2. Navigate to User Management -> Trainers.
3. Create a new trainer and login with that trainer account.
4. Navigate to Course Management -> Questions.
5. Observe the Questions table.

Actual: Existing questions from unrelated courses are displayed.
Expected: A new trainer sees an empty table, or only questions from courses explicitly assigned to that trainer.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [x] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

Added feature coverage for an unassigned trainer, an assigned trainer, and admin visibility.
