### PR TITLE
Unwanted DataTables Selection Information Displayed on Certificates P…

### DIFF
--- a/resources/views/backend/certificates/admin_index.blade.php
+++ b/resources/views/backend/certificates/admin_index.blade.php
@@ -87,6 +87,9 @@
                     }
                 },
                 iDisplayLength: 10,
+                select: {
+                    info: false
+                },
                 language: {
                     @if (app()->getLocale() == 'ar')
                     url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ar.json'


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

The Certificates Management page displayed unwanted DataTables selection status information in the table footer:

`0 rows selected 0 columns selected 0 cells selected`

This message was displayed by default even when no rows, columns, or cells were selected.

This PR disables the DataTables Select extension's selection information display for the Certificates Management table. The standard table information, including the total entries count and pagination controls, remains unchanged.

- What problem does this PR solve?
  - Removes the unnecessary selection status message from the Certificates Management page.
  - Prevents confusion caused by displaying selection-related information when selection functionality is not required.

- What feature does it add?
  - No new feature added.
  - The DataTables selection information display is disabled for the Certificates Management table.

- What issue does it close?

Fixes: #943

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 📸 Screenshots (if applicable)

<img width="1907" height="892" alt="image" src="https://github.com/user-attachments/assets/2e24ec33-bc61-476d-9c47-a1632f28f153" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing

### Testing Details

- Opened the Certificates Management page.
- Verified that the `0 rows selected 0 columns selected 0 cells selected` message is no longer displayed.
- Verified that the total entries count is still displayed.
- Verified that pagination controls are still displayed and functional.
- Verified that the Certificates Management DataTable continues to load records correctly.
- Verified that existing course, user, status, and date filters continue to work.
- Verified that existing View and Reissue Certificate actions remain functional.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Login to the application as an administrator.
2. Navigate to **Certificates Management**.
3. Scroll to the bottom of the Certificates DataTable.
4. Observe the DataTables footer section.
5. Notice that the following message is displayed even when no records are selected:

`0 rows selected 0 columns selected 0 cells selected`

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

The fix is limited to the Certificates Management DataTable configuration.

The DataTables Select extension's selection information display has been disabled using:

```javascript
select: {
    info: false
}