### PR TITLE
Fix: Correct import label on User Group page to 'Import User Groups'

### DIFF
--- a/resources/views/backend/department/index.blade.php
+++ b/resources/views/backend/department/index.blade.php
@@ -38,9 +38,9 @@
 
             <div class="row">
 
-                <!-- Import Internal Trainee -->
+                <!-- Import User Groups -->
                 <div class="col-6 mb-2">
-                    <h6>@lang('Import Internal Trainee')</h6>
+                    <h6>@lang('Import User Groups')</h6>
 
                     <form method="POST"
                           action="{{ route('admin.department.add.import') }}"


### PR DESCRIPTION
## Summary
The file-upload action on the User Group (department) index page was labeled **'Import Internal Trainee'**, which is misleading. The underlying `import_exl()` controller method imports `Department` (User Group) records via `DepartmentImport`, not trainees. Updated the label to accurately reflect what it does.

## Problem
- Upload button on User Group master page was labeled 'Import Internal Trainee'
- The action actually creates Department records, not trainees
- Label was misleading and out of context for the page

## Solution
Renamed the heading from 'Import Internal Trainee' to 'Import User Groups' to match the actual functionality (`DepartmentImport`). No backend changes needed.

## Related Issue
Fixes #840

## Files Changed
- `resources/views/backend/department/index.blade.php`