### PR TITLE
Refactor: Move Categories into Courses Management dropdown

### DIFF
--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -155,13 +155,6 @@
                         null == Session::get('setvaluesession') ||
                         (null !== Session::get('setvaluesession') && in_array(Session::get('setvaluesession'), [1, 2, 3]))
                     )
-                    <li class="nav-item ">
-                        <a class="nav-link {{ $request->segment(2) == 'categories' ? 'active' : '' }}"
-                            href="{{ route('admin.categories.index') }}">
-                            <i class="nav-icon fas fa-tags"></i>
-                            <span class="title">@lang('menus.backend.sidebar.categories.title')</span>
-                        </a>
-                    </li>
                 @endif
 
                 {{-- Temporarily disabled: Positions menu item hidden per issue #466 --}}
@@ -264,6 +257,12 @@
                             </a>
                             <ul class="nav-dropdown-items">
                                 @can('course_access')
+                                    <li class="nav-item ">
+                                        <a class="nav-link {{ $request->segment(2) == 'categories' ? 'active' : '' }}"
+                                            href="{{ route('admin.categories.index') }}">
+                                            <span class="title">@lang('menus.backend.sidebar.categories.title')</span>
+                                        </a>
+                                    </li>
                                     <li class="nav-item ">
                                         <a class="nav-link {{ $request->segment(2) == 'courses' ? 'active' : '' }}"
                                             href="{{ route('admin.courses.index') }}">


### PR DESCRIPTION
## Summary
Relocated the Categories menu item from a standalone position to become the first submenu item within the Courses Management dropdown menu.

## Problem
Categories was a separate menu item, but it's closely related to course management. Having it grouped separately from other course-related items created a fragmented navigation experience.

## Solution
- Moved Categories to the first position within Courses Management dropdown
- Improved information architecture by grouping related functionality
- Reduced visual clutter in the sidebar menu

## Related Issue
Fixes #777

## Files Changed
- `resources/views/backend/includes/sidebar.blade.php`

## Testing
- [x] Categories link works in dropdown
- [x] Sidebar displays correctly
- [x] Navigation routes to correct page

## Checklist
- [x] Follows contribution guidelines
- [x] Improves UX
- [x] No breaking changes