### PR TITLE
Create Database Table for Languages if currently not available #448

### DIFF
--- a/app/Models/Language.php
+++ b/app/Models/Language.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Language extends Model
+{
+    protected $fillable = [
+        'name',
+        'code',
+        'is_enabled',
+        'is_default',
+    ];
+
+    /**
+     * Ensure only one default language
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($language) {
+            if ($language->is_default) {
+                self::where('id', '!=', $language->id)
+                    ->update(['is_default' => false]);
+            }
+        });
+    }
+
+    /**
+     * Get default language
+     */
+    public static function getDefault()
+    {
+        return self::where('is_default', true)->first();
+    }
+}

--- a/database/migrations/2026_06_06_144955_create_languages_table.php
+++ b/database/migrations/2026_06_06_144955_create_languages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('languages', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('languages');
+    }
+};

--- a/database/seeders/LanguageSeeder.php
+++ b/database/seeders/LanguageSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Language;
+
+
+class LanguageSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run()
+    {
+        Language::create([
+            'name' => 'English',
+            'code' => 'en',
+            'is_enabled' => true,
+            'is_default' => true,
+        ]);
+
+        Language::create([
+            'name' => 'Arabic',
+            'code' => 'ar',
+            'is_enabled' => true,
+            'is_default' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR introduces a new languages table to manage system-wide language settings.

### Problem Solved

- No centralized way to manage available languages
- No default language fallback mechanism in the system

### What This PR Adds

- Created languages table with:
     - name
     - code (unique)
     - is_enabled
     - is_default
- Ensured only one default language at a time using model logic
-  Added Language model with helper method to fetch default language
-  Added optional seeder with initial languages (English, Arabic)
      
     Fixes: #448 

---

## ✅ Type of Change

-  Bug fix
-  Documentation update

---

## 📸 Screenshots 

<img width="1916" height="912" alt="image" src="https://github.com/user-attachments/assets/709cedcf-1964-4c75-91c9-e5cae31f1779" />

---

## 🚀 How Has This Been Tested?

-  Local environment
-  Database migrations tested

###  Test Details

- Ran migration successfully
- Inserted multiple languages
- Set one language as default → verified others updated automatically
- Retrieved default language using helper method

---

## 🔄 Checklist

-  Followed the project's coding guidelines
-  Updated documentation (if needed)
-  Verified no sensitive data is included
-  Ensured the app builds without errors

---