### PR TITLE
Fix: Add missing calendar legend translation key

### DIFF
--- a/resources/lang/ar/calendar_page.php
+++ b/resources/lang/ar/calendar_page.php
@@ -5,6 +5,7 @@ return array(
   'legend_lessons' => 'الدروس',
   'legend_live_sessions' => 'الجلسات المباشرة (Zoom/Teams/Meet)',
   'legend_live_lesson_slots' => 'خانات الدروس المباشرة',
+  'legend_scheduled_sessions' => 'جلسات مجدولة',
   'add_schedule' => 'أضف جدولك',
   'edit_schedule' => 'عدّل جدولك',
   'schedule_name' => 'اسم الجدول:',

--- a/resources/lang/en/calendar_page.php
+++ b/resources/lang/en/calendar_page.php
@@ -5,6 +5,7 @@ return array(
   'legend_lessons' => 'Lessons',
   'legend_live_sessions' => 'Live Sessions (Zoom/Teams/Meet)',
   'legend_live_lesson_slots' => 'Live Lesson Slots',
+  'legend_scheduled_sessions' => 'Scheduled Sessions',
   'add_schedule' => 'Add Your Schedule',
   'edit_schedule' => 'Edit Your Schedule',
   'schedule_name' => 'Schedule Name:',

--- a/resources/lang/es/calendar_page.php
+++ b/resources/lang/es/calendar_page.php
@@ -5,6 +5,7 @@ return array(
   'legend_lessons' => 'Lecciones',
   'legend_live_sessions' => 'Sesiones en vivo (Zoom/Teams/Meet)',
   'legend_live_lesson_slots' => 'Franjas de lecciones en vivo',
+  'legend_scheduled_sessions' => 'Sesiones programadas',
   'add_schedule' => 'Agregar su horario',
   'edit_schedule' => 'Editar su horario',
   'schedule_name' => 'Nombre del horario:',

--- a/resources/lang/fr/calendar_page.php
+++ b/resources/lang/fr/calendar_page.php
@@ -5,6 +5,7 @@ return array(
   'legend_lessons' => 'Leçons',
   'legend_live_sessions' => 'Sessions en direct (Zoom/Teams/Meet)',
   'legend_live_lesson_slots' => 'Créneaux de leçons en direct',
+  'legend_scheduled_sessions' => 'Sessions programmées',
   'add_schedule' => 'Ajouter votre planning',
   'edit_schedule' => 'Modifier votre planning',
   'schedule_name' => 'Nom du planning :',

--- a/resources/lang/it/calendar_page.php
+++ b/resources/lang/it/calendar_page.php
@@ -5,6 +5,7 @@ return array(
   'legend_lessons' => 'Lezioni',
   'legend_live_sessions' => 'Sessioni live (Zoom/Teams/Meet)',
   'legend_live_lesson_slots' => 'Slot lezioni live',
+  'legend_scheduled_sessions' => 'Sessioni programmate',
   'add_schedule' => 'Aggiungi il tuo programma',
   'edit_schedule' => 'Modifica il tuo programma',
   'schedule_name' => 'Nome programma:',


### PR DESCRIPTION
## Summary
Add the missing 'legend_scheduled_sessions' translation key to all calendar_page language files. This ensures the calendar legend displays the proper translated text instead of the raw translation key.

## Problem
The calendar legend was displaying the raw key `calendar_page.legend_scheduled_sessions` instead of the translated text "Scheduled Sessions" because the key was missing from all language files.

## Solution
Added the missing translation key to all supported languages:
- English: "Scheduled Sessions"
- Spanish: "Sesiones programadas"
- French: "Sessions programmées"
- Arabic: "جلسات مجدولة"
- Italian: "Sessioni programmate"

## Related Issue
Fixes #623

## Files Changed
- `resources/lang/en/calendar_page.php`
- `resources/lang/es/calendar_page.php`
- `resources/lang/fr/calendar_page.php`
- `resources/lang/ar/calendar_page.php`
- `resources/lang/it/calendar_page.php`

## Checklist
- [x] All languages updated consistently
- [x] Translation keys match view usage
- [x] No breaking changes