### PR TITLE
Incorrect Label Import User Group Displayed on Internal Trainee Page …

### DIFF
--- a/resources/lang/en/admin_pages.php
+++ b/resources/lang/en/admin_pages.php
@@ -81,7 +81,7 @@ return array(
     'page_title' => 'Trainees',
     'title' => 'Trainees',
     'add_more_trainees' => 'Add More Trainees',
-    'import_department' => 'Import User Group',
+    'import_department' => 'Import Internal Trainee',
     'import' => 'Import',
     'download_sample_excel' => 'Download Sample Excel',
     'employee_id' => 'Employee Id',


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This pull request fixes an incorrect label displayed on the Internal Trainee (Employee) import section.

- The current label shows "Import User Group", which is misleading and does not match the module context.
- This PR updates the label to a more accurate and meaningful value such as "Import Internal Trainee".
- Ensures consistency between UI text and actual module functionality in the Internal Trainee management page.

Fixes: #842  

---

## ✅ Type of Change

- [x] 🐞 Bug fix  
- [x] 🎨 UI/UX update  

---

## 📸 Screenshots (if applicable)

<img width="1907" height="905" alt="image" src="https://github.com/user-attachments/assets/00267901-d433-49b0-ba5a-48c7deffb251" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment  
- [x] Browser testing  

Verified on Internal Trainee master list page that:
- Label is updated correctly
- Import functionality works as expected
- No side effects on existing employee/trainee import flow

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin  
2. Navigate to User Management → Trainee module  
3. Open Internal Trainee master list page  
4. Locate import section  
5. Observe incorrect label "Import User Group"  
6. Apply fix and verify updated label  

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines  
- [x] Updated UI label through proper translation key  
- [x] Verified no functional regression in import feature  
- [x] Ensured consistent naming across module  
- [x] App builds without errors  

---

## 🙏 Additional Notes

This fix improves UI clarity and ensures consistent naming conventions across admin modules. Future improvements may include standardizing all import-related translation keys to avoid similar mismatches.