### PR TITLE
Feat: Remove 'Preferred Language' field from registration form

### DIFF
--- a/resources/views/frontend/layouts/modals/loginModal.blade.php
+++ b/resources/views/frontend/layouts/modals/loginModal.blade.php
@@ -264,19 +264,6 @@
                                 </div>
                             </div>
 
-                            <!-- Language Select -->
-                            <div class="contact-info mb-2 plang">
-                                <label>{{ __('auth_pages.modal.preferred_language') }}</label><br>
-
-                                <label class="radio-inline mr-3 mb-0">
-                                    <input type="radio" name="fav_lang" value="english" checked> {{ __('auth_pages.modal.english') }}
-                                </label>
-
-                                <label class="radio-inline mr-3 mb-0">
-                                    <input type="radio" name="fav_lang" value="arabic"> {{ __('auth_pages.modal.arabic') }}
-                                </label>
-                            </div>
-
                             <!-- Dynamic fields -->
                             @if(config('registration_fields') != NULL)
                                 @php


### PR DESCRIPTION
## Summary
Simplified the registration form by removing the 'Preferred Language' field. Users can set their language preference later in their account settings if needed.

## Problem
The 'Preferred Language' field added unnecessary complexity to the registration process without providing significant value during signup.

## Solution
- Removed radio buttons for language selection (English/Arabic) from registration modal
- Users can still set language preferences in account settings after signup
- Reduces cognitive load during registration

## Related Issue
Fixes #791

## Files Changed
- `resources/views/frontend/layouts/modals/loginModal.blade.php`

## Testing
- [x] Registration form displays without language selection
- [x] Other registration fields work correctly
- [x] Form submission still functions

## Checklist
- [x] Follows contribution guidelines
- [x] Minimal, focused changes
- [x] No breaking changes