### PR TITLE
Toggle Switch Misalignment in Notification Settings Page #601

### DIFF
--- a/resources/views/backend/settings/notifications.blade.php
+++ b/resources/views/backend/settings/notifications.blade.php
@@ -15,7 +15,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: 12px 0;
+        padding: 14px 0;
         border-bottom: 1px solid #f1f1f1;
         gap: 20px;
     }
@@ -29,12 +29,14 @@
         font-weight: 500;
         color: #2d3748;
         margin-bottom: 0;
+        flex: 1;
     }
 
     .toggle-group {
+        flex-shrink: 0;
         display: flex;
         align-items: center;
-        justify-content: flex-start;
+        justify-content: flex-end;
         min-width: 60px;
     }
 
@@ -43,6 +45,9 @@
     }
     .card {
         margin-bottom: 20px;
+    }
+    .switch-label{
+        width: 100%;
     }
 </style>
 @endpush
@@ -69,23 +74,24 @@
         </div>
 
         <hr/>
-
-        <div class="row mt-4 mb-4">
-            <div class="col">
-                <div class="notification-setting-row">
+               <div class="notification-setting-row">
                     <label class="notification-label">
                         {{ __('labels.notifications.settings.email_notifications') }}
                     </label>
+
                     <div class="toggle-group">
                         <label class="switch switch-3d switch-primary">
-                            <input type="checkbox" class="switch-input channel-master-toggle" data-channel="email" checked>
+                            <input
+                                type="checkbox"
+                                class="switch-input channel-master-toggle"
+                                data-channel="email"
+                                checked>
+
                             <span class="switch-label"></span>
                             <span class="switch-handle"></span>
                         </label>
                     </div>
                 </div>
-            </div>
-        </div>
     </div>
 </div>
 
@@ -102,34 +108,44 @@
 
         <hr/>
 
-        <div class="row mt-4 mb-4">
-            <div class="col">
-                @foreach($module['events'] as $eventKey => $event)
+               @foreach($module['events'] as $eventKey => $event)
+
                 <div class="notification-setting-row">
+
                     <label class="notification-label">
                         {{ $event['label'] }}
                     </label>
+
                     <div class="toggle-group">
-                        @php $emailChannel = $event['channels']['email'] ?? null; @endphp
+
+                        @php
+                            $emailChannel = $event['channels']['email'] ?? null;
+                        @endphp
+
                         @if($emailChannel)
-                            <label class="switch switch-3d switch-primary">
-                                <input type="checkbox"
-                                    class="switch-input notification-toggle"
-                                    data-module="{{ $moduleKey }}"
-                                    data-event="{{ $eventKey }}"
-                                    data-channel="email"
-                                    {{ $emailChannel['enabled'] ? 'checked' : '' }}
-                                >
-                                <span class="switch-label"></span>
-                                <span class="switch-handle"></span>
-                            </label>
+
+                        <label class="switch switch-3d switch-primary">
+
+                            <input
+                                type="checkbox"
+                                class="switch-input notification-toggle"
+                                data-module="{{ $moduleKey }}"
+                                data-event="{{ $eventKey }}"
+                                data-channel="email"
+                                {{ $emailChannel['enabled'] ? 'checked' : '' }}>
+
+                            <span class="switch-label"></span>
+                            <span class="switch-handle"></span>
+
+                        </label>
+
                         @endif
+
                     </div>
 
                 </div>
+
                 @endforeach
-            </div>
-        </div>
     </div>
 </div>
 @endforeach


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

This pull request resolves the UI alignment issue on the **Notification Settings** page by improving the positioning of notification toggle switches.

Previously, the toggle switches were displayed with excessive spacing from their corresponding notification labels, resulting in an inconsistent and less intuitive interface.

The toggle container styling has been updated to ensure each switch is properly aligned with its respective label while maintaining the existing functionality and responsive layout.

**Fixes:** #601 

---

## ✅ Type of Change

- [x] 🐞 Bug fix

---

## 🧪 How Has This Been Tested?

- Verified the Notification Settings page loads successfully.
- Verified the **Global Channel Controls** toggle is correctly aligned with its label.
- Verified notification toggles under all modules are consistently aligned with their corresponding labels.
- Confirmed toggle functionality (enable/disable) works as expected.
- Tested the layout on different screen sizes to ensure consistent alignment and responsiveness.

---

## 📸 Screenshots (if applicable)

<img width="1917" height="916" alt="image" src="https://github.com/user-attachments/assets/a60c1581-e96e-4c68-a7f2-c59519bcb8bb" />

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have tested my changes locally.
- [x] Existing functionality remains unaffected.
- [x] UI alignment has been verified.
- [x] Changes are limited to UI/CSS improvements only.