### PR TITLE
fix: restore course delete confirmation

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -105,7 +105,7 @@ class CoursesController extends Controller
         if (auth()->user()->can('course_edit')) {
             $has_edit = true;
         }
-        if (auth()->user()->can('lesson_delete')) {
+        if (auth()->user()->can('course_delete')) {
             $has_delete = true;
         }
 
@@ -278,7 +278,7 @@ class CoursesController extends Controller
         if (auth()->user()->can('course_edit')) {
             $has_edit = true;
         }
-        if (auth()->user()->can('lesson_delete')) {
+        if (auth()->user()->can('course_delete')) {
             $has_delete = true;
         }
 

--- a/public/js/backend.js
+++ b/public/js/backend.js
@@ -21907,6 +21907,23 @@ function addDeleteForms() {
  * Place any jQuery/helper plugins in here.
  */
 $(function () {
+    var fireConfirm = function fireConfirm(options) {
+        if (window.Swal && typeof window.Swal.fire === 'function') {
+            return window.Swal.fire(options);
+        }
+
+        if (window.swal && typeof window.swal.fire === 'function') {
+            return window.swal.fire(options);
+        }
+
+        if (typeof window.swal === 'function') {
+            return window.swal(options);
+        }
+
+        var confirmed = window.confirm(options.title);
+        return Promise.resolve({ value: confirmed, isConfirmed: confirmed });
+    };
+
     /**
      * Add the data-method="delete" forms to all delete links
      */
@@ -21928,19 +21945,20 @@ $(function () {
         e.preventDefault();
 
         var form = this;
-        var link = $('a[data-method="delete"]');
+        var link = $(form).closest('a[data-method="delete"]');
         var cancel = link.attr('data-trans-button-cancel') ? link.attr('data-trans-button-cancel') : 'Cancel';
         var confirm = link.attr('data-trans-button-confirm') ? link.attr('data-trans-button-confirm') : 'Yes, delete';
         var title = link.attr('data-trans-title') ? link.attr('data-trans-title') : 'Are you sure you want to delete this item?';
 
-        swal({
+        fireConfirm({
             title: title,
             showCancelButton: true,
             confirmButtonText: confirm,
             cancelButtonText: cancel,
+            icon: 'warning',
             type: 'warning'
         }).then(function (result) {
-            result.value && form.submit();
+            (result.value || result.isConfirmed) && form.submit();
         });
     }).on('click', 'a[name=confirm_item]', function (e) {
         /**
@@ -21953,14 +21971,15 @@ $(function () {
         var cancel = link.attr('data-trans-button-cancel') ? link.attr('data-trans-button-cancel') : 'Cancel';
         var confirm = link.attr('data-trans-button-confirm') ? link.attr('data-trans-button-confirm') : 'Continue';
 
-        swal({
+        fireConfirm({
             title: title,
             showCancelButton: true,
             confirmButtonText: confirm,
             cancelButtonText: cancel,
+            icon: 'info',
             type: 'info'
         }).then(function (result) {
-            result.value && window.location.assign(link.attr('href'));
+            (result.value || result.isConfirmed) && window.location.assign(link.attr('href'));
         });
     });
 });

--- a/resources/js/plugins.js
+++ b/resources/js/plugins.js
@@ -26,6 +26,23 @@ function addDeleteForms() {
  * Place any jQuery/helper plugins in here.
  */
 $(function () {
+    const fireConfirm = (options) => {
+        if (window.Swal && typeof window.Swal.fire === 'function') {
+            return window.Swal.fire(options);
+        }
+
+        if (window.swal && typeof window.swal.fire === 'function') {
+            return window.swal.fire(options);
+        }
+
+        if (typeof window.swal === 'function') {
+            return window.swal(options);
+        }
+
+        const confirmed = window.confirm(options.title);
+        return Promise.resolve({ value: confirmed, isConfirmed: confirmed });
+    };
+
     /**
      * Add the data-method="delete" forms to all delete links
      */
@@ -47,19 +64,20 @@ $(function () {
         e.preventDefault();
 
         const form = this;
-        const link = $('a[data-method="delete"]');
+        const link = $(form).closest('a[data-method="delete"]');
         const cancel = (link.attr('data-trans-button-cancel')) ? link.attr('data-trans-button-cancel') : 'Cancel';
         const confirm = (link.attr('data-trans-button-confirm')) ? link.attr('data-trans-button-confirm') : 'Yes, delete';
         const title = (link.attr('data-trans-title')) ? link.attr('data-trans-title') : 'Are you sure you want to delete this item?';
 
-        swal({
+        fireConfirm({
             title: title,
             showCancelButton: true,
             confirmButtonText: confirm,
             cancelButtonText: cancel,
+            icon: 'warning',
             type: 'warning'
         }).then((result) => {
-            result.value && form.submit();
+            (result.value || result.isConfirmed) && form.submit();
         });
     }).on('click', 'a[name=confirm_item]', function (e) {
         /**
@@ -72,14 +90,15 @@ $(function () {
         const cancel = (link.attr('data-trans-button-cancel')) ? link.attr('data-trans-button-cancel') : 'Cancel';
         const confirm = (link.attr('data-trans-button-confirm')) ? link.attr('data-trans-button-confirm') : 'Continue';
 
-        swal({
+        fireConfirm({
             title: title,
             showCancelButton: true,
             confirmButtonText: confirm,
             cancelButtonText: cancel,
+            icon: 'info',
             type: 'info'
         }).then((result) => {
-            result.value && window.location.assign(link.attr('href'));
+            (result.value || result.isConfirmed) && window.location.assign(link.attr('href'));
         });
     });
 });

--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -400,6 +400,9 @@ window.addEventListener('load', function () {
                 $('#myTable_length select').addClass('form-select form-select-sm custom-entries');
                 },
   
+                drawCallback: function () {
+                    addDeleteForms();
+                },
                 createdRow: function(row, data, dataIndex) {
                     $(row).attr('data-entry-id', data.id);
                 },


### PR DESCRIPTION
## Description

Replaces PR #753 with a clean branch based on the current upstream main.

This keeps only the Course Management delete fix for issue #702:
- initialize DataTables delete forms after each course table draw
- use course_delete permission for course delete actions
- support the currently loaded SweetAlert2 API while preserving older swal compatibility

## Testing

- git diff --check upstream/main...HEAD
- php -l app/Http/Controllers/Backend/Admin/CoursesController.php
- php artisan test --filter CourseTrainerScheduleOverlapTest

Fixes #702
Supersedes #753