### PR TITLE
Fix: Add validation message for empty Users dropdown in Send Email

### DIFF
--- a/resources/views/backend/notification/index.blade.php
+++ b/resources/views/backend/notification/index.blade.php
@@ -287,6 +287,35 @@
 
         $('input[name="recipient_mode"]').on('change', function() {
             setRecipientMode($(this).val());
+            // Clear the users validation message when switching recipient source
+            $('.recipient-source-group[data-recipient-mode="users"] .users-error').remove();
+        });
+
+        // Client-side validation: block submission and show inline message
+        // when the "Select Users" mode is active but no user is selected.
+        $('form.ajax').on('submit', function(e) {
+            var mode = $('input[name="recipient_mode"]:checked').val();
+            if (mode === 'users') {
+                var selectedUsers = $('[name="users[]"]').val() || [];
+                var $group = $('.recipient-source-group[data-recipient-mode="users"]');
+                $group.find('.users-error').remove();
+
+                if (selectedUsers.length === 0) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    $group.find('.custom-select-wrapper').append(
+                        '<span class="text-danger w-100 users-error">{{ __('admin_pages.email_notifications.messages.no_users_selected') }}</span>'
+                    );
+                    return false;
+                }
+            }
+        });
+
+        // Remove the validation message once the user makes a selection
+        $('[name="users[]"]').on('change', function() {
+            if (($(this).val() || []).length > 0) {
+                $('.recipient-source-group[data-recipient-mode="users"] .users-error').remove();
+            }
         });
 
         ClassicEditor


### PR DESCRIPTION
## Summary
Adds client-side validation to the Users dropdown in the **Send Email Notification** form so users get clear feedback when the field is left empty.

## Problem
- In 'Select Users' recipient mode, the Users dropdown is required, but submitting without selecting any user gave no inline feedback
- The mandatory (*) indicator was already present via the label's `.required` class, but there was no message and no client-side block

## Solution
- Added a form submit handler that blocks submission when no user is selected in 'Select Users' mode
- Displays an inline 'Please select at least one user' message next to the dropdown using the existing `messages.no_users_selected` translation key (already defined in all 5 supported languages)
- The message auto-clears when a user is selected or the recipient source is changed

The backend already returned a 422 with the same error key — this just surfaces it client-side before submission and consistently inline.

## Related Issue
Fixes #789

## Files Changed
- `resources/views/backend/notification/index.blade.php`