### PR TITLE
fix: resolve course feedback error page

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CourseFeedbackController.php
+++ b/app/Http/Controllers/Backend/Admin/CourseFeedbackController.php
@@ -108,16 +108,6 @@ class CourseFeedbackController extends Controller
             ->with('success', 'Questions added successfully!');
     }
 
-    public function assignedQuestions($courseId)
-    {
-        return CourseFeedback::where('course_id', $courseId)
-            ->pluck('feedback_question_id')
-            ->map(function ($questionId) {
-                return (int) $questionId;
-            })
-            ->values();
-    }
-
     public function assignedQuestions($course_id)
     {
         $questionIds = CourseFeedback::where('course_id', $course_id)

--- a/resources/views/backend/course_feedback_question/index.blade.php
+++ b/resources/views/backend/course_feedback_question/index.blade.php
@@ -156,7 +156,7 @@ width: 58% !important;
 
     // OPTIONAL: fetch already assigned questions (for duplicate prevention)
     $.ajax({
-        url: '{{ route("admin.course-feedback.assigned-questions", ["course_id" => "__COURSE_ID__"]) }}'.replace('__COURSE_ID__', courseId),
+        url: '{{ route('admin.course-feedback-questions.assigned', ['course_id' => '__COURSE_ID__']) }}'.replace('__COURSE_ID__', courseId),
         type: 'GET',
         success: function (assignedIds) {
             $('#question_select option').each(function () {

--- a/routes/backend/admin.php
+++ b/routes/backend/admin.php
@@ -424,10 +424,8 @@ Route::get('lessons/add', function () {
 
 Route::resource('lessons', 'Admin\LessonsController');
 Route::post('course-feedback-questions/add-questions', 'Admin\CourseFeedbackController@addQuestionsToCourse')->name('course-feedback.add-questions');
-Route::get('course-feedback-questions/assigned/{course_id}', 'Admin\CourseFeedbackController@assignedQuestions')->name('course-feedback.assigned-questions');
+Route::get('course-feedback-questions/assigned/{course_id}', 'Admin\CourseFeedbackController@assignedQuestions')->name('course-feedback-questions.assigned');
 Route::resource('course-feedback-questions', 'Admin\CourseFeedbackController');
-Route::post('course-feedback/add-questions', 'Admin\CourseFeedbackController@addQuestionsToCourse')->name('course-feedback.add-questions');
-Route::get('course-feedback-questions/assigned/{course}', 'Admin\CourseFeedbackController@assignedQuestions')->name('course-feedback-questions.assigned');
 Route::get('course-feedback-questions/delete/{id}', 'Admin\CourseFeedbackController@destroy');
 Route::get('course-feedback-questions/edit/{id}', 'Admin\CourseFeedbackController@edit')->name('course.coursefeedbackquestion.edit');
 Route::post('course-feedback-questions/update', 'Admin\CourseFeedbackController@update');


### PR DESCRIPTION
## Description

Fixes the error page reported in issue #708 comment: https://github.com/Tadreeb-LMS/tadreeblms/issues/708#issuecomment-4591393059

After PR #709, `CourseFeedbackController` contained two `assignedQuestions()` methods, which caused PHP to fail loading the page with:

`Cannot redeclare App\Http\Controllers\Backend\Admin\CourseFeedbackController::assignedQuestions()`

This PR:
- removes the duplicate controller method
- removes duplicate course feedback route definitions
- keeps one assigned-questions route name and updates the Blade reference to match the existing route-reference test

## Testing

- `php -l app/Http/Controllers/Backend/Admin/CourseFeedbackController.php`
- `php -l routes/backend/admin.php`
- `php -l tests/Unit/Backend/CourseFeedbackRouteReferencesTest.php`
- `git diff --check`
- `php vendor/bin/phpunit tests/Unit/Backend/CourseFeedbackRouteReferencesTest.php`

Fixes #708