### PR TITLE
Fix: Display all facilitator names in Trainer column (#830 follow-up)

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -340,13 +340,22 @@ class CoursesController extends Controller
     return $actions;
 })
             ->addColumn('teachers', function ($q) {
-                $teachers = "";
-                foreach ($q->teachers as $singleTeachers) {
-                    if($singleTeachers->hasRole('teacher')){
-                    $teachers .= '<span class="text-dark">' . $singleTeachers->name . ' </span>';
+                // The course_user pivot stores every facilitator attached
+                // to a course. Historically this was filtered to role='teacher'
+                // only, but when a non-administrator creates a course the
+                // store flow attaches the creator (e.g. a custom admin role)
+                // as the facilitator. Filtering by hasRole('teacher') then
+                // produced an empty column for those courses. We now show
+                // every attached user that is NOT a student, which covers
+                // teachers, administrators and custom admin roles.
+                $names = [];
+                foreach ($q->teachers as $facilitator) {
+                    if ($facilitator->hasRole('student')) {
+                        continue;
                     }
+                    $names[] = '<span class="text-dark">' . e($facilitator->name) . '</span>';
                 }
-                return $teachers;
+                return implode(' ', $names);
             })
             // ->addColumn('lessons', function ($q) {
             //     $lesson = '<a href="' . route('admin.lessons.create', ['course_id' => $q->id]) . '" class="btn btn-success mb-1"><i class="fa fa-plus-circle"></i></a>  <a href="' . route('admin.lessons.index', ['course_id' => $q->id]) . '" class="btn mb-1 btn-warning text-white"><i class="fa fa-arrow-circle-right"></a>';


### PR DESCRIPTION
## Context
Follow-up to [#863](https://github.com/Tadreeb-LMS/tadreeblms/pull/863). After making the Trainer column visible for all admin roles, @BalajiTester reported that the column now appears but the trainer names are empty.

## What was happening
The \`teachers\` addColumn callback filtered the \`course_user\` pivot with \`\$singleTeachers->hasRole('teacher')\`. Looking at the course store flow in the same controller (line 848):

\`\`\`php
\$teacherId = Auth::user()->isAdmin()
    ? \$request->input('teacher_id')
    : Auth::user()->id;
\$course->teachers()->sync([\$teacherId]);
\`\`\`

When a **custom admin role** creates a course, the creator's own user id is attached as the facilitator. That user has the custom admin role, **not** the built-in \`teacher\` role, so the display filter dropped them and the column rendered empty.

## Fix
Loosened the display filter from "must have teacher role" to "must NOT have student role". The \`course_user\` pivot is the canonical list of facilitators attached to a course (students live on the separate \`course_student\` pivot), so listing every non-student attached user is the correct contract. This now correctly shows teachers, administrators, and custom admin roles that created the course.

Also escaped the displayed name with \`e()\` to avoid unintentional HTML injection if a user's name ever contains markup.

## Files Changed
- \`app/Http/Controllers/Backend/Admin/CoursesController.php\`

## Related
Fixes #830 (reopened)