### PR TITLE
Latest Records Not Displayed First in Administrative Data Grid #838

### DIFF
--- a/app/Http/Controllers/Backend/CertificateController.php
+++ b/app/Http/Controllers/Backend/CertificateController.php
@@ -54,8 +54,13 @@ class CertificateController extends Controller
     {
         abort_unless($this->hasCertificatePermission('certificate_access'), 403);
 
-        $query = Certificate::query()->with(['user:id,first_name,last_name,email', 'course:id,title']);
-
+        $query = Certificate::query()
+        ->with([
+            'user:id,first_name,last_name,email',
+            'course:id,title'
+        ])
+        ->latest('created_at');
+        
         return DataTables::of($query)
             ->filter(function ($query) use ($request) {
                 if ($request->filled('course_id')) {


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the certificate management data grid sorting issue where newly created certificates were displayed on the last page instead of appearing at the top of the grid.

### Root Cause

The certificate query used for the administrative DataTable did not apply any explicit sorting. As a result, records were returned in database default order, causing newly created certificates to appear at the end of the paginated dataset.

### Changes Made

* Added default descending sort order using `latest('created_at')`
* Added DataTable default ordering on the Issue Date column
* Ensured newly created certificates appear first in the grid
* Preserved existing filtering, search, and pagination behavior

Fixes: #838 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 🧪 Testing

### Steps Performed

1. Login as Admin
2. Navigate to Certificate Management
3. Create a new certificate
4. Refresh the certificate grid
5. Verify the newly created certificate appears at the top of the first page

### Result

✅ Latest certificates are displayed first

✅ Newly created records are immediately visible

✅ Existing search, filtering, and pagination continue to work as expected

---

## 📸 Screenshots (if applicable)

<img width="1911" height="911" alt="image" src="https://github.com/user-attachments/assets/3c336b8d-f1e9-48e7-9163-7d245f5c6104" />

---

## 🔍 Checklist

* [x] Code follows project standards
* [x] Tested locally
* [x] No breaking changes introduced
* [x] Existing functionality verified
* [x] Latest records now display first
