### PR TITLE
fix: enroll and notify students after course assignment

### DIFF
--- a/app/Console/Commands/SyncCourseAssignmentSubscriptions.php
+++ b/app/Console/Commands/SyncCourseAssignmentSubscriptions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\CustomHelper;
+use Illuminate\Console\Command;
+
+class SyncCourseAssignmentSubscriptions extends Command
+{
+    protected $signature = 'courses:sync-assignment-subscriptions';
+
+    protected $description = 'Create missing course subscriptions from course assignment records.';
+
+    public function handle()
+    {
+        $synced = CustomHelper::syncCourseAssignmentAndSubscribeCourseData();
+
+        $this->info($synced . ' course subscription(s) synced from assignments.');
+
+        return 0;
+    }
+}

--- a/app/Helpers/CustomHelper.php
+++ b/app/Helpers/CustomHelper.php
@@ -9,7 +9,7 @@ use App\Models\Course;
 use App\Models\Category;
 use App\Models\courseAssignment;
 use App\Models\AssignmentQuestion;
-use App\Models\{Assignment, Lesson, AttendanceStudent, ChapterStudent, StudentCourseFeedback, Certificate, Config, CourseModuleWeightage, EmployeeProfile, Test, TestQuestion, TestsResult, UserCourseDetail};
+use App\Models\{Assignment, Lesson, AttendanceStudent, ChapterStudent, StudentCourseFeedback, Certificate, Config, CourseAssignmentToUser, CourseModuleWeightage, EmployeeProfile, Test, TestQuestion, TestsResult, UserCourseDetail};
 use App\Models\Stripe\SubscribeCourse;
 use App\Services\LmsEventRecorder;
 use Auth;
@@ -1086,37 +1086,87 @@ class CustomHelper
 
     public static function syncCourseAssignmentAndSubscribeCourseData()
     {
+        $synced = 0;
         $cas = courseAssignment::get();
 
         foreach ($cas as $ca) {
+            if (empty($ca->course_id) || empty($ca->assign_to)) {
+                continue;
+            }
+
             if (strpos($ca->assign_to, ',') !== false) {
                 $usersAssigned = explode(',', $ca->assign_to);
 
                 foreach ($usersAssigned as $value) {
-                    $sc = SubscribeCourse::where('user_id', $value)->where('course_id', $ca->course_id)->exists();
-                    if (!$sc) {
-                        SubscribeCourse::create([
-                            'user_id' => $value,
-                            'course_id' => $ca->course_id,
-                            'status' => 1,
-                            'created_at' => $ca->assign_date,
-                            'updated_at' => $ca->assign_date,
-                        ]);
-                    }
+                    $synced += self::syncAssignedCourseSubscription($value, $ca->course_id, $ca);
                 }
             } else {
-                $sc = SubscribeCourse::where('user_id', $ca->assign_to)->where('course_id', $ca->course_id)->exists();
-                if (!$sc) {
-                    SubscribeCourse::create([
-                        'user_id' => $ca->assign_to,
-                        'course_id' => $ca->course_id,
-                        'status' => 1,
-                        'created_at' => $ca->assign_date,
-                        'updated_at' => $ca->assign_date,
-                    ]);
-                }
+                $synced += self::syncAssignedCourseSubscription($ca->assign_to, $ca->course_id, $ca);
             }
         }
+
+        CourseAssignmentToUser::with('assignment')
+            ->where('by_pathway', 0)
+            ->whereNull('deleted_at')
+            ->whereNotNull('user_id')
+            ->whereNotNull('course_id')
+            ->chunkById(200, function ($assignments) use (&$synced) {
+                foreach ($assignments as $assignmentUser) {
+                    $synced += self::syncAssignedCourseSubscription(
+                        $assignmentUser->user_id,
+                        $assignmentUser->course_id,
+                        $assignmentUser->assignment
+                    );
+                }
+            });
+
+        return $synced;
+    }
+
+    private static function syncAssignedCourseSubscription($userId, $courseId, $assignment = null)
+    {
+        $userId = (int) $userId;
+        $courseId = (int) $courseId;
+
+        if (!$userId || !$courseId || !Course::where('id', $courseId)->exists()) {
+            return 0;
+        }
+
+        $subscription = SubscribeCourse::withTrashed()
+            ->where('user_id', $userId)
+            ->where('course_id', $courseId)
+            ->first();
+
+        if ($subscription && is_null($subscription->deleted_at)) {
+            return 0;
+        }
+
+        $hasFeedback = StudentCourseFeedback::where('course_id', $courseId)->exists()
+            || \App\Models\CourseFeedback::where('course_id', $courseId)->exists();
+        $hasAssessment = Assignment::where('course_id', $courseId)->exists();
+        $assignDate = optional($assignment)->assign_date ?: now();
+
+        if (!$subscription) {
+            $subscription = new SubscribeCourse([
+                'user_id' => $userId,
+                'course_id' => $courseId,
+            ]);
+        } else {
+            $subscription->restore();
+        }
+
+        $subscription->fill([
+            'status' => 1,
+            'assign_date' => $assignDate,
+            'due_date' => optional($assignment)->due_date,
+            'has_feedback' => $hasFeedback ? 1 : 0,
+            'has_assesment' => $hasAssessment ? 1 : 0,
+            'course_trainer_name' => self::getCourseTrainerName($courseId) ?? null,
+            'is_pathway' => 0,
+        ]);
+        $subscription->save();
+
+        return 1;
     }
 
     public static function completeCourseForUser($course_id, $user_id)

