### PR TITLE
Fix page editor content loading

### DIFF
--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -212,7 +212,7 @@
     </script>
 <script src="{{ asset('js/app.js') }}"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>  
-    <script src="https://cdn.ckeditor.com/4.22.1/full/ckeditor.js"></script>
+    <script src="{{ asset('ckeditor/ckeditor.js') }}"></script>
     <script>
     if (typeof CKEDITOR !== 'undefined') {
         CKEDITOR.config.versionCheck = false;

--- a/resources/views/backend/pages/create.blade.php
+++ b/resources/views/backend/pages/create.blade.php
@@ -121,23 +121,8 @@
 
 @push('after-scripts')
     <script src="{{asset('plugins/bootstrap-tagsinput/bootstrap-tagsinput.js')}}"></script>
-    <script type="text/javascript" src="{{asset('/vendor/unisharp/laravel-ckeditor/ckeditor.js')}}"></script>
-    <script type="text/javascript" src="{{asset('/vendor/unisharp/laravel-ckeditor/adapters/jquery.js')}}"></script>
     <script src="{{asset('/vendor/laravel-filemanager/js/lfm.js')}}"></script>
     <script>
-        $('.editor').each(function () {
-
-            CKEDITOR.replace($(this).attr('id'), {
-                filebrowserImageBrowseUrl: '/laravel-filemanager?type=Images',
-                filebrowserImageUploadUrl: '/laravel-filemanager/upload?type=Images&_token={{csrf_token()}}',
-                filebrowserBrowseUrl: '/laravel-filemanager?type=Files',
-                filebrowserUploadUrl: '/laravel-filemanager/upload?type=Files&_token={{csrf_token()}}',
-
-                extraPlugins: 'smiley,lineutils,widget,codesnippet,prism,flash,colorbutton,colordialog,codesnippet',
-            });
-
-        });
-
         var uploadField = $('input[type="file"]');
 
         $(document).on('change','input[type="file"]',function () {

--- a/resources/views/backend/pages/edit.blade.php
+++ b/resources/views/backend/pages/edit.blade.php
@@ -106,7 +106,7 @@
             <div class="row">
                 <div class="col-12 form-group">
                     {!! Form::label('content', trans('labels.backend.pages.fields.content'), ['class' => 'control-label']) !!}
-                    {!! Form::textarea('content', old('content'), [
+                    {!! Form::textarea('content', old('content', $page->content), [
                         'class' => 'form-control editor',
                         'placeholder' => '',
                         'id' => 'editor',
@@ -183,22 +183,7 @@
 
 @push('after-scripts')
     <script src="{{ asset('plugins/bootstrap-tagsinput/bootstrap-tagsinput.js') }}"></script>
-    <script type="text/javascript" src="{{ asset('/vendor/unisharp/laravel-ckeditor/ckeditor.js') }}"></script>
-    <script type="text/javascript" src="{{ asset('/vendor/unisharp/laravel-ckeditor/adapters/jquery.js') }}"></script>
     <script src="{{ asset('/vendor/laravel-filemanager/js/lfm.js') }}"></script>
-    <script>
-        $('.editor').each(function() {
-
-            CKEDITOR.replace($(this).attr('id'), {
-                filebrowserImageBrowseUrl: '/laravel-filemanager?type=Images',
-                filebrowserImageUploadUrl: '/laravel-filemanager/upload?type=Images&_token={{ csrf_token() }}',
-                filebrowserBrowseUrl: '/laravel-filemanager?type=Files',
-                filebrowserUploadUrl: '/laravel-filemanager/upload?type=Files&_token={{ csrf_token() }}',
-
-                extraPlugins: 'smiley,lineutils,widget,codesnippet,prism,flash,colorbutton,colordialog',
-            });
-
-        });
         $(document).ready(function() {
             $(document).on('click', '.delete', function(e) {
                 e.preventDefault();


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes #635 

This PR fixes the issue where the Content section in the Edit Page interface was not loading the Rich Text Editor properly.

The editor area previously appeared as a blank white container with no toolbar, cursor, or pre-filled page content. This prevented administrators from viewing or editing existing page content.

This change ensures that:

- The Rich Text Editor initializes correctly on the Edit Page screen
- Existing page content is loaded and displayed in the editor
- Admin users can edit and format page content as expected

Fixes: #635

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

_Add screenshots or GIFs showing the Rich Text Editor now loading correctly in the Edit Page Content section._

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

Verified that:

- The Page Manager edit screen loads successfully
- The Content section displays the Rich Text Editor
- Existing page content is pre-populated in the editor
- The editor toolbar and text cursor are visible
- Admin users can update and format content

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in with admin credentials.
2. Navigate to **Site Management → Page Manager**.
3. Click the edit icon for an existing page record.
4. Check the **Content** section.
5. Confirm that the Rich Text Editor loads with the existing page content.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This PR focuses on restoring the expected editor behavior in the Edit Page interface so administrators can properly view, edit, and format existing page content.
