### PR TITLE
Chore: Add deterministic pagination tiebreaker to all server-side datatables

### DIFF
--- a/app/Http/Controllers/Backend/Admin/BlogController.php
+++ b/app/Http/Controllers/Backend/Admin/BlogController.php
@@ -52,7 +52,7 @@ class BlogController extends Controller
         $blogs = "";
 
 
-        $blogs = Blog::query()->whereHas('category')->orderBy('created_at', 'desc');
+        $blogs = Blog::query()->whereHas('category')->orderBy('created_at', 'desc')->orderBy('id', 'desc');
 
 
         if (auth()->user()->can('blog_view')) {

--- a/app/Http/Controllers/Backend/Admin/BundlesController.php
+++ b/app/Http/Controllers/Backend/Admin/BundlesController.php
@@ -54,12 +54,12 @@ class BundlesController extends Controller
             if (!Gate::allows('bundle_delete')) {
                 return abort(401);
             }
-            $bundles = Bundle::query()->ofAuthor()->onlyTrashed()->orderBy('created_at', 'desc');
+            $bundles = Bundle::query()->ofAuthor()->onlyTrashed()->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         } elseif (request('cat_id') != "") {
             $id = request('cat_id');
-            $bundles = Bundle::query()->ofAuthor()->where('category_id', '=', $id)->orderBy('created_at', 'desc');
+            $bundles = Bundle::query()->ofAuthor()->where('category_id', '=', $id)->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         } else {
-            $bundles = Bundle::query()->ofAuthor()->orderBy('created_at', 'desc');
+            $bundles = Bundle::query()->ofAuthor()->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         }
 
 

--- a/app/Http/Controllers/Backend/Admin/CategoriesController.php
+++ b/app/Http/Controllers/Backend/Admin/CategoriesController.php
@@ -48,9 +48,9 @@ class CategoriesController extends Controller
                 return abort(401);
             }
             $categories = Category::query()->onlyTrashed()
-                ->orderBy('created_at', 'desc');
+                ->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         } else {
-            $categories = Category::query()->orderBy('created_at', 'desc');
+            $categories = Category::query()->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         }
 
         if (auth()->user()->can('category_view')) {

--- a/app/Http/Controllers/Backend/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Backend/Admin/EmployeeController.php
@@ -133,9 +133,9 @@ class EmployeeController extends Controller
 
 
         if (request('show_deleted') == 1) {
-            $teachers = User::query()->role('student')->where('employee_type', 'external')->onlyTrashed()->orderBy('created_at', 'desc');
+            $teachers = User::query()->role('student')->where('employee_type', 'external')->onlyTrashed()->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         } else {
-            $teachers = User::query()->role('student')->where('employee_type', 'external')->orderBy('created_at', 'desc');
+            $teachers = User::query()->role('student')->where('employee_type', 'external')->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         }
 
         if (auth()->user()->isAdmin()) {
@@ -227,14 +227,16 @@ class EmployeeController extends Controller
                     $q->where('active', '1');
                 })
                 ->onlyTrashed()
-                ->orderBy('created_at', 'desc');
+                ->orderBy('created_at', 'desc')
+                ->orderBy('id', 'desc');
         } else {
             $teachers = User::query()->role('student')
             ->when($status == 'active', function ($q) {
                     $q->where('active', '1');
             })
-            ->orderBy('created_at', 'desc');
-        }      
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc');
+        }
 
         if (auth()->user()->isAdmin()) {
             $has_view = true;
@@ -1208,9 +1210,9 @@ class EmployeeController extends Controller
 
 
         if (request('show_deleted') == 1) {
-            $teachers = User::query()->role('student')->where('employee_type', 'external')->onlyTrashed()->orderBy('created_at', 'desc');
+            $teachers = User::query()->role('student')->where('employee_type', 'external')->onlyTrashed()->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         } else {
-            $teachers = User::query()->role('student')->where('employee_type', 'external')->orderBy('created_at', 'desc');
+            $teachers = User::query()->role('student')->where('employee_type', 'external')->orderBy('created_at', 'desc')->orderBy('id', 'desc');
         }
 
 


### PR DESCRIPTION
## Summary

This is a **housekeeping PR** — no user-reported issue, but the same class of bug we fixed in [#879](https://github.com/Tadreeb-LMS/tadreeblms/pull/879) (re-open of #802) is latent in several other admin datatables. This sweeps the codebase for them.

## What was wrong

A query that orders only by \`created_at DESC\` is **non-deterministic with MySQL LIMIT/OFFSET** when multiple rows share the same \`created_at\` value. With seeded data, bulk imports, or records created in the same second, page 2's \`OFFSET 10 LIMIT 10\` is allowed to return the same rows page 1 already showed — because MySQL is free to pick any order among ties.

The fix is to append a deterministic secondary order on the primary key, making the \`(created_at, id)\` tuple unique per row.

\`\`\`php
// before
->orderBy('created_at', 'desc')

// after
->orderBy('created_at', 'desc')->orderBy('id', 'desc')
\`\`\`

## Audit scope

I went through every \`getData\`-style controller in \`app/Http/Controllers/Backend/Admin/\` that contains \`orderBy('created_at', 'desc')\` (≈15 hits). Each one was classified:

### ✅ Fixed (server-side query builder passed to DataTables::of → MySQL LIMIT/OFFSET applies)

| Controller | Method | Branches fixed |
|---|---|---|
| \`BlogController\` | \`getData\` | 1 |
| \`BundlesController\` | \`getData\` | 3 (trashed / by-category / default) |
| \`CategoriesController\` | \`getData\` | 2 (trashed / default) |
| \`EmployeeController\` | \`getData\` | 2 (trashed / default) |
| \`EmployeeController\` | \`getExternalData\` | 2 (trashed / default) |
| \`EmployeeController\` | \`get_external_trainee_info\` | 2 (trashed / default) |

### ❌ Not changed — audited and confirmed don't apply

These call \`->get()\` **before** passing to \`DataTables::of\`, so yajra slices an in-memory collection. The slice is index-based and deterministic within a single response (a separate, milder bug where two refreshes can show different "first 10" rows still exists, but that's not what this PR addresses):

- \`DepartmentController::getData\`
- \`EventsController::getData\`
- \`EmployeeController::enrolled_get_data\`
- \`EmployeeController::enrolled_get_data_internal\`

## How to verify

For any of the fixed pages (e.g. Bundles, Categories, Employee):

1. Make sure at least 20 records exist (preferably some sharing a \`created_at\` second — seeded data is perfect).
2. Open the admin index and click page 2.
3. Rows 11–20 should appear, **not** a duplicate of rows 1–10.

## Why one PR instead of six

Same conceptual fix, same one-line change, identical reasoning. A single review covers the whole class of bug and the audit table above makes scope explicit. If you'd prefer this split per controller, happy to do that — just let me know.

## Related

- Builds on #879 (which fixed the same pattern in \`CoursesController::getData\`)
- Class of bug originally reported as #802