### PR TITLE
Context-Blind Deletion Confirmation Modal in Roles Management #811

### DIFF
--- a/resources/views/backend/roles/index.blade.php
+++ b/resources/views/backend/roles/index.blade.php
@@ -31,8 +31,14 @@
                             <form action="{{ route('admin.roles.destroy', $role->id) }}"
                                 method="POST" class="d-inline">
                                 @csrf @method('DELETE')
-                                <button class="btn btn-sm btn-danger"
-                                    onclick="return confirm('{{ __('admin_pages.roles.delete_role_confirm') }}')">{{ __('admin_pages.roles.delete') }}</button>
+                                <button type="button"
+                                        class="btn btn-sm btn-danger delete-role-btn"
+                                        data-toggle="modal"
+                                        data-target="#deleteRoleModal"
+                                        data-role-name="{{ $role->name }}"
+                                        data-delete-url="{{ route('admin.roles.destroy', $role->id) }}">
+                                    {{ __('admin_pages.roles.delete') }}
+                                </button>
                             </form>
                         @endif
                     </td>
@@ -42,4 +48,67 @@
         </table>
     </div>
 </div>
+<!-- Delete Role Modal -->
+<div class="modal fade" id="deleteRoleModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+
+            <div class="modal-header">
+                <h5 class="modal-title">Delete Role</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+
+            <form id="deleteRoleForm" method="POST">
+                @csrf
+                @method('DELETE')
+
+                <div class="modal-body">
+                    <p id="deleteRoleMessage"></p>
+
+                    <div class="alert alert-warning">
+                        <strong>Warning:</strong>
+                        This action may affect users currently assigned to this role and cannot be undone.
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn btn-secondary"
+                            data-dismiss="modal">
+                        Cancel
+                    </button>
+
+                    <button type="submit" class="btn btn-danger">
+                        Delete Role
+                    </button>
+                </div>
+            </form>
+
+        </div>
+    </div>
+</div>
 @endsection
+@push('after-scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+
+    const deleteButtons = document.querySelectorAll('.delete-role-btn');
+
+    deleteButtons.forEach(button => {
+
+        button.addEventListener('click', function () {
+
+            const roleName = this.dataset.roleName;
+            const deleteUrl = this.dataset.deleteUrl;
+
+            document.getElementById('deleteRoleMessage').innerHTML =
+                `Are you sure you want to delete the <strong>${roleName}</strong> role?<br>`;
+
+            document.getElementById('deleteRoleForm').action = deleteUrl;
+        });
+
+    });
+
+});
+</script>
+@endpush


### PR DESCRIPTION
# 🐞 Context-Blind Deletion Confirmation Modal in Roles Management

## 🔧 Description

This pull request improves the role deletion confirmation modal by providing contextual information about the role being deleted and highlighting the potential impact of the action.

### Changes Made

* Display the specific role name within the confirmation modal.
* Add a warning message indicating that deleting the role may affect users currently assigned to it.
* Improve clarity around the irreversible nature of the action.
* Preserve existing deletion functionality and backend behavior.

Fixes: #811 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 🧪 Testing

### Verified

* [x] Confirmation modal displays the selected role name.
* [x] Warning message is shown before deletion.
* [x] Cancel action works correctly.
* [x] Delete action works correctly.
* [x] No regressions introduced in role management.

---

## Screenshot : 

<img width="1915" height="908" alt="image" src="https://github.com/user-attachments/assets/cd2ea828-418b-462c-a93d-f70bbb91f7d1" />

---

## ✅ Expected Result

* Confirmation modal clearly identifies the role being deleted.
* Warning about potential impact on assigned users is displayed.
* Users receive sufficient context before confirming deletion.

---

## 📈 Impact

* Reduces risk of accidental deletions.
* Improves administrative decision-making.
* Aligns destructive actions with UX best practices.
* Enhances system usability and safety.

---

## Checklist

* [x] Code follows project coding standards.
* [x] Tested locally.
* [x] No breaking changes introduced.
* [x] Ready for review.
