### PR TITLE
Raw Boolean Values Displayed in In Sequence Column #962

### DIFF
--- a/resources/views/backend/learning-pathway/index.blade.php
+++ b/resources/views/backend/learning-pathway/index.blade.php
@@ -74,7 +74,12 @@
             },
             {
                 data: "in_sequence",
-                name: 'in_sequence'
+                name: "in_sequence",
+                render: function (data) {
+                    return Number(data) === 1
+                        ? '<span class="badge bg-success" style="color:#fff; padding:7px;">Yes</span>'
+                        : '<span class="badge bg-red" style="color:#fff;  padding:7px;">No</span>';
+                }
             },
             {
                 data: "actions",


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR improves the readability of the **Learning Pathways** listing by replacing raw boolean values displayed in the **In Sequence** column with user-friendly labels.

Previously, the datatable displayed database values (`1` and `0`), exposing implementation details and reducing usability.

This change formats the values before rendering:

- `1` → **Yes**
- `0` → **No**

This keeps the UI consistent with other boolean fields across the application.

Fixes: #962 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 How Has This Been Tested?

- Opened **Learning Pathways** listing.
- Verified that records with `in_sequence = 1` display **Yes**.
- Verified that records with `in_sequence = 0` display **No**.
- Confirmed no impact on sorting, pagination, or search functionality.

---

## 📸 Screenshots 

<img width="1916" height="900" alt="image" src="https://github.com/user-attachments/assets/dd3ca243-8fe8-4411-a5d9-aadacd46835e" />

