### PR TITLE
Fix: Hide 'Create Lesson' action for E-Live course types

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -353,15 +353,21 @@ class CoursesController extends Controller
             //     return $lesson;
             // })
             ->addColumn('lessons', function ($q) {
-    $dropdown = '
-        
-           
-            <div class="">
-            
-                <a class="createbtn" href="' . route('admin.lessons.create', ['course_id' => $q->id]) . '">
+    // Lessons (modules) only apply to E-Learning (Online) courses.
+    // Live-Online and Live-Classroom (E-Live) courses are delivered via
+    // live sessions and do not support lesson creation, so the "Create"
+    // action is hidden for those types and only "View" remains visible.
+    $isELearning = ($q->is_online === 'Online' || empty($q->is_online));
+    $createBtn = $isELearning
+        ? '<a class="createbtn" href="' . route('admin.lessons.create', ['course_id' => $q->id]) . '">
                 Create
                    <!-- <i class="fa fa-plus-circle" aria-hidden="true" style="font-size:20px"></i> -->
-                </a>
+                </a>'
+        : '';
+
+    $dropdown = '
+            <div class="">
+                ' . $createBtn . '
                 <a class="viewbtn" href="' . route('admin.lessons.index', ['course_id' => $q->id]) . '">
                 View
                    <!-- <i class="fa fa-eye" aria-hidden="true" style="font-size:18px margin-bottom:-3px"></i> -->


### PR DESCRIPTION
## Summary
Hides the 'Create' button in the Lessons column of the Courses Management datatable for E-Live course types (Live-Online and Live-Classroom). These types are delivered through live sessions and do not support lesson/module creation, so showing the action was misleading.

## Problem
'Create Lesson' was visible for every course regardless of type. For E-Live courses (Live-Online, Live-Classroom) lesson creation is not applicable and clicking the action would take the user to a flow that doesn't fit those course types.

## Solution
Updated `addColumn('lessons')` in `CoursesController@getData` to render the 'Create' button only when the course is E-Learning (`is_online === 'Online'` or empty for legacy records). The 'View' lessons link remains for all course types.

This is a UI-only gate — no route changes are needed.

## Related Issue
Fixes #829