### PR TITLE
Fix: Disable debugbar in production environment

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -12,7 +12,7 @@ return [
      |
      */
 
-    'enabled' => env('DEBUGBAR_ENABLED', env('APP_DEBUG', false)),
+    'enabled' => env('DEBUGBAR_ENABLED', env('APP_DEBUG', false) && env('APP_ENV') !== 'production'),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Ensure debugbar doesn't display on production by adding an explicit check for APP_ENV !== 'production'. This prevents debugbar from being accidentally enabled online even if APP_DEBUG is set to true.

## Changes
- Modified `config/debugbar.php` line 15 to add environment check
- Debugbar will now only be enabled if APP_DEBUG is true AND APP_ENV is not 'production'

## Related Issue
Fixes #612

## Checklist
- [x] Code follows the contribution guidelines
- [x] Changes are minimal and focused
- [x] No breaking changes