--- a/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
+++ b/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
@@ -766,6 +766,8 @@ public function courseAssignment(Request $request)
                     dispatch(new SendEmailJob($details));
 
                     $enrolled_count++;
+                    CourseNotification::createCourseEnrollmentBell($emp, $course);
+
                     // Bell notification for course enrollment
                     try {
                         $notificationSettings = app(NotificationSettingsService::class);
@@ -904,6 +906,7 @@ public function courseAssignment(Request $request)
             ]);
 
             $enrolled_count++;
+            CourseNotification::createCourseEnrollmentBell($emp, $course);
 
             // Send email notification (same as course_assignment)
             $user_fav_lang = $emp->fav_lang;
@@ -1143,6 +1146,8 @@ public function courseAssignment(Request $request)
                         'by_invitation' => 1
                     ]);
 
+                    CourseNotification::createCourseEnrollmentBell($emp, $course);
+
                     //dd($sb, $course_Ass->due_date);
 
                     $user_fav_lang = $emp->fav_lang;
@@ -1215,6 +1220,13 @@ public function courseAssignment(Request $request)
                     'created_at' => date('Y-m-d H:i:s'),
                     'updated_at' => date('Y-m-d H:i:s'),
                 ]);
+
+                $emp = User::where('id', $teacher)->active()->first();
+                $course = Course::find($request->course_id);
+
+                if ($emp && $course) {
+                    CourseNotification::createCourseEnrollmentBell($emp, $course);
+                }
             }
         }
         return redirect()->route('admin.assessment_accounts.course-assign-list')->withFlashSuccess(trans('Course Assignment Updated sucessfully...'));

