### PR TITLE
Sensitive Password Exposed in DOM via Input Field Value Attribute #888

### DIFF
--- a/app/Http/Controllers/Backend/Admin/ConfigController.php
+++ b/app/Http/Controllers/Backend/Admin/ConfigController.php
@@ -497,7 +497,6 @@ class ConfigController extends Controller
         $ldap_port = (int) env('LDAP_PORT', 1389);
         $ldap_base_dn = env('LDAP_BASE_DN', '');
         $ldap_username = env('LDAP_USERNAME', '');
-        $ldap_password = env('LDAP_PASSWORD', '');
         $ldap_connected = Config::where('key', 'ldap_connected')->value('value') ?? 0;
 
         return view('backend.settings.ldap_setting', compact(
@@ -507,7 +506,6 @@ class ConfigController extends Controller
             'ldap_port',
             'ldap_base_dn',
             'ldap_username',
-            'ldap_password'
         ));
     }
 
@@ -517,21 +515,26 @@ class ConfigController extends Controller
     {
         try {
 
-            $this->setEnv([
+            $envData = [
                 'LDAP_CONNECTION' => 'default',
                 'LDAP_HOST' => $request->ldap_host,
                 'LDAP_PORT' => (int) $request->ldap_port,
                 'LDAP_BASE_DN' => $request->ldap_base_dn,
                 'LDAP_USERNAME' => $request->ldap_username,
-                'LDAP_PASSWORD' => $request->ldap_password,
-            ]);
+            ];
 
+            if ($request->filled('ldap_password')) {
+                $envData['LDAP_PASSWORD'] = $request->ldap_password;
+            }
+
+            $this->setEnv($envData);
             // Save toggle state: explicitly check the value sent from JavaScript
             // If not present or falsy, save as 0; if present and 1, save as 1
             $toggle_value = (int) $request->input('ldap_toggle', 0);
             Config::updateOrCreate(
                 ['key' => 'ldap_toggle'],
-                ['value' => $toggle_value]
+                ['value' => (int) $request->input('ldap_toggle', 0)]
+
             );
 
             return response()->json([
@@ -553,12 +556,17 @@ class ConfigController extends Controller
 
         try {
             // Update config at runtime
+
+            $password = $request->filled('ldap_password')
+                ? $request->ldap_password
+                : env('LDAP_PASSWORD');
+
             config([
                 'ldap.connections.default.hosts' => [$request->ldap_host],
                 'ldap.connections.default.port' => (int) $request->ldap_port,
                 'ldap.connections.default.base_dn' => $request->ldap_base_dn,
                 'ldap.connections.default.username' => $request->ldap_username,
-                'ldap.connections.default.password' => $request->ldap_password,
+                'ldap.connections.default.password' => $password,
             ]);
 
 

--- a/resources/views/backend/settings/ldap_setting.blade.php
+++ b/resources/views/backend/settings/ldap_setting.blade.php
@@ -171,8 +171,7 @@
                                 <div class="form-group row">
                                     <label class="col-md-4">{{ __('ldap_settings.admin_password') }}</label>
                                     <div class="col-md-8">
-                                        <input type="password" name="ldap_password" class="form-control"
-                                            value="{{ $ldap_password ?? '' }}">
+                                        <input type="password" name="ldap_password" class="form-control" placeholder="Enter new password" autocomplete="new-password">
                                     </div>
                                 </div>
 


### PR DESCRIPTION
# 📥 Pull Request

## 🔧 Description

This pull request fixes a critical security vulnerability in the LDAP Settings page where the LDAP administrator password was exposed in the HTML DOM through the `value` attribute of the password input field.

Although the password was visually masked in the UI, the actual password was rendered in the page source and could be viewed using browser Developer Tools, exposing sensitive credentials.

### Changes Made

- Removed the `value` attribute from the LDAP password input field.
- Added a placeholder (`Enter new password`) instead of pre-populating the password.
- Prevented the LDAP password from being rendered in the DOM.
- Updated the backend to preserve the existing LDAP password when the password field is left blank.
- Updated LDAP connection testing to use the stored password when no new password is provided.
- Improved secure handling of sensitive credentials without affecting existing functionality.

**Fixes:** #888 

---

## ✅ Type of Change

- [x] 🐞 Bug fix
- [x] 🔐 Security improvement

---

## 📸 Screenshots (if applicable)

<img width="1906" height="918" alt="image" src="https://github.com/user-attachments/assets/c0b0d3a7-2d86-415a-961a-3d99470292c0" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Other: Verified using browser Developer Tools that the password is no longer present in the HTML DOM.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an Administrator.
2. Navigate to **Settings → LDAP Settings**.
3. Open Browser Developer Tools (Inspect Element).
4. Locate the **Admin Password** input field.
5. Verify that no password is present in the `value` attribute.
6. Update LDAP settings without entering a new password and confirm the existing password is preserved.
7. Enter a new password and save to verify the password is updated successfully.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This PR addresses a security issue by ensuring sensitive LDAP credentials are never exposed in client-side HTML. The existing password is retained when the password field is left blank, while allowing administrators to update the password only when a new value is explicitly provided. This implementation follows secure credential handling practices and helps align the application with OWASP security recommendations.