### PR TITLE
fix: record attendance before live session redirect

### DIFF
--- a/app/Http/Controllers/CoursesController.php
+++ b/app/Http/Controllers/CoursesController.php
@@ -383,34 +383,9 @@ $hasFeedBack       = $subscribe_data ? ($subscribe_data->has_feedback ?? 0) : 0;
             $isScheduledCourse = in_array($course->schedule_type, ['daily', 'weekly', 'custom']);
 
             if ($isScheduledCourse && $subscribe_data && request()->has('joined')) {
-                // Scheduled course: mark per-session attendance (only within time window)
                 $joinedSessionId = request()->get('session_id');
                 if ($joinedSessionId) {
-                    $joinedSession = LiveSession::find($joinedSessionId);
-                    if ($joinedSession) {
-                        $sessionStart = Carbon::parse($joinedSession->session_date->format('Y-m-d') . ' ' . $joinedSession->session_time);
-                        $sessionEnd = $sessionStart->copy()->addMinutes((int)($joinedSession->duration ?? 60));
-                        $windowStart = $sessionStart->copy()->subMinutes(15);
-                        $now = Carbon::now();
-
-                        if ($now->between($windowStart, $sessionEnd)) {
-                            LiveSessionAttendance::firstOrCreate(
-                                ['live_session_id' => $joinedSessionId, 'user_id' => $logged_in_user_id],
-                                ['attended_at' => Carbon::now()]
-                            );
-                        }
-                    }
-                }
-
-                // Check if this is the last session (no future sessions after today)
-                $futureSessionsCount = LiveSession::where('course_id', $course->id)
-                    ->where('session_date', '>', Carbon::today())
-                    ->count();
-
-                if ($futureSessionsCount == 0 && !$subscribe_data->is_attended) {
-                    // Last session day — mark course-level attendance to trigger post-attendance flow
-                    DB::table('subscribe_courses')->where('id', $subscribe_data->id)->update(['is_attended' => 1]);
-                    $subscribe_data->is_attended = 1;
+                    $this->recordScheduledLiveSessionAttendance($course, $subscribe_data, $joinedSessionId, $logged_in_user_id);
                 }
             } elseif (!$isScheduledCourse && $subscribe_data && !$subscribe_data->is_attended && request()->has('joined')) {
                 // Single meeting: existing flow — mark attended immediately
@@ -1342,10 +1317,127 @@ if ($this->isLiveCourse($course) && $subscribe_data && $subscribe_data->due_date
             ->make();
     }
 
+    public function recordLiveSessionAttendance(Request $request, $slug)
+    {
+        $course = Course::withoutGlobalScope('filter')->where('slug', $slug)->firstOrFail();
+        $userId = Auth::id();
+        $subscribeData = SubscribeCourse::where('user_id', $userId)
+            ->where('course_id', $course->id)
+            ->where('status', 1)
+            ->first();
+
+        if (!$subscribeData) {
+            return response()->json([
+                'message' => __('You are not subscribed to this course.'),
+            ], 403);
+        }
+
+        if (!in_array($course->is_online, ['Offline', 'Live-Classroom', 'Live-Online'])) {
+            return response()->json([
+                'message' => __('This course does not have a live meeting.'),
+            ], 422);
+        }
+
+        $isScheduledCourse = in_array($course->schedule_type, ['daily', 'weekly', 'custom']);
+
+        if ($isScheduledCourse) {
+            $request->validate([
+                'session_id' => 'required|integer',
+            ]);
+
+            $session = LiveSession::where('id', $request->input('session_id'))
+                ->where('course_id', $course->id)
+                ->first();
+
+            if (!$session) {
+                return response()->json([
+                    'message' => __('Live session was not found for this course.'),
+                ], 404);
+            }
+
+            $meetingLink = $session->meeting_link;
+            if (!$meetingLink) {
+                return response()->json([
+                    'message' => __('Meeting link is missing for this session.'),
+                ], 422);
+            }
+
+            if (!$this->isLiveSessionJoinWindowOpen($session)) {
+                return response()->json([
+                    'message' => __('Join is not open for this session.'),
+                ], 422);
+            }
+
+            $this->recordScheduledLiveSessionAttendance($course, $subscribeData, $session->id, $userId);
+
+            return response()->json([
+                'meeting_link' => $meetingLink,
+            ]);
+        }
+
+        $meetingLink = $course->meeting_join_url;
+        if (!$meetingLink) {
+            return response()->json([
+                'message' => __('Meeting link is missing for this course.'),
+            ], 422);
+        }
+
+        if (!$subscribeData->is_attended) {
+            DB::table('subscribe_courses')->where('id', $subscribeData->id)->update(['is_attended' => 1]);
+        }
+
+        return response()->json([
+            'meeting_link' => $meetingLink,
+        ]);
+    }
+
+    private function recordScheduledLiveSessionAttendance($course, $subscribeData, $sessionId, $userId)
+    {
+        $session = LiveSession::where('id', $sessionId)
+            ->where('course_id', $course->id)
+            ->first();
+
+        if (!$session || !$this->isLiveSessionJoinWindowOpen($session)) {
+            return false;
+        }
+
+        try {
+            LiveSessionAttendance::firstOrCreate(
+                ['live_session_id' => $session->id, 'user_id' => $userId],
+                ['attended_at' => Carbon::now()]
+            );
+        } catch (\Illuminate\Database\QueryException $exception) {
+            if (!LiveSessionAttendance::where('live_session_id', $session->id)->where('user_id', $userId)->exists()) {
+                throw $exception;
+            }
+        }
+
+        $futureSessionsCount = LiveSession::where('course_id', $course->id)
+            ->where('session_date', '>', Carbon::today())
+            ->count();
+
+        if ($futureSessionsCount == 0 && !$subscribeData->is_attended) {
+            DB::table('subscribe_courses')->where('id', $subscribeData->id)->update(['is_attended' => 1]);
+            $subscribeData->is_attended = 1;
+        }
+
+        return true;
+    }
+
+    private function isLiveSessionJoinWindowOpen($session)
+    {
+        $sessionDate = $session->session_date instanceof Carbon
+            ? $session->session_date->format('Y-m-d')
+            : Carbon::parse($session->session_date)->format('Y-m-d');
+        $sessionStart = Carbon::parse($sessionDate . ' ' . $session->session_time);
+        $sessionEnd = $sessionStart->copy()->addMinutes((int)($session->duration ?? 60));
+
+        return Carbon::now()->between($sessionStart->copy()->subMinutes(15), $sessionEnd);
+    }
+
     private function isLiveCourse($course)
-{
-    return in_array($course->is_online, ['Live-Online', 'Live-Classroom', 'Offline']);
-}
+    {
+        return in_array($course->is_online, ['Live-Online', 'Live-Classroom', 'Offline']);
+    }
 
 }
