### PR TITLE
Missing Mandatory Field Indicator for Role Name on Add Role Page #810

### DIFF
--- a/resources/views/backend/roles/create.blade.php
+++ b/resources/views/backend/roles/create.blade.php
@@ -15,7 +15,9 @@
             @endif
 
             <div class="mb-3">
-                <label for="name" class="form-label">{{ __('admin_pages.roles.role_name') }}</label>
+                <label for="name" class="form-label">{{ __('admin_pages.roles.role_name') }}
+                    <span class="required"></span>
+                </label>
                 <input type="text" name="name" id="name" class="form-control" value="{{ $role->name ?? old('name') }}" required>
             </div>
 


### PR DESCRIPTION
# 🐞 Missing Mandatory Field Indicator for Role Name on Add Role Page

## 🔧 Description

This pull request adds a mandatory field indicator (*) to the Role Name field on the Add Role page.

Currently, the Role Name field is required by validation but does not display a visual indicator informing users that it is mandatory. This change aligns the page with existing application form conventions and improves usability.

Fixes: #810 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 🧪 Testing

### Verified

* [x] Role Name field displays mandatory indicator (*)
* [x] UI remains consistent with other required fields
* [x] Existing validation continues to work correctly
* [x] No layout or styling issues introduced

---

## Screenshots

<img width="1907" height="902" alt="image" src="https://github.com/user-attachments/assets/a69836ab-7e50-47bf-a621-196c1b06e878" />


---

## 📈 Impact

* Improves user experience.
* Ensures consistency across application forms.
* Reduces confusion during role creation.

---

## Checklist

* [x] Code follows project coding standards.
* [x] Tested locally.
* [x] No breaking changes introduced.
* [x] Ready for review.
