### PR TITLE
Lesson Dropdown Not Populating & No Question Count Indicator in Quiz/…

### DIFF
--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -52,7 +52,10 @@ class TestQuestionController extends Controller
 
     public function create(Request $request, $course_id = null, $temp_id = null)
     {
-        $course_id = $course_id ?? $request->course_id;
+        $course_id = $request->input('course_id')
+            ?? $course_id
+            ?? optional(Test::find($request->test_id))->course_id
+            ?? optional(Test::find($request->input('test_id')))->course_id;
         $temp_id = $temp_id ?? $request->uuid; 
         $legacy_test_id = (int) $request->input('test_id');
         $selected_test = $legacy_test_id > 0 ? Test::find($legacy_test_id) : null;
@@ -68,13 +71,25 @@ class TestQuestionController extends Controller
         }
 
         $lessons = $course_id
-            ? Lesson::where('course_id', $course_id)
-                ->where('published', 1)
+            ? Lesson::query()
+                ->where('course_id', $course_id)
+                ->where(function ($q) {
+                     $q->where('published', 1)
+                        ->orWhereNull('published'); // fallback for old data
+                })
+                ->withCount([
+                    'questions as questions_count' => function ($query) {
+                        $query->whereNull('deleted_at');
+                    }
+                ])
                 ->orderBy('position')
                 ->orderBy('id')
-                ->get(['id', 'title'])
-            : collect();
-
+                ->get([
+                    'id',
+                    'title',
+                    'course_id'
+                ])
+            : collect([])->values();
         $lesson_id_preselect = $request->input('lesson_id');
         $lock_lesson_selection = $request->filled('lesson_id');
 
@@ -295,26 +310,26 @@ class TestQuestionController extends Controller
         }
     }
 
-    if ($request->action_btn == 'save_and_add_more') {
-        if ($legacy_test_id > 0 && !$lesson_id) {
-            $params = ['test_id=' . $legacy_test_id];
-            if ($course_id) {
-                $params[] = 'course_id=' . $course_id;
-            }
-            if (!empty($request->temp_id)) {
-                $params[] = 'uuid=' . urlencode($request->temp_id);
-            }
-            if ($lesson_id) {
-                $params[] = 'lesson_id=' . $lesson_id;
-            }
-            $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);
-        } else {
-            $redirect_url = route('admin.test_questions.create', [$course_id, $request->temp_id]);
-            if ($lesson_id) {
-                $redirect_url .= '?lesson_id=' . $lesson_id;
-            }
-        }
+if ($request->action_btn == 'save_and_add_more') {
+
+    $params = [
+        'course_id=' . $course_id,
+    ];
+
+    if ($lesson_id !== null) {
+        $params[] = 'lesson_id=' . ($lesson_id ?? 0);
     }
+
+    if (!empty($request->temp_id)) {
+        $params[] = 'uuid=' . urlencode($request->temp_id);
+    }
+
+    if ($legacy_test_id > 0) {
+        $params[] = 'test_id=' . $legacy_test_id;
+    }
+
+    $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);
+} 
 
     Course::where('id', $course_id)->update([
         'current_step' => 'question-added'

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-
+use App\Models\Question;
 //use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 //use Spatie\MediaLibrary\HasMedia\HasMedia;
 use Illuminate\Support\Facades\File;
@@ -142,6 +142,14 @@ class Lesson extends Model
     public function course()
     {
         return $this->belongsTo(Course::class);
+    }
+
+    public function questions()
+    {
+        return $this->hasMany(
+            Question::class,
+            'lesson_id'
+        );
     }
 
     public function test()

--- a/resources/views/backend/test_questions/create.blade.php
+++ b/resources/views/backend/test_questions/create.blade.php
@@ -404,9 +404,17 @@
                                 <select class="form-control custom-select-box" id="lesson_id_select">
                                     <option value="">-- Final Assessment (No Lesson) --</option>
                                     @foreach($lessons as $lsn)
-                                        <option value="{{ $lsn->id }}" @if((int)($lesson_id_preselect ?? 0) === (int)$lsn->id) selected @endif>
+                                        <option value="{{ $lsn->id }}"
+                                        @if((int)($lesson_id_preselect ?? 0)===(int)$lsn->id)
+                                            selected
+                                        @endif
+                                        >
+
                                             {{ $lsn->title }}
+                                        ({{ $lsn->questions_count ?? 0 }} Questions)
+
                                         </option>
+
                                     @endforeach
                                 </select>
                                 <span class="custom-select-icon"><i class="fa fa-chevron-down"></i></span>


### PR DESCRIPTION
# 📥 Pull Request: Fix Lesson Dropdown Not Populating & Add Question Count Indicator

## 🔧 Description

This PR fixes critical issues in the Quiz/Question Bank module related to lesson selection and visibility of question distribution.

### 🐞 Problem Solved
- Lesson dropdown was not consistently populating with all lessons under a course
- No visibility of question count per lesson
- Poor usability while mapping questions to lessons

### ✨ Changes Introduced
- Fixed lesson dropdown binding to ensure all lessons are displayed correctly
- Ensured lessons are always fetched using `course_id`
- Added question count display per lesson (e.g., `Lesson 1 (5 Questions)`)
- Improved UI consistency in lesson selection flow
- Enhanced lesson mapping reliability during "Save & Add More"

### 🔗 Fixes Issue
Fixes: #816

---

## ✅ Type of Change

- [x] 🐞 Bug fix
- [x] 🎨 UI/UX update
- [x] ♻️ Code refactor

---

## 📸 Screenshots

<img width="1917" height="896" alt="image" src="https://github.com/user-attachments/assets/9b45ae8f-82cf-4a33-9b5d-50730d8976c5" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Multiple course scenarios
- [x] Multiple lessons validation
- [x] Save & Add More flow tested

---

## 🧪 Steps to Reproduce

1. Login as admin  
   URL: http://dev.tadreeblms.com/  
   Username: testadmin@tadreeblms.com  
   Password: 123456  

2. Navigate to:  
   Course Management → Courses → Add Course  

3. Select:
   - E-learning type
   - Click "Next"

4. Create multiple lessons and proceed

5. Navigate to Questions section

6. Select lessons and add questions

7. Click "Save & Add More" and observe dropdown behavior

---

## ❌ Actual Result

- Lesson dropdown appears empty or partially populated
- No question count per lesson
- Difficult to track question distribution

---

## 🎯 Expected Result

- All lessons should be visible in dropdown
- Each lesson should display question count:
  - Example: `Checking-1 (5 Questions)`
- Admin should be able to easily:
  - Select lesson
  - Track question distribution

---

## 💥 Impact

- 🚫 Incorrect quiz configuration risk
- 📉 Poor UX in question mapping
- ⚠️ Lack of visibility in assessment setup

---

## 🛠️ Suggested Fix

- Ensure lessons are fetched correctly using `course_id`
- Fix dropdown data binding issues
- Add dynamic question count per lesson
- Validate behavior across multiple courses and lessons

---

## 🙏 Additional Notes

This fix significantly improves usability in the Question Bank module and ensures correct mapping of questions to lessons without confusion.