### PR TITLE
Incorrect Mandatory Validation Applied to Expiry Field for E-learning…

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -592,8 +592,13 @@ class CoursesController extends Controller
             return abort(401);
         }
         $request->validate([
-             'start_date' => 'required|date',
-             'expire_at'  => 'required|date|after_or_equal:start_date',
+            'start_date' => $request->course_type === 'Online'
+                ? 'nullable|date'
+                : 'required|date',
+
+            'expire_at' => $request->course_type === 'Online'
+                ? 'nullable|date'
+                : 'required|date|after_or_equal:start_date',
              'title' => 'required|string|max:255',
              'category_id' => 'required',
              'course_type' => 'required',


### PR DESCRIPTION
## 🐞 Defect Title

Fix Incorrect Mandatory Validation Applied to Expiry Field for E-learning Course Type

### 📍 Module

Admin Panel → Course Management → Create Course

### 📝 Description

This PR fixes the validation logic for the **Expiry** field during course creation.

Previously, the system enforced the **Expiry** field as mandatory for all course types, including **E-learning** courses. Since E-learning courses are self-paced, requiring an expiry date prevented administrators from creating valid courses without unnecessary constraints.

The validation has been updated so that:

* **E-learning (Online)** courses treat the **Expiry** field as optional.
* **Instructor-led / Live Online / Live Classroom** courses continue to require an expiry date.

Fixes : #812 

### ✅ Changes Made

* Updated backend validation to conditionally require the `expire_at` field based on `course_type`.
* Preserved existing validation behavior for scheduled course types.
* Verified that E-learning courses can now be created successfully without specifying an expiry date.

### 🧪 Testing Performed

* ✅ Online (E-learning) course without expiry → Course created successfully.
* ✅ Online (E-learning) course with expiry → Course created successfully.
* ✅ Live Online course without expiry → Validation error displayed.
* ✅ Live Classroom course without expiry → Validation error displayed.
* ✅ Existing course creation workflow remains unaffected.

### 🎯 Impact

* Resolves incorrect business rule enforcement.
* Improves administrator experience during course creation.
* Maintains validation for scheduled course types while allowing self-paced courses to omit an expiry date.
