### PR TITLE
KPI Toggle Enabled by Default During Course Creation #885

### DIFF
--- a/resources/views/backend/courses/create.blade.php
+++ b/resources/views/backend/courses/create.blade.php
@@ -295,7 +295,7 @@
                                 <input type="hidden" name="include_in_kpi" value="0">
                                 <div class="custom-control custom-switch">
                                     <input type="checkbox" class="custom-control-input" id="include_in_kpi"
-                                        name="include_in_kpi" value="1" {{ old('include_in_kpi', 1) ? 'checked' : '' }}>
+                                        name="include_in_kpi" value="1" {{ old('include_in_kpi', 0) ? 'checked' : '' }}>
                                     <label class="custom-control-label" for="include_in_kpi">Include this course in KPI
                                         calculations</label>
                                 </div>


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the default state of the **Include in KPI Calculations** toggle on the **Create Course** page.

Previously, the KPI toggle was initialized in the **ON** state because the Blade template used `old('include_in_kpi', 1)`, which automatically checked the toggle on first load. This could unintentionally enable KPI tracking for newly created courses without explicit user action.

The default value has been changed so that the toggle is **OFF** when creating a new course while still preserving the user's selected value after validation errors.

Fixes: #885 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 Testing

### Test Cases

- [x] KPI toggle is OFF by default on Create Course.
- [x] KPI toggle can be enabled manually.
- [x] KPI value is saved correctly when enabled.
- [x] KPI value remains disabled when left OFF.
- [x] Toggle state is preserved after validation errors.

---

## 📸 Screenshots

<img width="1902" height="901" alt="image" src="https://github.com/user-attachments/assets/32c03c33-0249-4313-b0f7-1fd9a531f313" />

---

## 📋 Checklist

- [x] Code follows project coding standards.
- [x] No breaking changes introduced.
- [x] Existing functionality remains unaffected.
- [x] Tested locally.
- [x] Ready for review.