### PR TITLE
Fix: Show Trainer column for custom admin roles in Courses datatable

### DIFF
--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -114,12 +114,13 @@
                             <th>@lang('labels.backend.courses.fields.category')</th>
                             <th>@lang('labels.backend.courses.fields.price')</th>
                             
-                            @if (Auth::user()->isAdmin())
-                               
+                            {{-- Show the Trainer column for any role with the
+                                 trainer_access permission, not only the
+                                 built-in 'administrator' role, so custom
+                                 admin roles also see facilitator info. --}}
+                            @can('trainer_access')
                                 <th>@lang('labels.backend.courses.fields.teachers')</th>
-                            @else
-                              
-                            @endif
+                            @endcan
                             {{-- <th>@lang('Assignment')</th> --}}
                             <th>{{ __('course_pages.admin_index.total_students_enrolled') }}</th>
                             <th>{{ __('course_pages.admin_index.total_duration') }}</th>
@@ -321,17 +322,14 @@ window.addEventListener('load', function () {
     name: 'price'
 },
                     // {data: "department", name: 'department'},
-                    @if (Auth::user()->isAdmin())
+                    @can('trainer_access')
                         // {data: "DT_RowIndex", name: 'DT_RowIndex', searchable: false, orderable:false},
                         // {data: "id", name: 'id'},
                         {
                             data: "teachers",
                             name: 'teachers'
                         },
-                    @else
-                        // {data: "DT_RowIndex", name: 'DT_RowIndex', searchable: false},
-                        // {data: "id", name: 'id'},
-                    @endif
+                    @endcan
                     {
                         data: "total_students_enrolled",
                         name: "total_students_enrolled"


### PR DESCRIPTION
## Summary
The Trainer (course facilitator) column in the Courses Management datatable was hidden for custom administrative roles. Replaced the role check with a permission-based gate so any admin-level role can see the column.

## Root Cause
The column was gated behind `Auth::user()->isAdmin()`, which only returns true for the built-in `administrator` role (via `config('access.users.admin_role')`). Custom admin roles with full course access were therefore excluded, even though they reached the page just fine.

## Solution
Replaced the role-based check with `@can('trainer_access')`. Since the entire courses section is already mounted under the `permission:trainer_access` middleware group in `routes/backend/admin.php`, any user reaching this page necessarily has this permission — the visual gate is now consistent with the backend authorization model.

Updated both the `<th>` header markup and the DataTables columns config so the header and the data column stay aligned.

## Related Issue
Fixes #830