### PR TITLE
Cancel Action in Course Feedback Confirmation Dialog Still Submits Fo…

### DIFF
--- a/resources/views/frontend/assignment/user-feedback.blade.php
+++ b/resources/views/frontend/assignment/user-feedback.blade.php
@@ -207,7 +207,8 @@
                         if (window.confirm(response.message)) {
                             window.location = response.url;
                         } else {
-                            window.location = response.url;
+                            $('.feedback_submit').prop('disabled', false);
+                            return false;
                         }
                     }
                 },


### PR DESCRIPTION
# 📥 Pull Request

## 🔧 Description

This PR fixes an issue where cancelling the browser confirmation dialog after submitting Course Feedback still redirected the user to the lesson completion page.

Previously, both the **OK** and **Cancel** actions executed the same redirect logic, causing unintended navigation despite the user's cancellation.

This update ensures that:

- Clicking **OK** proceeds with the redirect.
- Clicking **Cancel** stops the redirect.
- The feedback page remains open for review or modification.
- The submit button is re-enabled after cancellation.

Fixes: #937 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 Testing

### Tested Scenarios

- [x] Submit feedback and click **OK** → Redirects correctly.
- [x] Submit feedback and click **Cancel** → No redirect.
- [x] User remains on the feedback page after cancellation.
- [x] Submit button is re-enabled after cancelling.
- [x] User can modify feedback and submit again.

---

## 📸 Screenshots

<img width="1917" height="907" alt="image" src="https://github.com/user-attachments/assets/26a86410-6114-4cab-8c9f-4f155469e856" />
<img width="1911" height="913" alt="image" src="https://github.com/user-attachments/assets/c747386b-ea91-4247-84c4-af0c2d03f2e7" />


---

## ✅ Checklist

- [x] Code follows project coding standards.
- [x] Existing functionality verified.
- [x] No console errors.
- [x] Tested locally.