### PR TITLE
fix: show Create User Group validation errors

### DIFF
--- a/resources/views/backend/department/create.blade.php
+++ b/resources/views/backend/department/create.blade.php
@@ -33,8 +33,7 @@
 
 @section('content')
 
-    <!-- <form action="{{ route('admin.department.store') }}" method="post" enctype="multipart/form-data"> -->
-    <form id="add-dep" method="post" enctype="multipart/form-data">
+    <form id="add-dep" action="{{ route('admin.department.store') }}" method="post" enctype="multipart/form-data" novalidate>
          @csrf()
 
          <div class="pb-3 d-flex justify-content-between align-items-center">
@@ -61,8 +60,21 @@
             <div class="card-body">
                 <div class="row">
                     <div class="col-12 form-group">
-                        <label for="title" class="control-label">Title</label>
-                        <input value="{{ old('title') }}" class="form-control" placeholder="Title" name="title" type="text" id="title">
+                        <label for="title" class="control-label">
+                            Title <span class="text-danger">*</span>
+                        </label>
+                        <input value="{{ old('title') }}"
+                               class="form-control @error('title') is-invalid @enderror"
+                               placeholder="Title"
+                               name="title"
+                               type="text"
+                               id="title"
+                               required
+                               aria-required="true"
+                               aria-describedby="title-error">
+                        <div id="title-error" class="invalid-feedback" data-required-message="The title field is required.">
+                            {{ $errors->first('title', 'The title field is required.') }}
+                        </div>
                     </div>
 
                 </div>
@@ -137,38 +149,60 @@
     $('.frm_submit').on('click', function (){
         nxt_url_val = $(this).val();
     });
+    $(document).on('input', '#add-dep [required]', function () {
+        $(this).removeClass('is-invalid');
+    });
+
     $(document).on('submit', '#add-dep', function (e) {
-    e.preventDefault();
-    hrefurl=$(location).attr("href");
-    last_part=hrefurl.substr(hrefurl.lastIndexOf('/') + 19)
-   // alert(last_part)
-    setTimeout(() => {
+        e.preventDefault();
+
+        var form = this;
+        var $form = $(form);
+        var hrefurl = $(location).attr("href");
+        var last_part = hrefurl.substr(hrefurl.lastIndexOf('/') + 19);
+
+        $form.find('.is-invalid').removeClass('is-invalid');
+        $form.find('.invalid-feedback[data-required-message]').each(function () {
+            $(this).text($(this).data('required-message'));
+        });
+
+        if (!form.checkValidity()) {
+            $form.find(':invalid').addClass('is-invalid').first().focus();
+            return;
+        }
+
         // Sync CKEditor content back to textarea before serializing
         for (var instance in CKEDITOR.instances) {
             CKEDITOR.instances[instance].updateElement();
         }
-        let data = $('#add-dep').serialize();
-        let url = '{{route('admin.department.store')}}';
-        var redirect_url=$("#feedback_index").val();
-        var redirect_url_course=$("#user-assisment").val();
-            $.ajax({
-                    type: 'POST',
-                    url: url,
-                    data: data,
-                    datatype: "json",
-                    success: function (res) {
-                    console.log(res)
-                    if(last_part == 'add_dep'){
-                        window.location.href = redirect_url_course;
-                        return;
-                    }
-                    else{
-                        window.location.href = redirect_url;
-                        return;
-                    }
+
+        $.ajax({
+            type: 'POST',
+            url: $form.attr('action'),
+            data: $form.serialize(),
+            dataType: 'json',
+            success: function () {
+                if (last_part == 'add_dep') {
+                    window.location.href = $("#user-assisment").val();
+                    return;
                 }
-                })
-            }, 100);
-        })
+
+                window.location.href = $("#feedback_index").val();
+            },
+            error: function (xhr) {
+                if (xhr.status !== 422 || !xhr.responseJSON || !xhr.responseJSON.errors) {
+                    return;
+                }
+
+                $.each(xhr.responseJSON.errors, function (field, messages) {
+                    var $field = $form.find('[name="' + field + '"]');
+                    $field.addClass('is-invalid');
+                    $field.siblings('.invalid-feedback').text(messages[0]);
+                });
+
+                $form.find('.is-invalid').first().focus();
+            }
+        });
+    });
 </script>
 @endpush

--- a/tests/Unit/Backend/DepartmentCreateValidationTest.php
+++ b/tests/Unit/Backend/DepartmentCreateValidationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Backend;
+
+use PHPUnit\Framework\TestCase;
+
+class DepartmentCreateValidationTest extends TestCase
+{
+    public function test_create_user_group_form_exposes_required_title_validation(): void
+    {
+        $view = file_get_contents(
+            __DIR__ . '/../../../resources/views/backend/department/create.blade.php'
+        );
+
+        $this->assertStringContainsString('action="{{ route(\'admin.department.store\') }}"', $view);
+        $this->assertStringContainsString('Title <span class="text-danger">*</span>', $view);
+        $this->assertStringContainsString('class="form-control @error(\'title\') is-invalid @enderror"', $view);
+        $this->assertStringContainsString('required', $view);
+        $this->assertStringContainsString('aria-required="true"', $view);
+        $this->assertStringContainsString('$errors->first(\'title\'', $view);
+        $this->assertStringContainsString('if (!form.checkValidity())', $view);
+        $this->assertStringContainsString('xhr.responseJSON.errors', $view);
+    }
+}


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR adds clear required-field guidance and validation feedback to the Create User Group form.

### Problem Solved

- The required Title field was not visually marked
- Empty submissions did not display validation feedback
- AJAX validation failures were silently discarded

### What This PR Adds

- Marks Title with a visible required-field indicator
- Adds accessible required-field attributes and inline invalid feedback
- Prevents submission until required fields are valid
- Displays server-side validation errors returned by AJAX
- Adds focused regression coverage for the form validation contract

Fixes: #781

---

## ✅ Type of Change

- Bug fix

---

## 📸 Screenshots

- Not applicable

---

## 🚀 How Has This Been Tested?

- Focused PHPUnit regression test
- PHP syntax checks
- Git diff whitespace check

### Test Details

- `/home/xheyon/tadreeblms/vendor/bin/phpunit --no-configuration tests/Unit/Backend/DepartmentCreateValidationTest.php`
- `php -l tests/Unit/Backend/DepartmentCreateValidationTest.php`
- `php -l app/Http/Requests/Admin/StoreDepartmentRequest.php`
- `git diff --check upstream/main...HEAD`

---

## 🔄 Checklist

- Followed the project's existing validation patterns
- Added focused regression coverage
- Verified no sensitive data is included
- Verified no unrelated files are included

---
