### PR TITLE
Incorrect Action Buttons Displayed in Lesson Creation Form #910

### DIFF
--- a/app/Http/Controllers/Backend/Admin/LessonsController.php
+++ b/app/Http/Controllers/Backend/Admin/LessonsController.php
@@ -183,8 +183,9 @@ class LessonsController extends Controller
         $courses     = Course::has('category')->get()->pluck('title', 'id')->prepend('Please select', '');
         $courses_all = null;
         $temp_id     = bin2hex(random_bytes(8));
+        $isWizard = $request->has('course_id') || $request->has('temp_id');
 
-        return view('backend.lessons.create', compact('courses', 'courses_all', 'temp_id'));
+        return view('backend.lessons.create', compact('courses', 'courses_all', 'temp_id' ,'isWizard'));
     }
 
     public function checkCourse(Request $request)

--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -112,6 +112,8 @@ class TestQuestionController extends Controller
                 : false;
         }
 
+        $isWizard = $request->boolean('isWizard');
+
         return view('backend.test_questions.create', compact(
             'course_id',
             'temp_id',
@@ -121,7 +123,8 @@ class TestQuestionController extends Controller
             'last_lesson_id',
             'selected_lesson_preselect',
             'is_last_lesson_preselect',
-            'legacy_test_id'
+            'legacy_test_id',
+            'isWizard'
         ));
     }
 
@@ -326,6 +329,9 @@ if ($request->action_btn == 'save_and_add_more') {
 
     if ($legacy_test_id > 0) {
         $params[] = 'test_id=' . $legacy_test_id;
+    }
+    if ($request->has('isWizard')) {
+        $params[] = 'isWizard=1';
     }
 
     $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);

--- a/app/Http/Controllers/Backend/Admin/TestsController.php
+++ b/app/Http/Controllers/Backend/Admin/TestsController.php
@@ -227,12 +227,12 @@ class TestsController extends Controller
             'passing_score' => 80
         ]);
 
-        $redirect_url = route('admin.test_questions.create'). '/' .$selected_course_id . '/' .$uniqueId;
+        $redirect_url = route('admin.test_questions.create', [
+            'course_id' => $selected_course_id,
+            'uuid'      => $uniqueId,
+            'isWizard'  => 1,
+        ]);
 
-        if($request->test) {
-            $redirect_url .= '/true';
-        }
-        
 
         // redirect
         return redirect($redirect_url);

--- a/app/Http/Controllers/LessonsController.php
+++ b/app/Http/Controllers/LessonsController.php
@@ -61,6 +61,7 @@ class LessonsController extends Controller
         'published' => 1,
         'temp_id' => $request->uuid,
         'position' => 1,
+        'isWizard' => false,
     ]);
 
     return response()->json(['status' => 'success']);

--- a/resources/views/backend/lessons/create.blade.php
+++ b/resources/views/backend/lessons/create.blade.php
@@ -325,16 +325,40 @@
                             <button type="button" name="addmorebtn" id="addmorebtn"
                                 class="btn btn-outline-info">{{ __('course_pages.admin_lessons_create.add_more_lesson') }}</button>
                         </div>
-                        <div>
-                            <button type="submit" class="btn cancel-btn frm_submit" id="doneBtn">
-                                {{ __('course_pages.admin_lessons_create.save_as_draft') }}
-                            </button>
-                            <button type="submit" class="btn add-btn frm_submit next" id="nextBtn">
-                                Next
-                            </button>
+                          @if($isWizard)
+                            <div class="d-flex align-items-center">
+                                <button type="submit"
+                                    class="btn cancel-btn frm_submit mr-2"
+                                    id="doneBtn">
+                                    Save As Draft
+                                </button>
 
-                            <span class="loading"></span>
-                        </div>
+                                <button type="submit"
+                                    class="btn add-btn frm_submit"
+                                    id="nextBtn">
+                                    Next
+                                </button>
+                            </div>
+                            @else
+                                <div class="d-flex align-items-center">
+                                    <button
+                                        type="button"
+                                        class="btn btn-outline-secondary mr-2 cancel-btn"
+                                        onclick="window.location='{{ route('admin.lessons.index') }}'">
+                                        Cancel
+                                    </button>
+
+                                    <button
+                                        type="submit"
+                                        class="btn add-btn frm_submit"
+                                        id="saveBtn">
+                                        Save
+                                    </button>
+
+                                    <span class="loading ml-3"></span>
+                                </div>
+                        @endif
+                      
                     </div>
                 </div>
             </div>