-

--- a/resources/views/frontend/courses/offline-course.blade.php
+++ b/resources/views/frontend/courses/offline-course.blade.php
@@ -115,8 +115,12 @@
                                                 ? ($todaySession->host_url ?: $todaySession->meeting_link)
                                                 : $todaySession->meeting_link;
                                         @endphp
-                                        <a href="{{ $topUrl }}" target="_blank" class="btn btn-success btn-block text-white mb-3 text-uppercase font-weight-bold"
-                                            onclick="setTimeout(function(){ window.location.href='{{ route('courses.show', [$course->slug]) }}?joined=1&session_id={{ $todaySession->id }}'; }, 500);">
+                                        <a href="{{ (isset($isHostRole) && $isHostRole) ? $topUrl : '#' }}" @if(isset($isHostRole) && $isHostRole) target="_blank" @endif
+                                            class="btn btn-success btn-block text-white mb-3 text-uppercase font-weight-bold @if(!(isset($isHostRole) && $isHostRole)) js-live-session-join @endif"
+                                            @if(!(isset($isHostRole) && $isHostRole))
+                                                data-attendance-url="{{ route('courses.attendance', [$course->slug]) }}"
+                                                data-session-id="{{ $todaySession->id }}"
+                                            @endif>
                                             <i class="fa fa-video"></i> {{ (isset($isHostRole) && $isHostRole) ? __('Host Meeting') : __('Join Today\'s Session') }}
                                         </a>
                                     @elseif(isset($todaySession) && $todaySession && !$isWithinTimeWindow)
