### PR TITLE
Mark mandatory fields on Edit Trainer form

### DIFF
--- a/resources/views/backend/teachers/edit.blade.php
+++ b/resources/views/backend/teachers/edit.blade.php
@@ -39,7 +39,7 @@
 
                 <!-- ID Number -->
                 <div class="col-lg-6 mt-3">
-                    <label>Id Number</label>
+                    <label>Id Number <span style="color: red;">*</span></label>
                     <input type="text"
                            name="id_number"
                            class="form-control"
@@ -49,7 +49,7 @@
 
                 <!-- First Name -->
                 <div class="col-lg-6 mt-3">
-                    <label>First Name</label>
+                    <label>First Name <span style="color: red;">*</span></label>
                     <input type="text"
                            name="first_name"
                            class="form-control"
@@ -59,7 +59,7 @@
 
                 <!-- Last Name -->
                 <div class="col-lg-6 mt-3">
-                    <label>Last Name</label>
+                    <label>Last Name <span style="color: red;">*</span></label>
                     <input type="text"
                            name="last_name"
                            class="form-control"
@@ -102,7 +102,7 @@
 
                 <!-- Gender -->
                 <div class="col-lg-6 mt-3">
-                    <label>Gender</label><br>
+                    <label>Gender <span style="color: red;">*</span></label><br>
                     <label>
                         <input type="radio"
                                name="gender"


### PR DESCRIPTION
## 🔧 Description

The Edit Trainer page (User Management → Trainers → Edit) showed no visual indicator for required fields, unlike the Create Trainer page. Users couldn't tell which inputs were mandatory, increasing the risk of incomplete submissions and breaking consistency with other forms.

Fixes: #782 

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

<img width="1895" height="820" alt="image" src="https://github.com/user-attachments/assets/bd62dbc8-84eb-45e9-9718-5230bded72d8" />

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [x] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:
- [ ] 
Verified the Edit Trainer page renders the red `*` next to Id Number, First Name, Last Name, and Gender, matching the Create Trainer page. This is a view-only change (a single Blade template); no logic, routes, or migrations were touched.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log into the Admin Panel.
2. Navigate to User Management → Trainers.
3. Select a trainer and click **Edit**.
4. **Before:** required fields (Id Number, First Name, Last Name, Gender) had no asterisk/indicator.
   **After:** these fields now display a red `*`, consistent with the Create Trainer form.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

- Fields marked match what's actually required: `id_number` (HTML `required`) plus `first_name`, `last_name`, and `gender` (enforced by `UpdateTeachersRequest`).
- Email is `readonly` and Password is optional on edit (blank = keep current), so neither is marked — consistent with the Create form.
- Only the `*` indicator markup was added; no new hardcoded/translatable strings were introduced, per the CONTRIBUTING.md translation guidelines.
- Closes #782
