### PR TITLE
Fix: Don't force-redirect to Feedback wizard step from standalone question creation

### DIFF
--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -331,11 +331,26 @@ if ($request->action_btn == 'save_and_add_more') {
     $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);
 } 
 
+    // Capture the course's wizard state BEFORE it gets overwritten below.
+    // This is the only reliable signal to tell apart two flows that hit this
+    // same store() action with an identical request shape (course_id set,
+    // temp_id blank, action_btn=Next):
+    //   1) The multi-step Create Course wizard (Course -> Lesson -> Questions
+    //      -> Feedback), where current_step is still 'course-added' or
+    //      'lesson-added' at this point.
+    //   2) An ad-hoc question added to an already-existing course via the
+    //      standalone Tests Management / Question Bank screens, where
+    //      current_step is already past that (e.g. 'question-added',
+    //      'feedback-added') or null for legacy courses.
+    // Only flow (1) should auto-advance into the Feedback wizard step.
+    $courseWizardStep = Course::where('id', $course_id)->value('current_step');
+    $isCourseCreationWizard = in_array($courseWizardStep, ['course-added', 'lesson-added'], true);
+
     Course::where('id', $course_id)->update([
         'current_step' => 'question-added'
     ]);
 
-    if (isset($request->temp_id) && $request->action_btn == 'Next') {
+    if ($isCourseCreationWizard && $request->action_btn == 'Next') {
         if ($course_id) {
             $has_feeback = FeedbackQuestion::query()
                 ->where('course_id', $course_id)


### PR DESCRIPTION
## Summary

Fixes #907 — after creating a quiz question from the standalone **Tests Management** workflow, submitting incorrectly redirected into the Feedback wizard step instead of returning to the Tests/Questions landing page.

## Root cause

`TestQuestionController::store()` handles question creation from **two distinct entry points** that produce an identical request shape:

1. **The multi-step Create Course wizard** (Course → Lesson → Questions → Feedback), reached via `CoursesController::store`/`update`, which redirects to `test_questions.create?course_id=X` with no `test_id`/`uuid`.
2. **The standalone Tests screen** (`admin.tests.index` → select course → Add New → create Test → add question) and the **Question Bank screen** (`admin.test_questions.index` → select course → Add New) — both ALSO redirect to `test_questions.create` with `course_id` set and no `uuid`, since neither flow passes a `temp_id`.

Both flows submit with `temp_id` blank and `action_btn=Next`. The old check:

```php
if (isset($request->temp_id) && $request->action_btn == 'Next') {
```

is `true` for **both**, because `isset()` returns `true` even for an empty string. This made the standalone flows — exactly as reported in #907 — always redirect into the Feedback wizard step, since no `FeedbackQuestion` exists yet for the blank `temp_id`.

## Fix

Use the course's existing `current_step` wizard-tracking field (already used elsewhere in the codebase — see `CoursesController::update` and `course-steps.blade.php`) as the real discriminator, captured **before** it gets overwritten to `question-added` later in the same method:

```php
$courseWizardStep = Course::where('id', $course_id)->value('current_step');
$isCourseCreationWizard = in_array($courseWizardStep, ['course-added', 'lesson-added'], true);

Course::where('id', $course_id)->update(['current_step' => 'question-added']);

if ($isCourseCreationWizard && $request->action_btn == 'Next') {
    // ...redirect to Feedback wizard step, unchanged
}
```

| Entry point | `current_step` at this point | Behavior |
|---|---|---|
| Wizard: Live/Offline course (skips Lessons) → Questions | `course-added` | Auto-advance to Feedback ✅ (unchanged) |
| Wizard: Online course → Lessons → Questions | `lesson-added` | Auto-advance to Feedback ✅ (unchanged) |
| **Tests Management → existing course → add question** (issue repro) | `question-added` / `feedback-added` / `null` | **No longer forced into Feedback** — falls through to `admin.test_questions.index` ✅ (fixed) |

## Verification

I traced all 4 relevant code paths against the fix (table above) and confirmed the `save_and_add_more` action button path is unaffected (it sets `$redirect_url` earlier and isn't `'Next'`, so this block never runs for it).

I attempted to reproduce live on `dev.tadreeblms.com` but the staging environment's TLS certificate is currently broken — Chrome shows a "Privacy error" interstitial that browser automation cannot click through, and `http://` force-redirects to the same broken `https://`. Flagging this separately in case it's worth a look; happy to re-verify live once staging TLS is fixed.

## Files changed

- `app/Http/Controllers/Backend/Admin/TestQuestionController.php`

## Related

Fixes #907