### PR TITLE
Attendance Report Page Applies Forced 3-Month Default Filter on Load …

### DIFF
--- a/resources/views/backend/employee/internal_attendace_report.blade.php
+++ b/resources/views/backend/employee/internal_attendace_report.blade.php
@@ -323,7 +323,6 @@
     const fromDateInput = document.getElementById('assign_from_date');
     const toDateInput = document.getElementById('assign_to_date');
     const MS_PER_DAY = 24 * 60 * 60 * 1000;
-    const MAX_RANGE_DAYS = 90;
     const today = new Date();
 
     function setSelectUser(emp_by) {
@@ -344,52 +343,13 @@
     }
 
     function initializeDates() {
-        if (!isValidDate(fromDateInput.value)) {
-            const defaultFrom = new Date(today.getTime() - MAX_RANGE_DAYS * MS_PER_DAY);
-            fromDateInput.value = formatDate(defaultFrom);
-        }
-
-        if (!isValidDate(toDateInput.value)) {
-            toDateInput.value = formatDate(today);
-        }
-
         const minDate = new Date(today.getTime() - 365 * MS_PER_DAY);
+
         fromDateInput.min = formatDate(minDate);
         fromDateInput.max = formatDate(today);
+
         toDateInput.min = formatDate(minDate);
         toDateInput.max = formatDate(today);
-    }
-
-    function enforceMaxRangeOnFromChange() {
-        const fromDate = new Date(fromDateInput.value);
-        if (!isValidDate(fromDateInput.value)) {
-            return;
-        }
-
-        const toDate = new Date(toDateInput.value);
-        if (!isValidDate(toDateInput.value) || (toDate - fromDate) > MAX_RANGE_DAYS * MS_PER_DAY) {
-            let newToDate = new Date(fromDate.getTime() + MAX_RANGE_DAYS * MS_PER_DAY);
-            if (newToDate > today) {
-                newToDate = today;
-            }
-            toDateInput.value = formatDate(newToDate);
-        }
-    }
-
-    function enforceMaxRangeOnToChange() {
-        const toDate = new Date(toDateInput.value);
-        if (!isValidDate(toDateInput.value)) {
-            return;
-        }
-
-        const fromDate = new Date(fromDateInput.value);
-        if (!isValidDate(fromDateInput.value) || (toDate - fromDate) > MAX_RANGE_DAYS * MS_PER_DAY) {
-            let newFromDate = new Date(toDate.getTime() - MAX_RANGE_DAYS * MS_PER_DAY);
-            if (newFromDate < new Date(fromDateInput.min)) {
-                newFromDate = new Date(fromDateInput.min);
-            }
-            fromDateInput.value = formatDate(newFromDate);
-        }
     }
 
     function selectedUserId() {
@@ -529,9 +489,6 @@
         $('#user_by').change(function () {
             setSelectUser($(this).val());
         });
-
-        $('#assign_from_date').change(enforceMaxRangeOnFromChange);
-        $('#assign_to_date').change(enforceMaxRangeOnToChange);
 
         $('#reset').click(function () {
             $('#user').val(null).trigger('change');


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes an issue in the Attendance Report page where a default 3-month date range was automatically applied when the page loaded.

### Problem

* Attendance Report automatically populated the "From Date" and "To Date" fields with a 90-day date range.
* Users were shown filtered data without explicitly applying any filters.
* This could lead users to believe they were viewing the complete dataset when older records were actually excluded.

### Solution

* Removed automatic date initialization on page load.
* Attendance Report now loads with empty date fields by default.
* Date filters are applied only when the user explicitly selects a date range and performs a search.
* Reset functionality continues to clear all filters and display unfiltered results.

Fixes: #844

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1918" height="900" alt="image" src="https://github.com/user-attachments/assets/d51d1224-9133-477a-bf4d-a123c56060c4" />
<img width="1911" height="920" alt="image" src="https://github.com/user-attachments/assets/897a5f32-41c9-40d5-bf57-332e5d4e27db" />


---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

* [x] Local environment
* [x] Browser testing


### Verification Performed

* Opened Attendance Report page and confirmed date fields are empty on initial load.
* Verified report data loads without automatically applying a date filter.
* Applied custom date ranges and confirmed filtering works correctly.
* Used Reset button and confirmed all filters are cleared and full dataset is displayed.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login as Admin.
2. Navigate to **All Reports → Attendance Report**.
3. Observe that the page previously loaded with a predefined 3-month date range.
4. Verify that after the fix, date fields remain empty and data is displayed without automatic date filtering.

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Verified no sensitive data is included
* [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This change aligns the Attendance Report behavior with standard reporting practices by ensuring that filters are user-driven rather than automatically applied on page load.