@@ -166,8 +170,12 @@
                                 </div>
                             </div>
                             @if($isWithinTimeWindow)
-                                <a href="{{ $sessionUrl }}" target="_blank" class="btn btn-success text-white font-weight-bold mt-2"
-                                    onclick="setTimeout(function(){ window.location.href='{{ route('courses.show', [$course->slug]) }}?joined=1&session_id={{ $todaySession->id }}'; }, 500);">
+                                <a href="{{ (isset($isHostRole) && $isHostRole) ? $sessionUrl : '#' }}" @if(isset($isHostRole) && $isHostRole) target="_blank" @endif
+                                    class="btn btn-success text-white font-weight-bold mt-2 @if(!(isset($isHostRole) && $isHostRole)) js-live-session-join @endif"
+                                    @if(!(isset($isHostRole) && $isHostRole))
+                                        data-attendance-url="{{ route('courses.attendance', [$course->slug]) }}"
+                                        data-session-id="{{ $todaySession->id }}"
+                                    @endif>
                                     <i class="fas fa-sign-in-alt"></i> {{ (isset($isHostRole) && $isHostRole) ? 'Host Meeting' : 'Join Now' }}
                                 </a>
                             @else
@@ -225,8 +233,12 @@
                                             </td>
                                             <td>
                                                 @if($sUrl && $rowInWindow && !$is_attended && !$wasAttended)
-                                                    <a href="{{ $sUrl }}" target="_blank" class="btn btn-sm btn-success text-white"
-                                                        onclick="setTimeout(function(){ window.location.href='{{ route('courses.show', [$course->slug]) }}?joined=1&session_id={{ $session->id }}'; }, 500);">
+                                                    <a href="{{ (isset($isHostRole) && $isHostRole) ? $sUrl : '#' }}" @if(isset($isHostRole) && $isHostRole) target="_blank" @endif
+                                                        class="btn btn-sm btn-success text-white @if(!(isset($isHostRole) && $isHostRole)) js-live-session-join @endif"
+                                                        @if(!(isset($isHostRole) && $isHostRole))
+                                                            data-attendance-url="{{ route('courses.attendance', [$course->slug]) }}"
+                                                            data-session-id="{{ $session->id }}"
+                                                        @endif>
                                                         <i class="fas fa-sign-in-alt"></i> {{ (isset($isHostRole) && $isHostRole) ? 'Host' : 'Join' }}
                                                     </a>
                                                 @elseif($isToday && !$rowInWindow && !$wasAttended)
@@ -359,8 +371,8 @@
                                             <i class="fa fa-video"></i> @lang('Host Meeting')
                                         </a>
                                     @elseif($sidebarJoinUrl)
-                                        <a href="{{ $sidebarJoinUrl }}" target="_blank" class="btn btn-primary btn-block text-white mb-3 text-uppercase font-weight-bold"
-                                            onclick="setTimeout(function(){ window.location.href='{{ route('courses.show', [$course->slug]) }}?joined=1'; }, 500);">
+                                        <a href="#" class="btn btn-primary btn-block text-white mb-3 text-uppercase font-weight-bold js-live-session-join"
+                                            data-attendance-url="{{ route('courses.attendance', [$course->slug]) }}">
                                             <i class="fa fa-video"></i> @lang('Join')
                                         </a>
                                     @elseif($course->is_online == 'Offline' || $course->is_online == 'Live-Classroom')
