### PR TITLE
Select Course dropdown does not auto-populate with the newly created …

### DIFF
--- a/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
+++ b/app/Http/Controllers/Backend/Admin/AssessmentAccountsController.php
@@ -436,8 +436,9 @@ public function courseAssignment(Request $request)
                             ->pluck('name', 'id');
 
         $departments = Department::all();
+        $selectedCourse = $request->course_id;
         
-        return view('backend.assessment_accounts.create_assignment_course', compact('user_id', 'tests', 'teachers', 'courses', 'category', 'departments'));
+        return view('backend.assessment_accounts.create_assignment_course', compact('user_id', 'tests', 'teachers', 'courses', 'category', 'departments','selectedCourse'));
         // return view('backend.assessment_accounts.assignment_create', compact('user_id', 'tests','teachers','courses'));
     }
 

--- a/resources/views/backend/assessment_accounts/create_assignment_course.blade.php
+++ b/resources/views/backend/assessment_accounts/create_assignment_course.blade.php
@@ -129,13 +129,17 @@
                     <div class="col-md-12 custom-select-wrapper">
                         <select class="form-control custom-select-box select2"
                                 name="course_ids[]" multiple >
-                            <option value="" disabled {{ old('course_id') ? '' : 'selected' }}>
-                                Select One Course
-                            </option>
 
                             @foreach ($courses as $value)
                                 <option value="{{ $value->id }}"
-                                    {{ old('course_id') == $value->id ? 'selected' : '' }}>
+                                    {{
+                                        in_array(
+                                            $value->id,
+                                            old('course_ids', $selectedCourse ? [$selectedCourse] : [])
+                                        )
+                                            ? 'selected'
+                                            : ''
+                                    }}>
                                     {{ $value->title }}
                                 </option>
                             @endforeach


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This PR fixes an issue where the newly created course was not automatically selected in the **Select Course** dropdown after clicking **"Yes, Assign Now"** from the course creation success popup.

The course ID was already being passed through the URL, but the assignment page ignored the parameter and always loaded with an empty course selection.

This change reads the `course_id` from the request, passes it to the view, and pre-selects the corresponding course in the Select2 dropdown to provide a smoother assignment workflow.

Fixes: #578 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 How Has This Been Tested?

- Created a new course successfully.
- Clicked **Yes, Assign Now** from the confirmation popup.
- Verified navigation to the Course Assignment page.
- Confirmed the newly created course is automatically selected in the **Select Course** dropdown.
- Completed a course assignment successfully using the pre-selected course.

---

## 📸 Screenshots (if applicable)

<img width="1906" height="910" alt="image" src="https://github.com/user-attachments/assets/163a31c5-ac58-4a95-926d-987ffa64b902" />

---

## ✔️ Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] No existing functionality is broken.
- [x] The fix is limited to the reported issue.
- [x] Documentation/comments updated where necessary.