### PR TITLE
Fix: Use favicon.ico as primary favicon for browser tab icon

### DIFF
--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -16,7 +16,11 @@
     <title>@if(View::hasSection('title'))@yield('title')@else{{ app_name() }}@endif</title>
     <meta name="description" content="@yield('meta_description', config('app.name', 'Learning Management System'))">
     <meta name="author" content="@yield('meta_author', config('app.author', 'Tadreeb LMS'))">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ asset('storage/logos/' . config('favicon_image', 'popup-logo.jpg')) }}" />
+    <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}" />
+    @if(config('favicon_image') && config('favicon_image') != '')
+        @php $faviconExt = strtolower(pathinfo(config('favicon_image'), PATHINFO_EXTENSION)); @endphp
+        <link rel="icon" type="{{ in_array($faviconExt, ['png']) ? 'image/png' : 'image/x-icon' }}" href="{{ asset('storage/logos/' . config('favicon_image')) }}" />
+    @endif
     @yield('meta')
     <link rel="stylesheet" href="{{ asset('css/select2.min.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/css/fontawesome-all.css') }}">


### PR DESCRIPTION
## Summary
Fixes the browser tab favicon not displaying by using the proper `favicon.ico` file that already exists at `/public/favicon.ico`.

## Root Cause
The previous fix pointed to `popup-logo.jpg` as the favicon, but that file is the wide application logo — not a proper square favicon image. Browsers require a small square icon (typically 16x16 or 32x32 px) which is what `favicon.ico` provides.

## Changes
- Added `favicon.ico` (from `/public/favicon.ico`) as the primary browser tab icon
- Kept the configured custom favicon as an optional override if one is set
- Fixed MIME type detection: PNG files now correctly use `image/png` instead of `image/x-icon`

## Related Issue
Fixes #778

## Files Changed
- `resources/views/backend/layouts/app.blade.php`

## Testing
- [x] Browser tab icon now displays the correct app logo
- [x] Falls back gracefully if favicon.ico is missing
- [x] Custom configured favicon still works as override