### PR TITLE
Missing Success Notification After Creating or Updating User Group #940

### DIFF
--- a/app/Http/Controllers/Backend/Admin/DepartmentController.php
+++ b/app/Http/Controllers/Backend/Admin/DepartmentController.php
@@ -172,14 +172,12 @@ class DepartmentController extends Controller
         $page->sidebar = 1;
         $page->save();
 
-        return response()->json([ 'status'=>'success' , 'clientmsg' => 'Added successfully' ]);
+        session()->flash('success', 'User Group created successfully.');
 
-        if ($page->id) {
-            return redirect()->route('admin.department.index')->withFlashSuccess(__('alerts.backend.general.created'));
-        } else {
-            return redirect()->route('admin.department.index')->withFlashDanger(__('alerts.backend.general.error'));
-
-        }
+        return response()->json([
+            'status' => 'success',
+            'redirect' => route('admin.department.index'),
+        ]);
     }
 
     /**
@@ -245,7 +243,7 @@ class DepartmentController extends Controller
         $page->sidebar = 0;
         $page->save();
 
-        return redirect()->route('admin.department.index')->withFlashSuccess(__('alerts.backend.general.updated'));
+        return redirect()->route('admin.department.index')->with('success', 'User Group updated successfully.');
 
 
     }


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixed the issue where the success notification was not displayed after successfully creating a new User Group.

The User Group creation form uses an AJAX request to submit the form and redirects directly to the User Group listing page. Because the request is handled through JavaScript, the Laravel session flash success message was not being displayed after the redirect.

This PR updates the User Group creation flow to properly handle the successful response and display the appropriate success notification to the user.

### Changes Made

- Fixed the User Group creation success notification issue.
- Updated the User Group creation response handling.
- Ensured successful User Group creation provides a proper success message.
- Maintained the existing success notification behavior for User Group updates.
- Improved the create User Group form submission flow and redirect handling.

Fixes: #940 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 📸 Screenshots 

<img width="1907" height="887" alt="image" src="https://github.com/user-attachments/assets/718847d5-8eaa-43c8-8521-fcc4be7f9edc" />

---

## 🚀 How Has This Been Tested?

- [x] Local environment
- [x] Browser testing

### Testing Performed

1. Navigated to the User Group management page.
2. Clicked **Add User Group**.
3. Entered valid User Group details.
4. Clicked the **Save** button.
5. Verified that the User Group was successfully created.
6. Verified that the user was redirected to the User Group listing page.
7. Verified that the **"User Group created successfully."** success notification is displayed.
8. Verified that the existing User Group update success notification continues to work correctly.

---

## 🧪 Steps to Reproduce

1. Navigate to **Admin Panel → User Groups**.
2. Click **Add User Group**.
3. Enter valid User Group details.
4. Click **Save**.
5. Observe the User Group listing page after successful creation.
6. Previously, the User Group was created successfully, but no success notification was displayed.

### Expected Result

After successfully creating a User Group, the user should be redirected to the User Group listing page and see a success notification:

> User Group created successfully.

---

## 🔄 Checklist

- [x] Followed the project's coding guidelines
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

The issue was caused by the User Group creation form being submitted through AJAX. The controller returned a JSON response, while the frontend JavaScript performed the redirect independently. Therefore, the Laravel session flash message was never available on the redirected page.

The create flow has been updated to properly handle the successful creation response and show the success notification to the user.