### PR TITLE
Course Creator Automatically Enrolled as Trainee Upon Course Creation…

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -835,12 +835,15 @@ $teachers = [$teacherId];
 
             $course->teachers()->sync($teachers);
 
-            $internalStudents = \Auth::user()->isAdmin() ? (array)$request->input('internalStudents') : [\Auth::user()->id];
-            $externalStudents = \Auth::user()->isAdmin() ? (array)$request->input('externalStudents') : [\Auth::user()->id];
+            $internalStudents = (array) $request->input('internalStudents', []);
+            $externalStudents = (array) $request->input('externalStudents', []);
 
             //dd($internalStudents, $externalStudents);
 
-            $students = array_merge($internalStudents, $externalStudents);
+            $students = array_values(array_unique(array_filter(array_merge(
+                $internalStudents,
+                $externalStudents
+            ))));
             $course->students()->sync($students);
             // Auto subscribe into courses
             foreach ($students as $id) {


### PR DESCRIPTION
# 📥 Pull Request

## 🔧 Description

This PR fixes an issue where the course creator was being automatically enrolled as a trainee upon course creation, even when no users were explicitly selected.

### 🐞 Problem
- Course creator was being added to enrolled trainees list automatically
- This affected reporting accuracy and role separation

### ✨ Solution
- Removed fallback logic that injected `Auth::user()->id` into student enrollment arrays
- Ensured only explicitly selected internal/external students are enrolled
- Added safeguard to prevent accidental self-enrollment of course creator

Fixes: #832

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1901" height="912" alt="image" src="https://github.com/user-attachments/assets/9c334e4e-8242-4639-9c7c-34a5a52f24d6" />


---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Manual course creation flow tested

---

## 🧪 Steps to Reproduce (before fix)

1. Login as course creator
2. Create a course
3. Do NOT select any students
4. Check enrolled trainee list → creator appears

---

## 🧪 Steps to Verify Fix

1. Create a course without selecting students
2. Confirm no users are enrolled
3. Ensure creator does not appear in trainee list

---

## 🔄 Checklist

- [x] Followed project coding guidelines
- [x] Verified no unintended enrollments occur
- [x] Ensured course creation still works for admin and non-admin users
- [x] No breaking changes introduced

---

## 🙏 Additional Notes

This fix improves data integrity between course creation and enrollment logic, ensuring enrollment only happens via explicit selection.