### PR TITLE
Fix: Pagination not loading new page data in Courses datatable

### DIFF
--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -194,24 +194,20 @@ window.addEventListener('load', function () {
 @endif
     <script>
         $(document).ready(function() {
+            // Use one base route; pass filter values through the ajax `data`
+            // callback below so they're sent on every paginated request
+            // instead of being baked into the URL (which caused duplicate
+            // query params and stale pages when navigating).
             var route = '{{ route('admin.courses.get_data') }}';
 
-            @if (request('show_deleted') == 1)
-                route = '{{ route('admin.courses.get_data', ['show_deleted' => 1]) }}';
-            @endif
-
-            @if (request('teacher_id') != '')
-                route = '{{ route('admin.courses.get_data', ['teacher_id' => request('teacher_id')]) }}';
-            @endif
-
-            @if (request('cat_id') != '')
-                route = '{{ route('admin.courses.get_data', ['cat_id' => request('cat_id')]) }}';
-            @endif
+            var initialShowDeleted = '{{ request('show_deleted') }}';
+            var initialTeacherId = '{{ request('teacher_id') }}';
+            var initialCatId = '{{ request('cat_id') }}';
 
             $('#myTable').DataTable({
                 processing: true,
                 serverSide: true,
-                iDisplayLength: 10,
+                pageLength: 10,
                 //retrieve: true,
                 dom: "<'table-controls'lfB>" +
                      "<'table-responsive't>" +
@@ -275,10 +271,15 @@ window.addEventListener('load', function () {
                
                 ajax: {
                     url: route,
+                    type: 'GET',
+                    cache: false,
                     data: function (d) {
                         d.status = $('#filter_status').val();
-                        d.teacher_id = $('#filter_teacher').val();
-                        d.cat_id = $('#filter_category').val();
+                        d.teacher_id = $('#filter_teacher').val() || initialTeacherId;
+                        d.cat_id = $('#filter_category').val() || initialCatId;
+                        if (initialShowDeleted == '1') {
+                            d.show_deleted = 1;
+                        }
                     }
                 },
                 columns: [


### PR DESCRIPTION
## Summary
Fixes a critical bug where clicking page 2+ in the Courses Management datatable updated the page indicator and footer counter, but the actual table rows still showed the page-1 data set.

## Root Cause
Filter values (`show_deleted`, `teacher_id`, `cat_id`) were baked into the ajax URL via Blade-rendered query strings, and the same values were also appended through the ajax `data` callback. DataTables ended up sending duplicate query params (e.g. `?teacher_id=5&teacher_id=`) on every pagination request — PHP coerced the duplicate to the empty value, and the resulting stable URL signature allowed intermediate caching layers to serve stale page-1 responses.

## Solution
- Use a single base route URL and pass **all** filter values through the ajax `data` callback so they're refreshed (and unique) on every request
- Added `cache: false` so browsers and proxies never serve a stale response
- Pre-seed the data callback with the initial query-string values so deep links (e.g. `?cat_id=3`) still filter correctly
- Switched from legacy `iDisplayLength` to the modern `pageLength` option

Controller-side pagination (yajra/laravel-datatables) was already correct — this was a frontend/cache-shape bug.

## Related Issue
Fixes #802 (High Priority / High Severity)