### PR TITLE
Add Download Sample File Link to Import Modules #841

### DIFF
--- a/app/Exports/DepartmentTemplateExport.php
+++ b/app/Exports/DepartmentTemplateExport.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\FromArray;
+
+class DepartmentTemplateExport implements FromArray
+{
+    public function array(): array
+    {
+        return [
+            ['title'],
+            ['Human Resources'],
+            ['Information Technology'],
+            ['Finance'],
+        ];
+    }
+}

--- a/app/Http/Controllers/Backend/Admin/DepartmentController.php
+++ b/app/Http/Controllers/Backend/Admin/DepartmentController.php
@@ -15,6 +15,7 @@ use App\Imports\DepartmentImport;
 use Config;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Str;
+use App\Exports\DepartmentTemplateExport;
 
 
 class DepartmentController extends Controller
@@ -133,6 +134,14 @@ class DepartmentController extends Controller
 
     }
 
+
+    public function downloadTemplate()
+    {
+        return Excel::download(
+            new DepartmentTemplateExport(),
+            'user-group-import-template.xlsx'
+        );
+    }
 
     /**
      * Store a newly created resource in storage.

--- a/resources/views/backend/department/index.blade.php
+++ b/resources/views/backend/department/index.blade.php
@@ -5,12 +5,19 @@
 @push('after-styles')
     <link rel="stylesheet" href="{{ asset('assets/css/colors/switch.css') }}">
        <style>
-        .dropdown-menu{
-            padding: 5px;
-        }
-      .dropdown-item{
-        border-bottom: none;
-      }
+            .dropdown-menu{
+                padding: 5px;
+            }
+            .dropdown-item{
+                border-bottom: none;
+            }
+            .download-template-btn {
+                white-space: nowrap;
+            }
+            .custom-file-upload-wrapper {
+                min-width: 380px;
+            }
+
    
     </style>
 @endpush
@@ -68,6 +75,12 @@
                                     value="submit">
                                 @lang('Import')
                             </button>
+
+                            <a href="{{ route('admin.department.template.download') }}"
+                                class="btn btn-light border ml-3 download-template-btn">
+                                    <i class="fa fa-download"></i>
+                                    Download Template
+                            </a>
 
                         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,13 @@ use App\Http\Controllers\Backend\Admin\TestQuestionController;
 use App\Http\Controllers\Frontend\Auth\LoginController;
 use App\Ldap\LdapUser;
 use LdapRecord\Container;
+use App\Http\Controllers\Backend\Admin\DepartmentController as AdminDepartmentController;
+
+Route::get(
+    'user/department/template/download',
+    [AdminDepartmentController::class, 'downloadTemplate']
+)->name('admin.department.template.download');
+
 Route::get('/admin/course-assignment', [AssessmentController::class,'index'])
 ->name('admin.course.assign');
 Route::get('admin/asmnt_0_withcourse', [AssessmentAccountsController::class, 'createWithCourse']);


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR adds a downloadable template for the User Group import functionality.

Previously, users were required to upload import files without any reference to the expected file structure, resulting in frequent upload errors and validation failures. This enhancement introduces a Download Template option adjacent to the upload field, allowing users to download a pre-formatted template before importing data.

### Changes Implemented

* Added a downloadable import template file.
* Added a new route and controller method for template download.
* Added a "Download Template" button beside the import upload field.
* Included sample headers and example data matching the import schema.
* Improved user guidance and reduced import-related errors.

Fixes: #841 

---

## ✅ Type of Change

* [x] 🐞 Bug fix
* [x] ✨ New feature

---

## 🧪 Testing

### Tested Scenarios

* Download Template button is displayed in the User Group import section.
* Clicking Download Template downloads the correct file.
* Template contains required columns and sample data.
* Existing import functionality remains unaffected.
* Imported data using the provided template uploads successfully.

---

## 📸 Screenshots 

<img width="1912" height="922" alt="image" src="https://github.com/user-attachments/assets/e16c2cd8-ed59-410a-ab55-c3b64a6206dc" />

---

## 📋 Checklist

* [x] Code follows project coding standards.
* [x] Existing functionality remains unaffected.
* [x] Tested locally.
* [x] No console errors introduced.
* [x] Template structure matches backend import schema.

---

## 💥 Impact

### Before

* High chance of upload errors.
* Users uncertain about required columns.
* Increased validation failures.
* Poor user experience.

### After

* Clear import guidance.
* Reduced upload failures.
* Faster and more accurate data imports.
* Improved user experience.
