### PR TITLE
Field Order in Create KPI Page #869

### DIFF
--- a/resources/views/backend/kpis/create.blade.php
+++ b/resources/views/backend/kpis/create.blade.php
@@ -50,6 +50,20 @@
                             @endforeach
                         </select>
                         <small class="form-text text-muted">@lang('kpi.help.formulas_managed')</small>
+                    </div>      
+                </div>
+
+                <div class="row">
+                    <div class="col-12 form-group">
+                        <label for="category_ids">@lang('kpi.labels.mapped_course_categories') *</label>
+                        <select id="category_ids" name="category_ids[]" class="form-control" multiple required>
+                            @foreach($categories as $category)
+                                <option value="{{ $category->id }}" {{ in_array($category->id, old('category_ids', []), true) ? 'selected' : '' }}>
+                                    {{ $category->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        <small class="form-text text-muted">@lang('kpi.help.category_scope')</small>
                     </div>
 
                     <div class="col-md-6 form-group">
@@ -72,20 +86,6 @@
                             @lang('kpi.messages.projected_active_total') <strong id="kpi-projected-active-total">{{ number_format($activeTotalWeight + (float) old('weight', $defaultWeight), 2) }}</strong>
                         </div>
                         <div id="kpi-weight-warning" class="small text-warning mt-1" style="display: none;"></div>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="col-12 form-group">
-                        <label for="category_ids">@lang('kpi.labels.mapped_course_categories') *</label>
-                        <select id="category_ids" name="category_ids[]" class="form-control" multiple required>
-                            @foreach($categories as $category)
-                                <option value="{{ $category->id }}" {{ in_array($category->id, old('category_ids', []), true) ? 'selected' : '' }}>
-                                    {{ $category->name }}
-                                </option>
-                            @endforeach
-                        </select>
-                        <small class="form-text text-muted">@lang('kpi.help.category_scope')</small>
                     </div>
 
                     <div class="col-12 form-group">


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the field ordering on the **Create KPI** page to provide a more logical workflow for administrators when creating KPIs.

### What problem does this PR solve?

The Create KPI form displayed fields in an inconsistent order, requiring administrators to enter the KPI weight before selecting the mapped course categories. This did not align with the expected creation workflow and reduced usability.

### What changes were made?

* Reordered the Create KPI form fields.
* Moved **Mapped Course Categories** above **Weight**.
* Kept existing weight validation and projected total calculations unchanged.
* Preserved all existing functionality and form validations.

### Updated field order

* KPI Name
* KPI Code
* KPI Type
* Mapped Course Categories
* Weight
* Legacy Courses
* Description

Fixes: #869 

---

## ✅ Type of Change

* [x] 🐞 Bug fix

---

## 🧪 Testing

* Verified the Create KPI page loads successfully.
* Verified fields appear in the expected order.
* Verified weight validation and projected total calculations continue to work.
* Verified the form submits successfully without affecting existing functionality.

---

## 📸 Screenshots

<img width="1917" height="917" alt="image" src="https://github.com/user-attachments/assets/e1552df9-e331-416b-b31a-f9c8b5a8b152" />

---

## ✔️ Checklist

* [x] Code follows project coding standards.
* [x] Existing functionality remains unaffected.
* [x] Manual testing completed.
* [x] No unrelated changes included.
 