### PR TITLE
Fix incorrect placeholder text in category dropdown on create course page (#807)

### DIFF
--- a/resources/views/backend/courses/edit.blade.php
+++ b/resources/views/backend/courses/edit.blade.php
@@ -1030,7 +1030,7 @@
             });
 
             $(".js-example-placeholder-single").select2({
-                placeholder: "Select Teacher",
+                placeholder: "Select Category",
                 allowClear: false
             });
 


### PR DESCRIPTION
## Description

This PR fixes the placeholder text displayed in the Category dropdown on the Create Course page.

### Issue (#807 )

The Category dropdown was incorrectly showing "Select Teacher" as its placeholder text, which could confuse administrators during course creation.

### Fix

* Updated the Category dropdown placeholder from "Select Teacher" to "Select Category".
* Verified that the change only affects the Category field and maintains consistency with the form's purpose.

### Result

Administrators now receive accurate guidance when selecting a course category, improving form clarity and usability.

Fixes #<807>
