### PR TITLE
Fix: Use SubscribeCourse model in subscription restore and delete methods

### DIFF
--- a/app/Http/Controllers/Backend/Admin/SubscriptionController.php
+++ b/app/Http/Controllers/Backend/Admin/SubscriptionController.php
@@ -97,7 +97,7 @@ class SubscriptionController extends Controller
                 */
                 if ($has_delete) {
                     $delete = view('backend.datatable.action-delete')
-                        ->with(['route' => route('admin.subscription.destroy', ['page' => $q->id])])
+                        ->with(['route' => route('admin.subscription.destroy', ['id' => $q->id])])
                         ->render();
                     $view .= $delete;
                 }
@@ -307,7 +307,7 @@ class SubscriptionController extends Controller
         if (!Gate::allows('page_delete')) {
             return abort(401);
         }
-        $page = Department::onlyTrashed()->findOrFail($id);
+        $page = SubscribeCourse::onlyTrashed()->findOrFail($id);
         $page->restore();
 
         return redirect()->route('admin.subscription.index')->withFlashSuccess(trans('alerts.backend.general.restored'));
@@ -324,7 +324,7 @@ class SubscriptionController extends Controller
         if (!Gate::allows('page_delete')) {
             return abort(401);
         }
-        $page = Department::onlyTrashed()->findOrFail($id);
+        $page = SubscribeCourse::onlyTrashed()->findOrFail($id);
         $page->forceDelete();
 
         return redirect()->route('admin.subscription.index')->withFlashSuccess(trans('alerts.backend.general.deleted'));


### PR DESCRIPTION
## Summary
Fixed a critical bug where the subscription Trash page crashed with a database error because the restore and permanent delete methods were querying the wrong database model.

## Root Cause
The `restore()` and `perma_del()` methods in `SubscriptionController` were using `Department::onlyTrashed()` instead of `SubscribeCourse::onlyTrashed()`. This caused the methods to look in the `departments` table instead of the `subscribe_courses` table, resulting in a database error — especially when the trash page was empty or the record didn't exist in that table.

## Changes
- `restore()`: Changed `Department::onlyTrashed()` → `SubscribeCourse::onlyTrashed()`
- `perma_del()`: Changed `Department::onlyTrashed()` → `SubscribeCourse::onlyTrashed()`
- `getData()`: Fixed route parameter from `['page' => $q->id]` → `['id' => $q->id]` to match updated route definitions

## Related Issue
Fixes #585

## Files Changed
- `app/Http/Controllers/Backend/Admin/SubscriptionController.php`

## Testing
- [x] Trash page loads correctly even when empty
- [x] Records can be restored from Trash
- [x] Records can be permanently deleted from Trash
- [x] No breaking changes to existing functionality