### PR TITLE
Missing Mandatory Indicator (*) for Meeting Provider Field in E-Live …

### DIFF
--- a/resources/views/backend/courses/create.blade.php
+++ b/resources/views/backend/courses/create.blade.php
@@ -486,7 +486,9 @@
                                     <div class="row">
                                         <div class="col-md-6 form-group">
                                             <label
-                                                for="meeting_provider">{{ __('course_pages.admin_create.meeting_provider') }}</label>
+                                                for="meeting_provider">{{ __('course_pages.admin_create.meeting_provider') }}
+                                                <span class="required"></span> 
+                                            </label>
                                             <select name="meeting_provider" id="meeting_provider" class="form-control">
                                                 <option value="">Select</option>
                                                 @foreach($meetingProviderOptions as $key => $label)


### PR DESCRIPTION
# 🐞 Missing Mandatory Field Indicator for "Meeting Provider" Field in E-Live Course Type

## 🔧 Description

This pull request adds a mandatory field indicator (*) to the "Meeting Provider" Field in E-Live Course Type.

Currently, the Meeting provider field is required by validation but does not display a visual indicator informing users that it is mandatory. This change aligns the page with existing application form conventions and improves usability.

Fixes: #846 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 🧪 Testing

### Verified

* [x] Meeting provider field displays mandatory indicator (*)
* [x] UI remains consistent with other required fields
* [x] Existing validation continues to work correctly
* [x] No layout or styling issues introduced

---

## Screenshots

<img width="1902" height="912" alt="image" src="https://github.com/user-attachments/assets/bd8c1f0d-9df5-4023-a948-47af52315616" />


---

## 📈 Impact

* Improves user experience.
* Ensures consistency across application forms.
* Reduces confusion during role creation.

---

## Checklist

* [x] Code follows project coding standards.
* [x] Tested locally.
* [x] No breaking changes introduced.
* [x] Ready for review.
