### PR TITLE
Enrolled Trainee Progress Not Updating in Admin Panel.#805

### DIFF
--- a/app/Http/Controllers/Backend/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Backend/Admin/EmployeeController.php
@@ -821,24 +821,25 @@ class EmployeeController extends Controller
 
                 return '<span class="pill-publish">Completed</span>';
             })
-            ->addColumn('feedback', function ($q)  use ($course_id, $request) {
+            ->addColumn('feedback', function ($q) use ($course_id) {
 
-                return CustomHelper::is_user_course_has_feedback($q->user_id, $course_id) ?  '<a class="btn btn-info mb-1" href="' . route('admin.employee.course_detail', [$course_id, $q->user_id]) . '">Veiw FeedBack</a>'  : '--';
+                $feedbackSubmitted = \DB::table('user_feedback')
+                    ->where('user_id', $q->user_id)
+                    ->where('course_id', $course_id)
+                    ->exists();
+
+                return $feedbackSubmitted
+                    ? '<span class="pill-publish">Yes</span>'
+                    : '<span class="pill-unpublish">No</span>';
             })
-            ->addColumn('issue_certificate', function ($q) use ($course_id, $request) {
+            ->addColumn('issue_certificate', function ($q) use ($course_id) {
+                $certificateIssued = UserCourseDetail::where('user_id', $q->user_id)
+                    ->where('course_id', $course_id)
+                    ->value('issue_certificate');
 
-                $has_certificate = CustomHelper::is_user_course_has_issed_certificate($q->user_id, $course_id);
-                if ($has_certificate) {
-                    $view_certificate_actions = '<a target="_blank" class="badge badge-success" href="' . asset('storage/certificates/' . $has_certificate->certificate_url) . '">View Certificate</a>';
-                } else {
-                    $is_completed = CustomHelper::is_course_completed($q->user_id, $course_id);
-                    if ($is_completed) {
-                        $view_certificate_actions = '<a class="badge badge-info" href="' . route('certificates.generate', [$course_id, $q->user_id]) . '">Issue Certificate</a>';
-                    } else {
-                        $view_certificate_actions = '--';
-                    }
-                }
-                return $view_certificate_actions;
+                return strtolower((string) $certificateIssued) === 'yes'
+                    ? '<span class="pill-publish">Issued</span>'
+                    : '<span class="pill-unpublish">Not Issued</span>';
             })
             ->addColumn('track_employee', function ($q) use ($course_id, $request) {
 
@@ -1129,20 +1130,24 @@ class EmployeeController extends Controller
                 return $summary['status'];
             })
             ->addColumn('feedback', function ($q) use ($course_id) {
-                return CustomHelper::is_user_course_has_feedback($q->user_id, $course_id)
-                    ? '<a class="btn btn-info mb-1" href="' . route('admin.employee.course_detail', [$course_id, $q->user_id]) . '">Veiw FeedBack</a>'
-                    : '--';
+
+                $feedbackSubmitted = \DB::table('user_feedback')
+                    ->where('user_id', $q->user_id)
+                    ->where('course_id', $course_id)
+                    ->exists();
+
+                return $feedbackSubmitted
+                    ? '<span class="pill-publish">Yes</span>'
+                    : '<span class="pill-unpublish">No</span>';
             })
             ->addColumn('issue_certificate', function ($q) use ($course_id) {
-                $has_certificate = CustomHelper::is_user_course_has_issed_certificate($q->user_id, $course_id);
-                if ($has_certificate) {
-                    return '<a target="_blank" class="badge badge-success" href="' . asset('storage/certificates/' . $has_certificate->certificate_url) . '">View Certificate</a>';
-                }
-                $is_completed = CustomHelper::is_course_completed($q->user_id, $course_id);
-                if ($is_completed) {
-                    return '<a class="badge badge-info" href="' . route('certificates.generate', [$course_id, $q->user_id]) . '">Issue Certificate</a>';
-                }
-                return '--';
+                $certificateIssued = UserCourseDetail::where('user_id', $q->user_id)
+                    ->where('course_id', $course_id)
+                    ->value('issue_certificate');
+
+                return strtolower((string) $certificateIssued) === 'yes'
+                    ? '<span class="pill-publish">Issued</span>'
+                    : '<span class="pill-unpublish">Not Issued</span>';
             })
             ->addColumn('track_employee', function ($q) use ($course_id) {
                 $is_course_started = CustomHelper::is_course_completed($q->user_id, $course_id);


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

Fixes the incorrect display of Feedback and Certificate status in the Enrolled Trainees DataTable.

After a trainee completes a course, the Feedback and Certificate columns were displaying action links or `--` instead of clearly indicating the current status.

This change updates the DataTable to display meaningful status values:

- Feedback → `Yes` / `No`
- Certificate → `Issued` / `Not Issued`

The existing helper methods and certificate state are reused. No database migration is required.

### Feedback

- `Yes` when feedback has been submitted
- `No` when feedback has not been submitted

### Certificate

- `Issued` when a certificate has been generated/issued
- `Not Issued` when a certificate has not been generated/issued

Issue : #805 
---

## 🔁 Steps to Reproduce

1. Log in to the Admin Panel.
2. Navigate to **Courses Management**.
3. Open a course.
4. Navigate to the **Enrolled Trainees** section.
5. Select a trainee.
6. Complete the course as the end user.
7. Submit course feedback.
8. Generate/download the certificate.
9. Return to the Enrolled Trainees list.
10. Observe the **Feedback** and **Certificate Issued** columns.

---

## ✅ Expected Result

### Feedback

✔️ Feedback submitted:

`Yes`

✔️ Feedback not submitted:

`No`

### Certificate

✔️ Certificate generated/issued:

`Issued`

✔️ Certificate not generated/issued:

`Not Issued`

---

## Screenshots : 

<img width="1906" height="907" alt="image" src="https://github.com/user-attachments/assets/c501f59c-3ed9-4f00-8918-c4fb71b42bf9" />
<img width="1915" height="902" alt="image" src="https://github.com/user-attachments/assets/f991e9a4-b69c-42ed-b359-b11d45fa6754" />
