### PR TITLE
Missing Success Message After Updating Status Toggle in Trainees Info…

### DIFF
--- a/resources/views/backend/employee/internal_info.blade.php
+++ b/resources/views/backend/employee/internal_info.blade.php
@@ -26,6 +26,7 @@
             <div class="row">
                 <div class="col-12">
                     <div class="table-responsive">
+                        <div id="employee-status-message" class="mb-3" aria-live="polite"></div>
                         <div class="d-block">
                             <ul class="list-inline">
                                 <li class="list-inline-item">
@@ -86,9 +87,10 @@
 
 @push('after-scripts')
     <script>
+        var employeeStatusUpdatedMessage = @json(__('Status updated successfully.'));
+        var employeeStatusUpdateFailedMessage = @json(__('Unable to update status. Please try again.'));
+        var employeeStatusCloseLabel = @json(__('Close'));
         $(document).ready(function() {
-
-
 
             var route = '{{ route('admin.employee.get_data') }}';
 
@@ -254,19 +256,51 @@
 
 
         });
-        $(document).on('click', '.switch-input', function(e) {
-            var id = $(this).data('id');
+
+        function showEmployeeStatusMessage(message, type) {
+
+            var alertClass = type === 'success'
+                ? 'alert-success'
+                : 'alert-danger';
+            var escapedMessage = $('<div>').text(message).html();
+
+            $('#employee-status-message').html(
+                '<div class="alert ' + alertClass + ' alert-dismissible fade show" role="alert">' +
+                    escapedMessage +
+                    '<button type="button" class="close" data-dismiss="alert" aria-label="' + employeeStatusCloseLabel + '">' +
+                        '<span aria-hidden="true">&times;</span>' +
+                    '</button>' +
+                '</div>'
+            );
+        }
+
+        $(document).on('click', '.switch-input', function () {
+            var $switch = $(this);
+            var id = $switch.data('id');
+
+            $switch.prop('disabled', true);
             $.ajax({
                 type: "POST",
                 url: "{{ route('admin.employee.status') }}",
                 data: {
-                    _token: '{{ csrf_token() }}',
+                    _token: "{{ csrf_token() }}",
                     id: id,
                 },
-            }).done(function() {
-                var table = $('#myTable').DataTable();
-                table.ajax.reload();
+            }).done(function (response) {
+                showEmployeeStatusMessage(
+                    response.message || employeeStatusUpdatedMessage,
+                    'success'
+                );
+                $('#myTable').DataTable().ajax.reload(null, false);
+            }).fail(function (xhr) {
+                var message = xhr.responseJSON && xhr.responseJSON.message
+                    ? xhr.responseJSON.message
+                    : employeeStatusUpdateFailedMessage;
+                showEmployeeStatusMessage(message, 'error');
+                $('#myTable').DataTable().ajax.reload(null, false);
+            }).always(function () {
+                $switch.prop('disabled', false);
             });
-        })
+        });
     </script>
 @endpush


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the missing user feedback after updating the trainee status from the **Reports → Trainees Info** module.

Previously, when an administrator toggled a trainee's Active/Inactive status, the update was processed successfully, but no success or confirmation message was displayed. This created uncertainty about whether the action had completed successfully.

This update introduces a consistent status notification similar to other modules by displaying a success message after a successful status update and an error message if the request fails.

Fixes: #783

---

## ✅ Type of Change

- [x] 🐞 Bug fix
- [x] 🎨 UI/UX update

---

## 📸 Screenshots (if applicable)

<img width="1910" height="913" alt="image" src="https://github.com/user-attachments/assets/01159e6b-ba78-42b1-bd70-d169f8266a38" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing
- [x] Other: Verified successful and failed AJAX responses for the status toggle.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in to the Admin Panel.
2. Navigate to **Reports → Trainees Info**.
3. Locate any trainee record.
4. Toggle the Active/Inactive status switch.
5. Verify that a success confirmation message is displayed after the status is updated.
6. Verify that an error message is displayed if the update request fails.

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

- Added a reusable status message container to display success and error alerts.
- Implemented AJAX success and error handling for the trainee status toggle.
- Reloaded the DataTable without resetting the current pagination after the status update.
- Aligned the Trainees Info module's user feedback behavior with similar status toggle implementations across the application for a more consistent user experience.