### PR TITLE
Fix: Prevent button text overflow in Language Marketplace panel

### DIFF
--- a/resources/views/backend/settings/general.blade.php
+++ b/resources/views/backend/settings/general.blade.php
@@ -89,12 +89,15 @@
 
         .workflow-publish-controls .form-control,
         .workflow-publish-controls .btn {
-            height: 38px;
+            min-height: 38px;
             border-radius: 6px;
         }
 
         .workflow-publish-controls .btn {
-            white-space: nowrap;
+            white-space: normal;
+            word-break: break-word;
+            padding-left: 10px;
+            padding-right: 10px;
         }
 
         .review-action-stack {


### PR DESCRIPTION
## Summary
Fixes the 'Publish source package' button text overflowing beyond the button boundary in the Language Marketplace Workflow panel (Settings → General → Translations).

## Root Cause
The button CSS used `white-space: nowrap` together with a fixed `height: 38px`. In narrow columns the text 'Publish source package' couldn't fit in one line, but `nowrap` prevented wrapping, so it clipped past the right edge.

## Solution
- Changed `white-space: nowrap` → `white-space: normal` with `word-break: break-word` so the text wraps cleanly
- Changed `height: 38px` → `min-height: 38px` so the button can grow vertically to fit wrapped text
- Added horizontal padding for proper spacing

## Related Issue
Fixes #790

## Files Changed
- `resources/views/backend/settings/general.blade.php`