### PR TITLE
fixed the assessment modal submission issue

### DIFF
--- a/resources/views/frontend-rtl/assignment/manual_question_set.blade.php
+++ b/resources/views/frontend-rtl/assignment/manual_question_set.blade.php
@@ -136,7 +136,14 @@
         }
 
         var flag = [];
-        $(document).on('click', '.mg_all_submit', function() {
+        $(document).on('click', '.mg_all_submit', function(e) {
+            e.preventDefault(); 
+            const confirmationText = "Thank you for attending this assessment. We will get back to you with the result soon.\n\nAre you sure you want to submit?";
+    
+            if (!window.confirm(confirmationText)) {
+                return false; 
+            }
+            $('.mg_all_submit').prop('disabled', true);
 
             // if (flag.includes(0)) {
             //     alert('Please answer all the questions');
@@ -154,11 +161,8 @@
                 success: function(response) {
                     response = JSON.parse(response);
                     if (response.status == 200) {
-                        if (window.confirm(response.message)) {
-                            window.location = home_url;
-                        } else {
-                            window.location = home_url;
-                        }
+                        window.alert(response.message);
+                        window.location = home_url;
                     }
                 },
             });

--- a/resources/views/frontend-rtl/assignment/question_set.blade.php
+++ b/resources/views/frontend-rtl/assignment/question_set.blade.php
@@ -234,7 +234,14 @@
         }
 
         var flag = [];
-        $(document).on('click', '.mg_all_submit', function() {
+        $(document).on('click', '.mg_all_submit', function(e) {
+
+            e.preventDefault(); 
+            const confirmationText = "Thank you for attending this assessment. We will get back to you with the result soon.\n\nAre you sure you want to submit?";
+    
+            if (!window.confirm(confirmationText)) {
+                return false; 
+            }
 
             $('.mg_all_submit').prop('disabled', true);
 
@@ -251,11 +258,8 @@
                 success: function(response) {
                     response = JSON.parse(response);
                     if (response.status == 200) {
-                        if (window.confirm(response.message)) {
-                            window.location = home_url;
-                        } else {
-                            window.location = home_url;
-                        }
+                        window.alert(response.message);
+                        window.location = home_url;
                     }
                 },
             });

--- a/resources/views/frontend/assignment/manual_question_set.blade.php
+++ b/resources/views/frontend/assignment/manual_question_set.blade.php
@@ -403,8 +403,14 @@
         }
 
         var flag = [];
-        $(document).on('click', '.mg_all_submit', function() {
-
+        $(document).on('click', '.mg_all_submit', function(e) {
+            e.preventDefault(); 
+            const confirmationText = "Thank you for attending this assessment. We will get back to you with the result soon.\n\nAre you sure you want to submit?";
+    
+            if (!window.confirm(confirmationText)) {
+                return false; 
+            }
+            $('.mg_all_submit').prop('disabled', true);
             // if (flag.includes(0)) {
             //     alert('Please answer all the questions');
             // }
@@ -421,11 +427,8 @@
                 success: function(response) {
                     response = JSON.parse(response);
                     if (response.status == 200) {
-                        if (window.confirm(response.message)) {
-                            window.location = home_url;
-                        } else {
-                            window.location = home_url;
-                        }
+                        window.alert(response.message);
+                        window.location = home_url;
                     }
                 },
             });

--- a/resources/views/frontend/assignment/question_set.blade.php
+++ b/resources/views/frontend/assignment/question_set.blade.php
@@ -505,7 +505,13 @@
         }
 
         var flag = [];
-        $(document).on('click', '.mg_all_submit', function() {
+        $(document).on('click', '.mg_all_submit', function(e) {
+            e.preventDefault(); 
+            const confirmationText = "Thank you for attending this assessment. We will get back to you with the result soon.\n\nAre you sure you want to submit?";
+    
+            if (!window.confirm(confirmationText)) {
+                return false; 
+            }
 
             $('.mg_all_submit').prop('disabled', true);
 
@@ -521,18 +527,8 @@
                 success: function(response) {
                     response = JSON.parse(response);
                     if (response.status == 200) {
-
-                        //alert(response.has_feedback)
-                        //var home_url = '{{ url('/online_assessment') }}' + window.location.search;
-                        if(response.has_feedback == 1) {
-                            window.location = response.return_url;
-                        }
-
-                        if (window.confirm(response.message)) {
-                            window.location = response.return_url;
-                        } else {
-                            window.location = response.return_url;
-                        }
+                        window.alert(response.message);
+                        window.location = response.return_url;
                     }
                 },
             });


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes the issue where clicking the "Cancel" button on the Final Assessment confirmation modal still submitted the form. I updated the JavaScript click event to intercept the submission, prompt the user *before* the AJAX call is made, and stop execution if they cancel.

Fixes: #936

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

N/A - Logic fix.

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Local environment
- [ ] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [ ] Other:

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Navigate to a course with a Final Assessment.
2. Click the "Submit Assessment" button.
3. Click "Cancel" on the confirmation popup.
4. Verify that the form does not submit and the user remains on the page.

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [ ] Ensured the app builds without errors

---

## 🙏 Additional Notes

Applied the fix to the standard and RTL layout files (`question_set.blade.php` and `manual_question_set.blade.php`) to ensure the bug is resolved across assessment types. 

*Note: I applied the JavaScript logic fix directly to address the issue, but I did not run a full local PHP environment test. Could a maintainer please verify the pre-AJAX confirmation pop-up behavior before merging?*