### PR TITLE
Security hardening: secure session cookie in production, track composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ README.md
 /storage/framework/views/*
 
 .phpunit.result.cache
-composer.lock
+# composer.lock SHOULD be committed for reproducible, auditable builds and
+# so that `composer audit` can flag vulnerable locked dependencies.
+# It was previously ignored — keep it tracked going forward.
 
 # Ignore all storage except public assets
 storage/*

--- a/config/session.php
+++ b/config/session.php
@@ -166,7 +166,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'secure' => env('SESSION_SECURE_COOKIE', str_starts_with(env('APP_URL', 'http://localhost'), 'https://')),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A couple of low-risk hardening improvements I noticed while reviewing the project.

## Changes

- **`config/session.php`** — `secure` cookie now defaults to `true` when `APP_URL` is served over HTTPS (auto-detected). This prevents the session cookie from being sent over plain HTTP in production. Explicitly overridable via `SESSION_SECURE_COOKIE`.
- **`.gitignore`** — stopped ignoring `composer.lock`. Committing it makes builds reproducible and enables `composer audit` to flag vulnerable locked dependencies.

## Notes

- No behaviour change for local dev (`APP_URL=http://localhost` keeps `secure=false`) or for deployments that already set `SESSION_SECURE_COOKIE`.
- `composer.lock` itself is intentionally not added in this PR: resolving it locally fails because `phpoffice/phpspreadsheet` (via `maatwebsite/excel`) both has open security advisories and a PHP 8.5 constraint mismatch. Generating it correctly should happen in CI / on a maintainer machine with the intended PHP runtime. I'll open a separate issue with the details.