### PR TITLE
fix: lessons ordering to the latest on top

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -50,6 +50,7 @@ class LessonsController extends Controller
         $lessons = Lesson::query()
             ->select('lessons.*')
             ->with(['attendance_list', 'course'])
+            ->orderBy('created_at', 'desc')
             ->where(function ($query) {
                 $query->where('live_lesson', 0)->orWhereNull('live_lesson');
             });


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the lesson ordering issue in the course lessons listing page.

Previously, lessons were not displayed in correct chronological order (newest first).
The query was not explicitly sorting lessons by creation date or position in the admin/DataTables view.

This fix ensures that lessons are properly ordered from newest to oldest using created_at sorting.

- What problem does this PR solve?
Lessons were not ordered correctly in the admin/course view.

- What feature does it add?
Consistent ordering of lessons (newest → oldest).

- What issue does it close (if any)?
Fixes UI/UX inconsistency in lesson listing.

Fixes: # (815)

---

## Video Proof

https://github.com/user-attachments/assets/dbf41b5d-5f66-4931-8ceb-21e0df23b158



## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1- Go to Admin → Lessons page
2- Add a lesson →  Observe lesson order
3- Confirm lessons are now sorted by newest first

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [x] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This fix only affects the listing order in the admin/DataTables view and does not affect lesson navigation inside the course flow.