@@ -402,4 +414,80 @@
 @endsection
 
 @push('after-scripts')
+    <script>
+        (function () {
+            var joinButtons = document.querySelectorAll('.js-live-session-join');
+            var csrfToken = document.querySelector('meta[name="csrf-token"]');
+
+            joinButtons.forEach(function (button) {
+                button.addEventListener('click', function (event) {
+                    event.preventDefault();
+
+                    if (button.dataset.joining === '1') {
+                        return;
+                    }
+
+                    var attendanceUrl = button.dataset.attendanceUrl;
+                    if (!attendanceUrl) {
+                        alert(@json(__('Meeting link is missing for this session.')));
+                        return;
+                    }
+
+                    button.dataset.joining = '1';
+                    button.dataset.originalText = button.innerHTML;
+                    button.classList.add('disabled');
+                    button.setAttribute('aria-disabled', 'true');
+                    button.innerHTML = '<i class="fa fa-spinner fa-spin"></i> ' + @json(__('Joining...'));
+
+                    var payload = {};
+                    if (button.dataset.sessionId) {
+                        payload.session_id = button.dataset.sessionId;
+                    }
+
+                    fetch(attendanceUrl, {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken ? csrfToken.getAttribute('content') : ''
+                        },
+                        body: JSON.stringify(payload)
+                    })
+                        .then(function (response) {
+                            return response.text().then(function (text) {
+                                var data = {};
+                                if (text) {
+                                    try {
+                                        data = JSON.parse(text);
+                                    } catch (error) {
+                                        data = {};
+                                    }
+                                }
+
+                                if (!response.ok) {
+                                    throw new Error(data.message || @json(__('Unable to record attendance. Please try again.')));
+                                }
+
+                                return data;
+                            });
+                        })
+                        .then(function (data) {
+                            if (!data.meeting_link) {
+                                throw new Error(@json(__('Meeting link is missing for this session.')));
+                            }
+
+                            window.location.href = data.meeting_link;
+                        })
+                        .catch(function (error) {
+                            button.dataset.joining = '0';
+                            button.classList.remove('disabled');
+                            button.removeAttribute('aria-disabled');
+                            button.innerHTML = button.dataset.originalText;
+                            alert(error.message || @json(__('Unable to record attendance. Please try again.')));
+                        });
+                });
+            });
+        })();
+    </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,6 +208,7 @@ Route::get('department/{id}', [DepartmentController::class, 'show'])->name('depa
 //============Course Routes=================//
 Route::get('courses', ['uses' => 'CoursesController@all', 'as' => 'courses.all']);
 Route::get('cme-courses', ['uses' => 'CoursesController@allCme', 'as' => 'courses.allCme']);
+Route::post('course/{slug}/attendance', ['uses' => 'CoursesController@recordLiveSessionAttendance', 'as' => 'courses.attendance'])->middleware(['subscribed', 'auth']);
 Route::get('course/{slug}', ['uses' => 'CoursesController@show', 'as' => 'courses.show'])->middleware(['subscribed', 'auth']);
 Route::get('course-preview/{slug}', 'CoursesController@coursePreview')->name('coursePreview')->middleware('subscribed');
 

--- a/tests/Feature/CourseLiveSessionAttendanceApiTest.php
+++ b/tests/Feature/CourseLiveSessionAttendanceApiTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Auth\User;
+use App\Models\Course;
+use App\Models\LiveSession;
+use App\Models\LiveSessionAttendance;
+use App\Models\Stripe\SubscribeCourse;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class CourseLiveSessionAttendanceApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.key' => 'base64:' . base64_encode(str_repeat('a', 32))]);
+
+        $this->withoutMiddleware();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_records_scheduled_session_attendance_before_returning_the_meeting_link()
+    {
+        Carbon::setTestNow('2026-06-04 09:55:00');
+
+        $user = factory(User::class)->create();
+        $course = $this->course();
+        $session = $this->liveSession($course, [
+            'session_date' => '2026-06-04',
+            'session_time' => '10:00:00',
+            'meeting_link' => 'https://meet.example.com/session',
+        ]);
+        $this->subscribe($user, $course);
+
+        $response = $this->actingAs($user)->postJson(route('courses.attendance', $course->slug), [
+            'session_id' => $session->id,
+        ]);
+
+        $response->assertOk()
+            ->assertJson(['meeting_link' => 'https://meet.example.com/session']);
+
+        $this->assertDatabaseHas('live_session_attendances', [
+            'live_session_id' => $session->id,
+            'user_id' => $user->id,
+        ]);
+    }
+
+    /** @test */
+    public function it_does_not_create_duplicate_attendance_when_join_is_clicked_twice()
+    {
+        Carbon::setTestNow('2026-06-04 09:55:00');
+
+        $user = factory(User::class)->create();
+        $course = $this->course();
+        $session = $this->liveSession($course, [
+            'session_date' => '2026-06-04',
+            'session_time' => '10:00:00',
+            'meeting_link' => 'https://teams.example.com/session',
+        ]);
+        $this->subscribe($user, $course);
+
+        $this->actingAs($user)->postJson(route('courses.attendance', $course->slug), ['session_id' => $session->id])->assertOk();
+        $this->actingAs($user)->postJson(route('courses.attendance', $course->slug), ['session_id' => $session->id])->assertOk();
+
+        $this->assertSame(1, LiveSessionAttendance::where('live_session_id', $session->id)
+            ->where('user_id', $user->id)
+            ->count());
+    }
+
+    /** @test */
+    public function it_blocks_redirect_when_the_scheduled_session_has_no_meeting_link()
+    {
+        Carbon::setTestNow('2026-06-04 09:55:00');
+
+        $user = factory(User::class)->create();
+        $course = $this->course();
+        $session = $this->liveSession($course, [
+            'session_date' => '2026-06-04',
+            'session_time' => '10:00:00',
+            'meeting_link' => null,
+        ]);
+        $this->subscribe($user, $course);
+
+        $response = $this->actingAs($user)->postJson(route('courses.attendance', $course->slug), [
+            'session_id' => $session->id,
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertSame(0, LiveSessionAttendance::where('live_session_id', $session->id)->count());
+    }
+
+    /** @test */
+    public function it_marks_single_meeting_course_attendance_before_returning_the_meeting_link()
+    {
+        $user = factory(User::class)->create();
+        $course = $this->course([
+            'schedule_type' => 'single',
+            'meeting_join_url' => 'https://zoom.example.com/course',
+        ]);
+        $subscription = $this->subscribe($user, $course);
+
+        $response = $this->actingAs($user)->postJson(route('courses.attendance', $course->slug));
+
+        $response->assertOk()
+            ->assertJson(['meeting_link' => 'https://zoom.example.com/course']);
+
+        $this->assertDatabaseHas('subscribe_courses', [
+            'id' => $subscription->id,
+            'is_attended' => 1,
+        ]);
+    }
+
+    private function course(array $attributes = []): Course
+    {
+        return Course::create(array_merge([
+            'title' => 'Live Course',
+            'category_id' => 1,
+            'slug' => 'live-course-' . uniqid(),
+            'description' => 'Live course description',
+            'published' => 1,
+            'is_online' => 'Offline',
+            'schedule_type' => 'daily',
+        ], $attributes));
+    }
+
+    private function liveSession(Course $course, array $attributes = []): LiveSession
+    {
+        return LiveSession::create(array_merge([
+            'course_id' => $course->id,
+            'provider' => 'zoom',
+            'session_date' => Carbon::today()->toDateString(),
+            'session_time' => '10:00:00',
+            'meeting_link' => 'https://meet.example.com/session',
+            'duration' => 60,
+            'recurrence_type' => 'daily',
+        ], $attributes));
+    }
+
+    private function subscribe(User $user, Course $course): SubscribeCourse
+    {
+        return SubscribeCourse::create([
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'status' => 1,
+            'has_assesment' => 0,
+            'has_feedback' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## 🔧 Description

This PR updates the live-session Join button flow so LMS attendance is recorded before the user is redirected to the external meeting link.

It resolves issue #480 by introducing an explicit attendance API endpoint for course live sessions. The frontend Join action now calls that endpoint first and only redirects after the attendance response returns a valid `meeting_link`.

### Problem Solved

Previously:

- **Attendance was recorded after redirect behavior had already started** because Join links opened the external meeting and then relied on a later `?joined=1` course-page load.
- **Redirects could happen even if attendance failed** because the external meeting link was the anchor target.
- **Double-clicks could open multiple meeting redirects** because Join buttons were not locked while attendance was being recorded.
- **Missing meeting links were handled late** after the user clicked a direct meeting anchor.
- **Scheduled-session attendance logic was duplicated inside the course page-load flow** instead of being available through a dedicated attendance API boundary.

### What This PR Adds

- New authenticated route:
  - `POST /course/{slug}/attendance`
  - Route name: `courses.attendance`
- `CoursesController::recordLiveSessionAttendance()`:
  - Validates course access/subscription.
  - Validates scheduled `session_id` ownership.
  - Validates meeting link presence before redirect.
  - Enforces the existing live-session join time window.
  - Records scheduled session attendance with duplicate-safe `firstOrCreate`.
  - Marks single-meeting course attendance before returning the meeting link.
- Shared scheduled attendance helper:
  - Keeps the legacy `?joined=1&session_id=...` fallback path aligned with the new attendance endpoint.
  - Handles duplicate attendance races using the existing unique attendance constraint.
- Frontend Join flow:
  - Student Join buttons now call the attendance endpoint first.
  - The clicked button is disabled while attendance is being recorded.
  - Redirect happens only after the attendance endpoint returns `meeting_link`.
  - API failures and missing meeting links block redirect.
  - Host links remain direct because host flow uses host URLs.
- Focused feature coverage for the attendance API flow.

Fixes: #480

---

## ✅ Type of Change

- Bug fix

---

## 📸 Screenshots

N/A - logic-only flow change.

---

## 🚀 How Has This Been Tested?

- Local environment
- Focused syntax checks
- Focused PHPUnit coverage for the attendance API flow
- Staged diff whitespace check

### Test Scenarios

- Scheduled live-session attendance is recorded before the meeting link is returned.
- Repeated Join clicks do not create duplicate attendance rows.
- Missing scheduled-session meeting links return an error and block redirect.
- Single-meeting courses mark course attendance before returning the course meeting link.
- Frontend Join buttons call the attendance API before redirecting.
- Host buttons continue using direct host links.

### Commands Run

- `php -l app/Http/Controllers/CoursesController.php`
- `php -l routes/web.php`
- `php -l resources/views/frontend/courses/offline-course.blade.php`
- `php -l tests/Feature/CourseLiveSessionAttendanceApiTest.php`
- `php vendor/bin/phpunit tests/Feature/CourseLiveSessionAttendanceApiTest.php`
- `git diff --cached --check`

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Open an enrolled student's Live-Online/Offline scheduled course page during a valid join window.
2. Click a student Join button.
3. Previously, the browser opened the meeting link first and attendance depended on a delayed course-page redirect.
4. With this PR, the Join button calls the LMS attendance endpoint first.
5. Confirm attendance is recorded in `live_session_attendances`.
6. Confirm the browser redirects to the returned meeting link only after the attendance API succeeds.
7. Remove the session meeting link and confirm the redirect is blocked with an error.
8. Double-click Join and confirm only one attendance row is created.

---

## 🔄 Checklist

- Followed the project's coding guidelines
- Verified no sensitive data is included
- Ensured the app builds without errors
