### PR TITLE
Feat: Add Course Type column to Courses Management datatable

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -522,7 +522,19 @@ class CoursesController extends Controller
                 }
                 //return '<a class="add-btn" style="padding:7px 20px 11px 20px"  href="' . route('admin.enrolled_student', ['course_id' => $q->id]) . '"> (' . CustomHelper::totalEnrolled($q->id) . ') <i class="fa fa-eye ml-1" aria-hidden="true"></i> </a>';
             })
-            ->rawColumns(['teachers', 'assignment', 'department', 'duration', 'total_students_enrolled', 'tests', 'lessons', 'course_image', 'actions', 'status','qr_code',  'expiry_date'])
+            ->addColumn('course_type', function ($q) {
+                switch ($q->is_online) {
+                    case 'Online':
+                        return '<span class="badge badge-info">' . __('course_pages.admin_create.course_type_e_learning') . '</span>';
+                    case 'Offline':
+                        return '<span class="badge badge-warning">' . __('course_pages.admin_create.course_type_live_online') . '</span>';
+                    case 'Live-Classroom':
+                        return '<span class="badge badge-success">' . __('course_pages.admin_create.course_type_live_classroom') . '</span>';
+                    default:
+                        return '<span class="badge badge-secondary">-</span>';
+                }
+            })
+            ->rawColumns(['teachers', 'assignment', 'department', 'duration', 'total_students_enrolled', 'tests', 'lessons', 'course_image', 'actions', 'status','qr_code',  'expiry_date', 'course_type'])
             ->make();
     }
 

--- a/resources/lang/en/course_pages.php
+++ b/resources/lang/en/course_pages.php
@@ -65,6 +65,7 @@ return array(
     'reset' => 'Reset',
     'course_code' => 'Course Code',
     'course_language' => 'Course Language',
+    'course_type' => 'Course Type',
     'total_students_enrolled' => 'Total Students Enrolled',
     'total_duration' => 'Total Duration',
     'start_date' => 'Start Date',

--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -111,6 +111,7 @@
                             <th>{{ __('course_pages.admin_index.course_language') }}</th>
                             <th>@lang('labels.backend.courses.fields.title')</th>
                             <!-- <th>@lang('Arabic Title')</th> -->
+                            <th>{{ __('course_pages.admin_index.course_type') }}</th>
                             <th>@lang('labels.backend.courses.fields.category')</th>
                             <th>@lang('labels.backend.courses.fields.price')</th>
                             
@@ -255,14 +256,14 @@ window.addEventListener('load', function () {
                         },
                             text: 'CSV',
                             exportOptions: {
-                                columns: [1, 2, 3, 4, 5]
+                                columns: [1, 2, 3, 4, 5, 6]
                             }
                         },
                         {
                             extend: 'pdf',
                             text: 'PDF',
                             exportOptions: {
-                                columns: [1, 2, 3, 4, 5]
+                                columns: [1, 2, 3, 4, 5, 6]
                             }
                         }
                     ]
@@ -312,6 +313,12 @@ window.addEventListener('load', function () {
                     //     data: "arabic_title",
                     //     name: 'arabic_title'
                     // },
+                    {
+                        data: "course_type",
+                        name: 'is_online',
+                        orderable: true,
+                        searchable: true
+                    },
                     {
                         data: "category",
                         name: 'category'


### PR DESCRIPTION
## Summary
Adds a new **Course Type** column to the Courses Management datatable that displays each course's delivery type (E-Learning, Live-Online, or Live-Classroom) as a colored badge. Admins can now identify course types at a glance.

## Problem
Administrators had to open each course to determine its delivery type, which was inefficient and error-prone.

## Solution
- Added new `<th>` header between Title and Category
- Added DataTables column config mapped to a new `course_type` add-column in the controller, with `name: 'is_online'` so server-side ordering/search keeps working
- Added new `addColumn('course_type')` in `CoursesController@getData` that switches on `\$q->is_online` and returns a badge:
  - `Online` → E-Learning (blue badge)
  - `Offline` → Live-Online (yellow badge)
  - `Live-Classroom` → Live-Classroom (green badge)
- Added `course_type` to `rawColumns` so the badge HTML renders
- Adjusted CSV/PDF `exportOptions` to include the new column
- Added `course_type` translation key in `course_pages.php`

## Related Issue
Fixes #828