### PR TITLE
Remember Me Checkbox Enabled by Default on Login Page #884

### DIFF
--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -247,8 +247,8 @@
                                    name="remember"
                                    id="remember"
                                    value="1"
-                                   checked>
-                            <label class="form-check-label" for="remember">
+                                    {{ old('remember') ? 'checked' : '' }}>
+                                   <label class="form-check-label" for="remember">
                                 @lang('labels.frontend.auth.remember_me')
                             </label>
                         </div>


### PR DESCRIPTION
# 📥 Pull Request

## 🔧 Description

This pull request fixes the default behavior of the **"Remember Me"** checkbox on the login page.

Previously, the checkbox was pre-selected by default, enabling persistent login without explicit user consent. This behavior is not aligned with security and usability best practices.

### Changes Made
- Removed the hardcoded `checked` attribute from the "Remember Me" checkbox.
- Used Laravel's `old('remember')` helper to preserve the user's selection after validation errors.
- Ensured the checkbox is **unchecked by default** when the login page is loaded.

This change makes session persistence an explicit opt-in choice while maintaining Laravel's standard authentication behavior.

Fixes: #884 

---

## ✅ Type of Change

- [x] 🐞 Bug fix
- [x] 🔐 Security improvement

---

## 📸 Screenshots (if applicable)

<img width="1911" height="902" alt="image" src="https://github.com/user-attachments/assets/19f1bcba-1705-4112-8c5a-c91abd36bb60" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Other: Verified Laravel authentication behavior with and without selecting "Remember Me".

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to the Login page.
2. Observe the "Remember Me" checkbox on initial page load.
3. Verify that it is unchecked by default.
4. Log in without selecting "Remember Me" and confirm authentication succeeds without persistent login.
5. Select "Remember Me" and verify persistent login functionality.
6. Submit invalid credentials after selecting "Remember Me" and verify the checkbox remains selected after validation errors.

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the application builds and functions without errors

---

## 🙏 Additional Notes

This change improves security and user experience by ensuring persistent login is enabled only after explicit user consent, while preserving Laravel's default authentication workflow.