@@ -644,6 +668,10 @@
                 if (clicked === 'doneBtn') {
                     window.location.href = redirect_url_course;
                 }
+
+                if (clicked === 'saveBtn') {
+                    window.location.href = redirect_url_course;
+                } 
             },
 
             error: function (xhr) {

--- a/resources/views/backend/test_questions/create.blade.php
+++ b/resources/views/backend/test_questions/create.blade.php
@@ -518,21 +518,39 @@
      <button type="button" class="frm_submit add-btn" id="save_and_add_more" value="save_and_add_more">Save & Add More</button>
 
      <span class="text-right pull-right">
-        <button
-            type="button"
-            class="frm_submit cancel-btn"
-            id="save_as_draft"
-            value="Save As Draft">
-            Save As Draft
-        </button>
+        @if($isWizard)
+                            <div class="d-flex align-items-center">
+                                <button type="submit"
+                                    class="btn cancel-btn frm_submit mr-2"
+                                    id="doneBtn">
+                                    Save As Draft
+                                </button>
 
-        <button
-            type="button"
-            class="frm_submit add-btn"
-            id="save"
-            value="Next">
-            Next
-        </button>
+                                <button type="submit"
+                                    class="btn add-btn frm_submit"
+                                    id="nextBtn">
+                                    Next
+                                </button>
+                            </div>
+                            @else
+                                <div class="d-flex align-items-center">
+                                    <button
+                                        type="button"
+                                        class="btn btn-outline-secondary mr-2 cancel-btn"
+                                        onclick="window.location='{{ route('admin.test_questions.index') }}'">
+                                        Cancel
+                                    </button>
+
+                                    <button
+                                        type="submit"
+                                        class="btn add-btn frm_submit"
+                                        id="saveBtn">
+                                        Save
+                                    </button>
+
+                                    <span class="loading ml-3"></span>
+                                </div>
+                        @endif
 </span>
     </div>
 


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR updates the Lesson creation page to display footer action buttons based on the workflow from which the page is accessed.

Previously, the page always displayed **Save As Draft** and **Next**, even when accessed directly from **Lessons → Add New**. These actions are appropriate for the course creation wizard but are confusing during standalone lesson creation, where users expect standard CRUD actions.

This change introduces context-aware button rendering:

- **Standalone Lesson Creation (Lessons → Add New)**
  - Displays **Save** and **Cancel**.
  - Redirects to the Lessons listing after saving.

- **Course Creation Wizard**
  - Continues to display **Save As Draft** and **Next**.
  - Preserves the existing workflow to proceed to the Questions step after lesson creation.

This ensures the correct actions are shown without affecting the existing multi-step course creation process.

Fixes: #910 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 Testing

### Tested on

- [x] Local

### Checklist

- [x] Standalone lesson creation displays Save and Cancel.
- [x] Save successfully creates the lesson.
- [x] Cancel redirects to the Lessons listing.
- [x] Course creation wizard still displays Save As Draft and Next.
- [x] Next correctly navigates to the Questions step.
- [x] Save As Draft still redirects as expected.
- [x] Multiple lesson creation continues to work.
- [x] No JavaScript errors occur.

---

## 📸 Screenshots : 
 Standalone lesson creation
<img width="1902" height="908" alt="image" src="https://github.com/user-attachments/assets/fefa6247-9121-4ab3-b1b4-a80b4141c0b9" />

course creation wizard
<img width="1901" height="906" alt="image" src="https://github.com/user-attachments/assets/c0843fd7-64d9-45e4-9179-6c46160373ac" />

Question creation
<img width="1905" height="907" alt="image" src="https://github.com/user-attachments/assets/485a391b-5e36-4783-a813-a32a92eb5bd7" />


---

## ✅ Checklist

- [x] Code follows project coding standards.
- [x] Existing functionality verified.
- [x] Multi-step course creation workflow preserved.
- [x] No unnecessary files included.
- [x] Ready for review.