### PR TITLE
Missing Column Header Label in KPI Role Configurations Table #929

### DIFF
--- a/resources/lang/en/kpi.php
+++ b/resources/lang/en/kpi.php
@@ -95,6 +95,7 @@ return [
         'global_active' => 'Global Active',
         'override_weight' => 'Override Weight',
         'override_active' => 'Override Active',
+        'action' => 'Actions',
         'role_scope' => 'Role Scope',
         'course_scope' => 'Course Scope',
         'target_value_percent' => 'Target Value (%)',

--- a/resources/views/backend/kpis/role_configs/index.blade.php
+++ b/resources/views/backend/kpis/role_configs/index.blade.php
@@ -39,7 +39,7 @@
                             <th>@lang('kpi.labels.global_active')</th>
                             <th style="min-width:130px">@lang('kpi.labels.override_weight')</th>
                             <th style="min-width:130px">@lang('kpi.labels.override_active')</th>
-                            <th></th>
+                            <th>@lang('kpi.labels.action')</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
# 📥 Pull Request

## 🔧 Description

This PR fixes a UI issue in the **KPI Role Configurations** table where the **Action** column header was missing.

Previously, the last table column displayed **Save** (and Remove Override) action buttons, but the corresponding `<th>` element was empty, resulting in an incomplete and inconsistent table structure.

### Changes Made

* Added an **"Action"** header label for the last column in the KPI Role Configurations table.
* Ensured the table header correctly maps to the corresponding action column.
* Improved table readability and UI consistency.

Fixes: #929 

---

## ✅ Type of Change

* [x] 🐞 Bug fix
* [x] 🎨 UI/UX update

---

## 📸 Screenshots 

<img width="1910" height="907" alt="image" src="https://github.com/user-attachments/assets/75f69b56-3c27-45ec-ac88-fcb4034364d6" />

---

## 🚀 How Has This Been Tested?

* [x] Local environment
* [x] Browser testing

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as an administrator.
2. Navigate to **KPI Management → KPI Role Configurations**.
3. Observe the KPI Role Configurations data table.
4. Verify that the last column now displays the **Action** header above the Save/Delete action buttons.

---

## 🔄 Checklist

* [x] Followed the project's coding guidelines
* [x] Verified no sensitive data is included
* [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

This change is purely a UI improvement and does not modify any business logic or backend functionality. It improves table clarity, accessibility, and overall user experience by ensuring every data column has a corresponding header.