--- a/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
+++ b/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
@@ -64,49 +64,7 @@ public function createWithCourse(Request $request)
 
 public function courseAssignment(Request $request)
 {
-
-    $request->validate([
-        'course_ids' => 'required|array',
-        'teachers' => 'required|array'
-    ]);
-
-    $courses = $request->course_ids;
-    $users = $request->teachers;
-
-    foreach ($courses as $courseId) {
-
-        $course = DB::table('courses')->where('id', $courseId)->first();
-
-        // create assignment
-        $assignmentId = DB::table('course_assignment')->insertGetId([
-            'title' => $course->title,
-            'course_id' => $courseId, 
-            'category_id' => $course->category_id ?? null,
-    'department_id' => $request->department_id ?? null,   
-             'assign_by' => auth()->id(),        // Assign By
-            'created_at' => now(),
-            'updated_at' => now(),
-            'assign_date' => now(),
-'assign_to' => $request->department_id ? 'department' : 'user',        ]);
-
-        // assign users
-        foreach ($users as $userId) {
-
-            DB::table('course_assignment_users')->insert([
-    'course_assignment_id' => $assignmentId,
-    'course_id' => $courseId,
-    'user_id' => $userId,
-    'log_comment' => 'By Admin',
-    'created_at' => now(),
-    'updated_at' => now()
-]);;
-
-        }
-
-    }
-
-    return redirect()->back()->with('success','Courses assigned successfully');
-
+    return $this->course_assignment($request);
 }
 
     /**
@@ -611,31 +569,24 @@ public function courseAssignment(Request $request)
         $this->validate($request, 
             [
                 // 'title' => 'required',
-                'course_id' => 'required',
+                'course_id' => 'required_without:course_ids',
+                'course_ids' => 'required_without:course_id|array',
                 // 'due_date' => 'required',    
                 'teachers' => 'required_without:department_id',
                 'department_id' => 'required_without:teachers',
             ],
             [
-                'course_id.required' => 'Please select the course',
+                'course_id.required_without' => 'Please select the course',
+                'course_ids.required_without' => 'Please select the course',
                 'teachers.required_without' => 'Please select either a users or department',
                 'department_id.required_without' => 'Please select either a users or department',
             ]
         );
 
         // course assignment
-        $course_ids_arr = [];
-        $single_course_id = $request->course_id;
-
-
-
-
-        if ($single_course_id) {
-            $course_ids_arr = [$single_course_id];
-        }
-
-        $course = Course::find($single_course_id);
-        $course_link = url("/course/$course->slug");
+        $course_ids_arr = $request->filled('course_ids')
+            ? array_filter((array) $request->course_ids)
+            : array_filter([(int) $request->course_id]);
 
         $users = [];
         $assign_to = null;
@@ -665,6 +616,13 @@ public function courseAssignment(Request $request)
         $already_enrolled = [];
 
         foreach ($course_ids_arr as $course_id) {
+            $course = Course::find($course_id);
+
+            if (!$course) {
+                continue;
+            }
+
+            $course_link = url("/course/$course->slug");
             $course_Ass = new courseAssignment;
             // $course_Ass->title = $request->title;
             $course_Ass->course_id = $course_id;

--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -869,12 +869,19 @@ $teachers = [$teacherId];
             $course->students()->sync($students);
             // Auto subscribe into courses
             foreach ($students as $id) {
-                $data = [
-                    'user_id' => $id,
-                    'course_id' =>  $course->id,
-                    'status' => 1
-                ];
-                SubscribeCourse::updateOrCreate($data);
+                $subscription = SubscribeCourse::updateOrCreate(
+                    [
+                        'user_id' => $id,
+                        'course_id' => $course->id,
+                    ],
+                    [
+                        'status' => 1,
+                    ]
+                );
+
+                if ($subscription->wasRecentlyCreated && ($student = User::find($id))) {
+                    CourseNotification::createCourseEnrollmentBell($student, $course);
+                }
             }
             $internalStudents = \App\Models\Auth\User::whereHas('roles', function ($q) {
                 $q->where('role_id', 3)->where('employee_type', 'internal');
@@ -1184,7 +1191,7 @@ $teachers = [$teacherId];
             $course->students()->sync($students);
 
             foreach ($students as $studentId) {
-                SubscribeCourse::updateOrCreate(
+                $subscription = SubscribeCourse::updateOrCreate(
                     [
                         'user_id' => $studentId,
                         'course_id' => $course->id,
@@ -1193,6 +1200,10 @@ $teachers = [$teacherId];
                         'status' => 1,
                     ]
                 );
+
+                if ($subscription->wasRecentlyCreated && ($student = User::find($studentId))) {
+                    CourseNotification::createCourseEnrollmentBell($student, $course);
+                }
             }
         }
         

--- a/app/Notifications/Backend/CourseNotification.php
+++ b/app/Notifications/Backend/CourseNotification.php
@@ -210,6 +210,20 @@ class CourseNotification
         }
     }
 
+    public static function createCourseEnrollmentBell($user, $course)
+    {
+        UserNotification::create([
+            'user_id' => $user->id,
+            'type' => 'course_enrollment',
+            'title' => 'Course Enrollment',
+            'message' => 'You have been enrolled in a course: ' . ($course->title ?? 'Untitled') . '.',
+            'icon' => 'fas fa-book',
+            'icon_color' => 'primary',
+            'link' => $course->slug ? route('courses.show', $course->slug) : null,
+            'is_read' => false,
+        ]);
+    }
+
     // =========================================================================
     // COURSE COMPLETED
     // =========================================================================

--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -68,9 +68,14 @@
 </div>
 </li>
 @endif
-
-
-
+@php
+    $bellUnreadNotifications = auth()->check()
+        ? \App\Models\UserNotification::forUser(auth()->id())->unread()->orderBy('created_at', 'desc')->take(10)->get()
+        : collect();
+    $bellUnreadNotificationCount = auth()->check()
+        ? \App\Models\UserNotification::forUser(auth()->id())->unread()->count()
+        : 0;
+@endphp
 
     </ul>
 
@@ -79,7 +84,7 @@
         <li class="nav-item d-md-down-none dropdown">
             <a class="nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                 <i class="icon-bell"></i>
-                <span class="badge badge-pill d-none badge-danger unreadNotificationCounter"></span>
+                <span class="badge badge-pill {{ $bellUnreadNotificationCount > 0 ? '' : 'd-none' }} badge-danger unreadNotificationCounter">{{ $bellUnreadNotificationCount > 0 ? $bellUnreadNotificationCount : '' }}</span>
             </a>
             <div class="dropdown-menu dropdown-menu-right notification-dropdown" style="width: 320px; max-height: 400px; overflow-y: auto;">
                 <div class="dropdown-header text-center d-flex justify-content-between align-items-center">
@@ -88,7 +93,22 @@
                 </div>
                 <div class="dropdown-divider"></div>
                 <div class="unreadNotifications">
-                   <p class="mb-0 text-center py-3 text-muted">@lang('navs.general.no_new_notifications')</p>
+                    @forelse($bellUnreadNotifications as $notification)
+                        <a class="dropdown-item notification-item py-2" href="{{ $notification->link ?: '#' }}" data-notification-id="{{ $notification->id }}">
+                            <div class="d-flex align-items-start">
+                                <div class="mr-3"><i class="fas {{ $notification->icon }} text-{{ $notification->icon_color }}"></i></div>
+                                <div class="flex-grow-1">
+                                    <p class="font-weight-bold mb-1" style="font-size: 13px;">{{ $notification->title }}</p>
+                                    @if($notification->message)
+                                        <p class="mb-1 text-muted" style="font-size: 12px;">{{ $notification->message }}</p>
+                                    @endif
+                                    <small class="text-muted">{{ $notification->created_at->diffForHumans() }}</small>
+                                </div>
+                            </div>
+                        </a>
+                    @empty
+                        <p class="mb-0 text-center py-3 text-muted">@lang('navs.general.no_new_notifications')</p>
+                    @endforelse
                 </div>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item text-center py-2" href="{{ route('admin.notifications.index') }}">

--- a/tests/Unit/Backend/CourseEnrollmentNotificationTest.php
+++ b/tests/Unit/Backend/CourseEnrollmentNotificationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Backend;
+
+use PHPUnit\Framework\TestCase;
+
+class CourseEnrollmentNotificationTest extends TestCase
+{
+    /** @test */
+    public function course_enrollment_creates_student_facing_bell_notifications(): void
+    {
+        $notification = file_get_contents(
+            __DIR__ . '/../../../app/Notifications/Backend/CourseNotification.php'
+        );
+
+        $assessmentController = file_get_contents(
+            __DIR__ . '/../../../app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php'
+        );
+
+        $coursesController = file_get_contents(
+            __DIR__ . '/../../../app/Http/Controllers/Backend/Admin/CoursesController.php'
+        );
+
+        $header = file_get_contents(
+            __DIR__ . '/../../../resources/views/backend/includes/header.blade.php'
+        );
+
+        $this->assertStringContainsString('function createCourseEnrollmentBell($user, $course)', $notification);
+        $this->assertStringContainsString("'user_id' => \$user->id", $notification);
+        $this->assertStringContainsString("'type' => 'course_enrollment'", $notification);
+        $this->assertStringContainsString('You have been enrolled in a course:', $notification);
+        $this->assertStringContainsString("route('courses.show', \$course->slug)", $notification);
+
+        $this->assertSame(
+            4,
+            substr_count($assessmentController, 'CourseNotification::createCourseEnrollmentBell($emp, $course);')
+        );
+
+        $this->assertSame(
+            2,
+            substr_count($coursesController, 'CourseNotification::createCourseEnrollmentBell($student, $course);')
+        );
+
+        $this->assertStringContainsString('$subscription->wasRecentlyCreated', $coursesController);
+
+        $this->assertStringContainsString('$bellUnreadNotificationCount', $header);
+        $this->assertStringContainsString('UserNotification::forUser(auth()->id())->unread()', $header);
+        $this->assertStringContainsString('@forelse($bellUnreadNotifications as $notification)', $header);
+        $this->assertStringContainsString('unreadNotificationCounter', $header);
+    }
+}

