### PR TITLE
Success Message Not Displayed on Role Creation and updating as well.#780

### DIFF
--- a/app/Http/Controllers/Backend/Admin/RolesController.php
+++ b/app/Http/Controllers/Backend/Admin/RolesController.php
@@ -73,7 +73,7 @@ class RolesController extends Controller
 
 
         return redirect()->route('admin.roles.index')
-            ->with('success', 'Role created successfully.');;
+            ->with('flash_success', 'Role created successfully.');;
     }
 
 
@@ -146,7 +146,8 @@ class RolesController extends Controller
 
         $role->syncPermissions($permissions);
 
-        return redirect()->route('admin.roles.index');
+        return redirect()->route('admin.roles.index')
+            ->with('flash_success', 'Role updated successfully.');
     }
 
 


### PR DESCRIPTION
# 🐞 Defect Title

⚠️ **Success Message Not Displayed on Role Creation**

---

## 📍 Module

🧩 **User Management → Roles**

---

## 📝 Description

When an administrator successfully creates a new role, the role is created successfully in the backend, but no success or confirmation message is displayed in the UI.

The issue was caused by a mismatch between the session key used by the `RolesController` and the session key checked by the Roles index Blade view.

The controller was flashing the message using the `success` session key, while the view was checking for `flash_success`.

The success message has been updated to use the existing `flash_success` convention so that administrators receive clear confirmation after successfully creating a role.

Issue : #780 
---

## 🔁 Steps to Reproduce

1. Log in to the Admin Panel.
2. Navigate to **User Management → Roles**.
3. Click **Create Role**.
4. Enter the required role details.
5. Select the required permissions.
6. Submit the form.
7. Observe the response on the Roles page.

---

## ✅ Expected Result

✔️ A success message should be displayed after successful role creation.

✔️ The administrator should receive clear confirmation that the role was created successfully.

Expected message:

> **Role created successfully.**

---

## 🧪 Testing

### Role Creation

* [x] Created a new role successfully.
* [x] Verified that the role appears in the Roles table.
* [x] Verified that the success message is displayed.
* [x] Verified that the message appears after redirecting to the Roles page.

### Validation

* [x] Verified that unsuccessful submissions do not display the role-created success message.
* [x] Verified that existing validation behavior remains unchanged.

### Regression

* [x] Existing role listing remains functional.
* [x] Existing role edit functionality remains unchanged.
* [x] Existing role delete functionality remains unchanged.
* [x] Permission assignment remains unchanged.

---

## Screenshots :

<img width="1897" height="917" alt="image" src="https://github.com/user-attachments/assets/4a83b440-25ab-40d5-b43e-82c51cf3bcec" />
<img width="1892" height="910" alt="image" src="https://github.com/user-attachments/assets/bc2e6394-0f76-480d-823d-8caab42c6b4f" />


---

## 📌 Conclusion

This fix ensures that administrators receive immediate confirmation after successfully creating a role. It also aligns the role creation response with the existing flash-message handling used by the Roles UI.
