### PR TITLE
fix: remove default backend permissions and sync parent checkboxes on…

### DIFF
--- a/resources/views/backend/roles/create.blade.php
+++ b/resources/views/backend/roles/create.blade.php
@@ -40,23 +40,13 @@
                         </div>
 
                         @foreach($modulePermissions as $permission)
-
-                            @php
-                                $default_permission_checked = false;
-                            @endphp
-
-                            @if($module == 'backend')
-                                @php
-                                    $default_permission_checked = true;
-                                @endphp
-                            @endif
                             <div class="form-check ms-3">
                                 <input type="checkbox"
                                     name="permissions[]"
                                     class="form-check-input permission-{{ $module }}"
                                     value="{{ $permission->id }}"
                                     id="perm_{{ $permission->id }}"
-                                    @if($default_permission_checked) checked @endif
+                                    {{ isset($role) && $role->permissions->contains($permission->id) ? 'checked' : '' }}
                                    >
                                 <label class="form-check-label" for="perm_{{ $permission->id }}">
                                     {{ $permission->name }}
@@ -108,6 +98,10 @@ document.addEventListener('DOMContentLoaded', function () {
             updateGlobalState();
         });
     });
+
+    // 🔹 SYNC STATE ON LOAD
+    updateModuleState();
+    updateGlobalState();
 
     // 🔹 UPDATE MODULE STATE
     function updateModuleState() {


### PR DESCRIPTION
… role create

Backend permissions were hardcoded as checked for every new role, granting unintended elevated access. Parent select-all checkboxes also failed to reflect pre-checked children on page load.


# 📥 Pull Request Template

## 🔧 Description

When creating a new role, all backend permissions (backend_access,
backend_create, backend_edit, backend_view, backend_delete) were
checked by default due to hardcoded logic in the view. Additionally,
the "Select All" parent checkbox did not reflect the pre-checked
children state on page load.

Fixes: #743 

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1843" height="1001" alt="image" src="https://github.com/user-attachments/assets/d4ce63ed-ab05-48b3-baf1-07b1bc6fab6c" />
---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to User Management → Roles Permissions → Add Role
2. Observe the Backend permissions section

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

Two changes in `resources/views/backend/roles/create.blade.php`:
1. Removed hardcoded `checked` logic for backend module — permissions now default to unchecked on create, and are driven by `$role->permissions` on edit.
2. Added `updateModuleState()` and `updateGlobalState()` on page load so parent checkboxes correctly sync with any pre-checked children.