--- a/tests/Unit/Backend/CourseEnrollmentNotificationTest.php
+++ b/tests/Unit/Backend/CourseEnrollmentNotificationTest.php
@@ -30,6 +30,9 @@ class CourseEnrollmentNotificationTest extends TestCase
         $this->assertStringContainsString("'type' => 'course_enrollment'", $notification);
         $this->assertStringContainsString('You have been enrolled in a course:', $notification);
         $this->assertStringContainsString("route('courses.show', \$course->slug)", $notification);
+        $this->assertStringContainsString('return $this->course_assignment($request);', $assessmentController);
+        $this->assertStringContainsString("'course_ids' => 'required_without:course_id|array'", $assessmentController);
+        $this->assertStringContainsString("\$request->filled('course_ids')", $assessmentController);
 
         $this->assertSame(
             4,


### PR DESCRIPTION
## Description

This PR fixes the student enrollment notification flow after an admin assigns users to courses.

### Problem Solved

Previously:

- The admin course assignment form could post to a duplicate route that only created `course_assignment_users`.
- That route did not create `subscribe_courses`, so the student was not actually enrolled for the My Courses page.
- Because enrollment was incomplete, the student notification bell did not reliably show an enrollment count or message.
- Existing assignment records could remain out of sync with `subscribe_courses`.

### What This PR Adds

- Routes both course assignment entry points through the same enrollment logic.
- Supports the current `course_ids[]` multi-course assignment payload while keeping legacy `course_id` support.
- Creates student-facing bell notifications when a course enrollment is created.
- Displays unread student bell notifications in the backend header.
- Adds `courses:sync-assignment-subscriptions` to backfill missing `subscribe_courses` rows from existing assignment records.
- Extends focused regression coverage for the enrollment notification and duplicate route path.

Fixes: #732

---

## Type of Change

- Bug fix

---

## Screenshots

Not included. This PR changes backend enrollment/notification flow and uses existing UI elements.

---

## How Has This Been Tested?

- Local environment
- Browser workflow with `student@lms.com`
- Focused PHPUnit regression test
- Backfill command tested locally

### Test Scenarios

- Assign a course to `student@lms.com` from admin course assignment.
- Confirm a `course_assignment_users` row is created.
- **Confirm a matching `subscribe_courses` row is created.**
- Confirm the assigned course appears in the student's My Courses query.
- **Confirm the student-facing enrollment bell notification helper is wired.**
- Run the assignment subscription backfill command for existing out-of-sync rows.

Commands run:

- `php -l app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php`
- `php -l app/Helpers/CustomHelper.php`
- `php -l app/Console/Commands/SyncCourseAssignmentSubscriptions.php`
- `php -l tests/Unit/Backend/CourseEnrollmentNotificationTest.php`
- `php vendor/bin/phpunit tests/Unit/Backend/CourseEnrollmentNotificationTest.php`
- `git diff --check`
- `php artisan courses:sync-assignment-subscriptions`

---

## Steps to Reproduce (for bug fixes)

1. Log in as admin.
2. Go to course assignment.
3. Assign a course to a student user.
4. Log in as that student.
5. Open My Courses and the notification bell.

Before this PR, the assignment path could create only `course_assignment_users`, leaving the student without a `subscribe_courses` enrollment and without a visible enrollment notification.

---

## Checklist

- Followed the project's coding guidelines
- Updated focused regression coverage
- Verified no sensitive data is included
- Ensured unrelated local files are not included in the PR

---
