### PR TITLE
fix: align edit user form layout with create user form

### DIFF
--- a/resources/views/backend/auth/user/edit.blade.php
+++ b/resources/views/backend/auth/user/edit.blade.php
@@ -14,14 +14,10 @@
     @csrf
     @method('PATCH')
 
-    <div class="pb-3 d-flex justify-content-between">
-        <h4>
-            @lang('labels.backend.access.users.management')
-            <small class="text-muted ml-3">
-                @lang('labels.backend.access.users.edit')
-            </small>
-        </h4>
-    </div>
+    <h4 class="pb-3 d-flex">
+        @lang('labels.backend.access.users.management')
+        <small class="text-muted ml-3 mt-1">@lang('labels.backend.access.users.edit')</small>
+    </h4>
 
     <div class="card">
         <div class="card-body">
@@ -30,6 +26,7 @@
             <div class="form-group row">
                 <label class="col-md-2 form-control-label" for="first_name">
                     {{ __('validation.attributes.backend.access.users.first_name') }}
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="text"
@@ -49,6 +46,7 @@
             <div class="form-group row">
                 <label class="col-md-2 form-control-label" for="last_name">
                     {{ __('validation.attributes.backend.access.users.last_name') }}
+                    <span class="text-danger">*</span>
                 </label>
                 <div class="col-md-10">
                     <input type="text"
@@ -152,69 +150,41 @@
 
             {{-- Roles --}}
             <div class="form-group row">
-                <label class="col-md-2 form-control-label">Abilities</label>
-
-                <div class="col-md-10 table-responsive">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>@lang('labels.backend.access.users.table.roles')</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr>
-                            <td>
-                                @php
-                                    $selectedRoles = old('roles', $userRoles);
-                                    $roleLabels = [
-                                        'trainer' => 'Trainer',
-                                        'trainee' => 'Trainee',
-                                        'student' => 'Student',
-                                        'teacher' => 'Teacher',
-                                        'administrator' => 'Administrator',
-                                        'admin' => 'Admin',
-                                    ];
-                                @endphp
-                                @foreach($roles as $role)
-                                    @if(1)
-                                        <div class="card mb-2">
-                                            <div class="card-header">
-                                                <div class="form-check">
-                                                    <input type="radio"
-                                                           name="roles[]"
-                                                           id="role-{{ $role->id }}"
-                                                           value="{{ $role->name }}"
-                                                           class="form-check-input @error('roles') is-invalid @enderror"
-                                                           {{ in_array($role->name, $selectedRoles) ? 'checked' : '' }}>
-                                                    <label class="form-check-label" for="role-{{ $role->id }}">
-                                                        {{ $roleLabels[strtolower($role->name)] ?? ucwords(str_replace('_', ' ', $role->name)) }}
-                                                    </label>
-                                                </div>
-                                            </div>
-
-                                            {{-- <div class="card-body">
-                                                @if($role->permissions->count())
-                                                    @foreach($role->permissions as $permission)
-                                                        <i class="fas fa-dot-circle"></i>
-                                                        {{ ucwords($permission->name) }} <br>
-                                                    @endforeach
-                                                @else
-                                                    @lang('labels.general.none')
-                                                @endif
-                                            </div> --}}
-                                        </div>
-                                    @endif
-                                @endforeach
-                                @error('roles')
-                                    <div class="text-danger small mt-1">{{ $message }}</div>
-                                @enderror
-                                @error('roles.*')
-                                    <div class="text-danger small mt-1">{{ $message }}</div>
-                                @enderror
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
+                <label class="col-md-2 form-control-label">
+                    @lang('labels.backend.access.users.table.abilities')
+                    <span class="text-danger">*</span>
+                </label>
+                <div class="col-md-10">
+                    @php
+                        $selectedRoles = old('roles', $userRoles);
+                        $roleLabels = [
+                            'trainer' => 'Trainer',
+                            'trainee' => 'Trainee',
+                            'student' => 'Student',
+                            'teacher' => 'Teacher',
+                            'administrator' => 'Administrator',
+                            'admin' => 'Admin',
+                        ];
+                    @endphp
+                    @foreach($roles as $role)
+                        <div class="form-check">
+                            <input type="radio"
+                                   name="roles[]"
+                                   id="role-{{ $role->id }}"
+                                   value="{{ $role->name }}"
+                                   class="form-check-input @error('roles') is-invalid @enderror"
+                                   {{ in_array($role->name, $selectedRoles) ? 'checked' : '' }}>
+                            <label class="form-check-label" for="role-{{ $role->id }}">
+                                {{ $roleLabels[strtolower($role->name)] ?? ucwords(str_replace('_', ' ', $role->name)) }}
+                            </label>
+                        </div>
+                    @endforeach
+                    @error('roles')
+                        <div class="text-danger small mt-1">{{ $message }}</div>
+                    @enderror
+                    @error('roles.*')
+                        <div class="text-danger small mt-1">{{ $message }}</div>
+                    @enderror
                 </div>
             </div>
 
@@ -241,7 +211,7 @@
             </div>
 
             {{-- Buttons --}}
-            <div class="row">
+            <div class="row mt-3">
                 <div class="col-12 d-flex justify-content-between">
                     <a href="{{ route('admin.auth.user.index') }}" class="btn btn-secondary">
                         {{ __('buttons.general.cancel') }}


### PR DESCRIPTION
## 🔧 Description

The "Edit User" form had a different visual structure than the "Create User" form despite both managing the same data entity, causing an inconsistent user experience.

Changes made to `resources/views/backend/auth/user/edit.blade.php`:
- Unified heading structure (`<h4 class="pb-3 d-flex">`) to match the Create form
- Added required field markers (`*`) to first name, last name, and roles labels
- Replaced the roles table + nested card-header structure with the same flat `form-check` radio list used on Create
- Used `@lang()` for the roles label instead of hardcoded `"Abilities"`
- Added `mt-3` spacing to the button row to match Create

Fixes: #744 

---

## ✅ Type of Change

Select all that apply:

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1892" height="815" alt="image" src="https://github.com/user-attachments/assets/193e61e5-50c0-4ab9-a61a-0c060fb9a960" />
<img width="1892" height="815" alt="image" src="https://github.com/user-attachments/assets/a8137c09-8cde-4c32-9b76-a0260c9584dc" />


---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to `/user/auth/user/create` and observe the form layout.
2. Navigate to `/user/auth/user/{id}/edit` and observe the form layout.
3. Compare heading structure, required markers, roles section, and button spacing — they differ visually.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

Only `edit.blade.php` was modified. No controller, model, or migration changes.

