### PR TITLE
Remove Unused Navigation Elements from UI #814

### DIFF
--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -43,7 +43,7 @@
 
 //echo '<pre>';print_r(Auth::user());
 @endphp
-@if(Auth::user()->isAdmin())
+<!-- @if(Auth::user()->isAdmin())
 <li class="nav-item px-3 dropdown">
 <a class="nav-link dropdown-toggle nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
 <span class="d-md-down-none">
@@ -67,7 +67,7 @@
 <small><a href="{{ route('admin.setvaluesession',3) }}" class="dropdown-item">@lang('menus.backend.sidebar.external')</a></small>
 </div>
 </li>
-@endif
+@endif -->
 @php
     $bellUnreadNotifications = auth()->check()
         ? \App\Models\UserNotification::forUser(auth()->id())->unread()->orderBy('created_at', 'desc')->take(10)->get()
@@ -148,10 +148,10 @@
               <strong>@lang('navs.general.account')</strong>
             </div>
 
-            <a class="dropdown-item" href="{{route('admin.messages')}}">
+            <!-- <a class="dropdown-item" href="{{route('admin.messages')}}">
               <i class="fa fa-envelope"></i> @lang('navs.general.messages')
               <span class="badge unreadMessageCounter d-none badge-success">5</span>
-            </a>
+            </a> -->
 
             <a class="dropdown-item" href="{{ route('admin.account') }}">
               <i class="fa fa-user"></i> @lang('navs.general.profile')


### PR DESCRIPTION
# 🧹 Enhancement: Remove Unused Navigation Elements from UI (General Menu & Messages Link)

## 🔧 Description

This pull request removes unused navigation elements from the user interface to improve usability and reduce navigation clutter.

### Changes Made

* Removed the **General** dropdown menu from the top navigation bar.
* Removed the **Messages** link from the user profile dropdown menu.
* Preserved all underlying routes and functionality to avoid unintended side effects.
* Verified that no dependencies rely on these navigation entries.

Fixes: #814 

---

## ✅ Type of Change

* [x] ✨ New feature
* [x] ♻️ Refactoring

---

## 🧪 Testing

### Verified

* [x] General menu no longer appears in the top navbar
* [x] Messages option no longer appears in the profile dropdown
* [x] Existing navigation items continue to function correctly
* [x] No console errors introduced
* [x] No backend errors introduced

---

## 📸 Screenshot

<img width="1912" height="911" alt="image" src="https://github.com/user-attachments/assets/b36b0b85-ac1b-40b3-9302-0faf8dc4ed4b" />

---

## 📈 Impact

* Improved UI clarity and usability.
* Reduced navigation clutter.
* Prevented access to unused modules through UI navigation.
* Maintained existing application stability.

---

## Checklist

* [x] Code follows project coding standards.
* [x] Tested locally.
* [x] No breaking changes introduced.
* [x] Ready for review.
