### PR TITLE
Course Creation Wizard Redirects to Global Questions Page Instead of …

### DIFF
--- a/app/Http/Controllers/Backend/Admin/CoursesController.php
+++ b/app/Http/Controllers/Backend/Admin/CoursesController.php
@@ -904,10 +904,14 @@ $teachers = [$teacherId];
                 $q->where('role_id', 3)->where('employee_type', 'internal');
             })->get()->pluck('name', 'id');
 
-            if($request->course_type == 'Online') {
-                $redirect_url = route('admin.lessons.create') . '?course_id=' . $course->id;
+            if ($request->course_type == 'Online') {
+                $redirect_url = route('admin.lessons.create') .
+                    '?course_id=' . $course->id .
+                    '&course_creation_wizard=1';
             } else {
-                $redirect_url = route('admin.test_questions.create') . '?course_id=' . $course->id;
+                $redirect_url = route('admin.test_questions.create') .
+                    '?course_id=' . $course->id .
+                    '&course_creation_wizard=1';
             }
 
             if ($request->meeting_provider && $request->course_type === 'Offline') {

--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -57,6 +57,7 @@ class TestQuestionController extends Controller
             ?? optional(Test::find($request->test_id))->course_id
             ?? optional(Test::find($request->input('test_id')))->course_id;
         $temp_id = $temp_id ?? $request->uuid; 
+        $course_creation_wizard = $request->boolean('course_creation_wizard');
         $legacy_test_id = (int) $request->input('test_id');
         $selected_test = $legacy_test_id > 0 ? Test::find($legacy_test_id) : null;
 
@@ -121,13 +122,15 @@ class TestQuestionController extends Controller
             'last_lesson_id',
             'selected_lesson_preselect',
             'is_last_lesson_preselect',
-            'legacy_test_id'
+            'legacy_test_id',
+            'course_creation_wizard'
         ));
     }
 
     public function store(Request $request)
 {
     $options = [];
+    $isCourseCreationWizard = $request->boolean('course_creation_wizard');
 
     // Accept both "marks" and legacy "score", but normalize to marks
     $marksInput = $request->input('marks', $request->input('score'));
@@ -331,27 +334,30 @@ class TestQuestionController extends Controller
         }
     }
 
-if ($request->action_btn == 'save_and_add_more') {
+    if ($request->action_btn == 'save_and_add_more') {
 
-    $params = [
-        'course_id=' . $course_id,
-    ];
+        $params = [
+            'course_id=' . $course_id,
+        ];
 
-    if ($lesson_id !== null) {
-        $params[] = 'lesson_id=' . ($lesson_id ?? 0);
+        if ($lesson_id !== null) {
+            $params[] = 'lesson_id=' . $lesson_id;
+        }
+
+        if (!empty($request->temp_id)) {
+            $params[] = 'uuid=' . urlencode($request->temp_id);
+        }
+
+        if ($legacy_test_id > 0) {
+            $params[] = 'test_id=' . $legacy_test_id;
+        }
+
+        if ($isCourseCreationWizard) {
+            $params[] = 'course_creation_wizard=1';
+        }
+
+        $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);
     }
-
-    if (!empty($request->temp_id)) {
-        $params[] = 'uuid=' . urlencode($request->temp_id);
-    }
-
-    if ($legacy_test_id > 0) {
-        $params[] = 'test_id=' . $legacy_test_id;
-    }
-
-    $redirect_url = route('admin.test_questions.create') . '?' . implode('&', $params);
-} 
-
     // Capture the course's wizard state BEFORE it gets overwritten below.
     // This is the only reliable signal to tell apart two flows that hit this
     // same store() action with an identical request shape (course_id set,
@@ -364,35 +370,22 @@ if ($request->action_btn == 'save_and_add_more') {
     //      current_step is already past that (e.g. 'question-added',
     //      'feedback-added') or null for legacy courses.
     // Only flow (1) should auto-advance into the Feedback wizard step.
-    $courseWizardStep = Course::where('id', $course_id)->value('current_step');
-    $isCourseCreationWizard = in_array($courseWizardStep, ['course-added', 'lesson-added'], true);
 
     Course::where('id', $course_id)->update([
         'current_step' => 'question-added'
     ]);
 
-    if ($isCourseCreationWizard && $request->action_btn == 'Next') {
-        if ($course_id) {
-            $has_feeback = FeedbackQuestion::query()
-                ->where('course_id', $course_id)
-                ->where('temp_id', $request->temp_id)
-                ->count();
-
-            if ($has_feeback == 0) {
-                $redirect_url = route('admin.feedback.create_course_feedback', ['course_id' => $course_id]);
-            }
-        }
+    if ($isCourseCreationWizard && $request->action_btn === 'Next' && $course_id) {
+        $redirect_url = route(
+            'admin.feedback.create_course_feedback',
+            ['course_id' => $course_id]
+        );
     }
-
     if ($request->action_btn == 'Save As Draft') {
         $redirect_url = route('admin.courses.index');
     }
 
-    if ($request->action_btn == 'Next') {
-        // Lesson quiz questions are independent from course-level assignments.
-    }
-
-    return json_encode([
+    return response()->json([
         'code' => 200,
         'message' => 'Question Inserted',
         'redirect_url' => $redirect_url ?? route('admin.test_questions.index')

--- a/resources/views/backend/lessons/create.blade.php
+++ b/resources/views/backend/lessons/create.blade.php
@@ -340,6 +340,7 @@
             </div>
 
             <input type="hidden" id="add_question_url" value="{{ route('admin.test_questions.create') }}">
+            <input type="hidden" id="course_creation_wizard" value="{{ request()->boolean('course_creation_wizard') ? '1' : '0' }}">
             <input type="hidden" id="ass_index" value="{{ url('user/assignments/create?assis_new') }} ">
             <input type="hidden" id="lesson_index" value="{{ route('admin.lessons.index') }}">
             <input type="hidden" id="temp_id" name="temp_id" value="{{ $temp_id }}">
@@ -638,7 +639,16 @@
                 let clicked = $('#btn_clicked').val();
 
                 if (clicked === 'nextBtn') {
-                    window.location.href = redirect_question_url + "/" + course_id + "/" + res.temp_id;
+                    let wizardFlag = $('#course_creation_wizard').val();
+
+                    let questionUrl =
+                        redirect_question_url + "/" + course_id + "/" + res.temp_id;
+
+                    if (wizardFlag === '1') {
+                        questionUrl += "?course_creation_wizard=1";
+                    }
+
+                    window.location.href = questionUrl;
                 }
 
                 if (clicked === 'doneBtn') {

--- a/resources/views/backend/test_questions/create.blade.php
+++ b/resources/views/backend/test_questions/create.blade.php
@@ -355,6 +355,7 @@
         <input type="hidden" id="temp_id" name="temp_id" value="{{ $temp_id }}">
         <input type="hidden" id="action_btn" name="action_btn" value="">
         <input type="hidden" id="course_id" name="course_id" value="{{ $course_id }}">
+        <input type="hidden" id="course_creation_wizard" name="course_creation_wizard" value="{{ !empty($course_creation_wizard) ? '1' : '0' }}">
         <input type="hidden" id="test_id" name="test_id" value="{{ $legacy_test_id ?? '' }}">
         <input type="hidden" name="lesson_id" id="lesson_id" value="{{ $lesson_id_preselect ?? '' }}">
         <input type="hidden" id="last_lesson_id" value="{{ $last_lesson_id ?? '' }}">
@@ -752,29 +753,64 @@
         var score = $("#score").val();
 
         return {
-            temp_id,
-            test_id,
-            lesson_id,
-            question_type,
-            question,
-            options: JSON.stringify(question_type == 3 ? [] : options),
-            solution,
-            comment,
-            score
+            temp_id: temp_id,
+            test_id: test_id,
+            lesson_id: lesson_id,
+            question_type: question_type,
+            question: question,
+            options: JSON.stringify(
+                question_type == 3 ? [] : options
+            ),
+            solution: solution,
+            comment: comment,
+            score: score,
+            course_creation_wizard:
+                $('#course_creation_wizard').val()
         };
     }
 
-    $(document).on('click', ".frm_submit", function() {
-        $('#action_btn').val($(this).val());
-        flag = 0;
-        sendData();
+    
+    $(document).ready(function () {
+
+        $('#save_and_add_more').on('click', function (e) {
+            e.preventDefault();
+
+            console.log('SAVE & ADD MORE clicked');
+
+            $('#action_btn').val('save_and_add_more');
+
+            sendData();
+        });
+
+        $('#save').on('click', function (e) {
+            e.preventDefault();
+
+            console.log('NEXT clicked');
+
+            $('#action_btn').val('Next');
+
+            sendData();
+        });
+
+        $('#save_as_draft').on('click', function (e) {
+            e.preventDefault();
+
+            console.log('SAVE AS DRAFT clicked');
+
+            $('#action_btn').val('Save As Draft');
+
+            sendData();
+        });
 
     });
 
     var question_submit_url = "{{route('admin.test_questions.store')}}";
 
-    function sendData(data) {
+    function sendData() {
+
+        console.log('sendData() started');
         var data = dataCollection();
+        console.log('Data being submitted:', data);
 
         if (!data.question || data.question.trim() === '') {
             alert('Question field is required.');
@@ -791,80 +827,97 @@
             return;
         }
 
-        // Get form context
-        const assessmentType = document.getElementById('assessment_type_select');
-        const courseId = document.getElementById('course_id').value;
-        const lessonId = document.getElementById('lesson_id').value;
-        const lessonSelect = document.getElementById('lesson_id_select');
-        const testId = document.getElementById('test_id').value;
+        const courseId = $('#course_id').val();
+        const lessonId = $('#lesson_id').val();
+        const testId = $('#test_id').val();
+        const actionBtn = $('#action_btn').val();
+
+        console.log('courseId:', courseId);
+        console.log('lessonId:', lessonId);
+        console.log('testId:', testId);
+        console.log('action:', actionBtn);
 
         if (!courseId && !testId) {
             alert('Please select a course from the Questions section before creating questions.');
             return;
         }
 
-        if (assessmentType) {
-            // STANDALONE MODE: Assessment type is required
-            if (!assessmentType.value) {
-                alert('Please select assessment type (Lesson Quiz or Final Assessment).');
-                return;
-            }
-            // If lesson quiz in standalone, lesson must be selected
-            if (assessmentType.value === 'lesson' && !lessonId) {
-                alert('Please select a lesson for this quiz question.');
-                return;
-            }
-        }
-
         data['_token'] = "{{ csrf_token() }}";
-        data['action_btn'] = $('#action_btn').val();
-        data['course_id'] = $('#course_id').val();
-        const redirect = "{{ request()->redirect }}";
+        data['action_btn'] = actionBtn;
+        data['course_id'] = courseId;
+        data['course_creation_wizard'] = $('#course_creation_wizard').val();
+
+        console.log('Sending AJAX request:', data);
+
         $.ajax({
-            url: question_submit_url,
-            type: 'post',
+            url: "{{ route('admin.test_questions.store') }}",
+            type: 'POST',
             data: data,
-            success: function(response) {
+            beforeSend: function () {
+                console.log('AJAX request started');
+                $('#save_and_add_more, #save, #save_as_draft')
+                    .prop('disabled', true);
+            },
+
+            success: function (response) {
+                console.log('AJAX success response:', response);
                 let payload = response;
                 if (typeof response === 'string') {
                     try {
                         payload = JSON.parse(response);
                     } catch (e) {
-                        alert('Unexpected server response. Please reload and try again.');
+                        console.error('Invalid JSON response:', response);
+                        alert(
+                            'Server returned an invalid response. ' +
+                            'Please check Laravel logs.'
+                        );
                         return;
                     }
                 }
 
                 if (payload.code == 200) {
-                    // if (data['action_btn'] == 'save_and_add_more') {
-                    //     window.location.replace(response.redirect_url);
-                    // }else{
-                    //     window.location.replace(redirect);
-                    // }
-                    window.location.replace(payload.redirect_url);
+                    console.log(
+                        'Redirecting to:',
+                        payload.redirect_url
+                    );
+                    if (payload.redirect_url) {
+                        window.location.href = payload.redirect_url;
+                    } else {
+                        alert('Question saved, but redirect URL is missing.');
+                    }
                 } else {
-                    alert(payload.message || 'Unable to save the question.');
+                    console.error('Server returned error:', payload);
+                    alert(
+                        payload.message ||
+                        'Unable to save the question.'
+                    );
                 }
             },
-            error: function (xhr) {
-                if (xhr.status === 422) {
-                    let res = xhr.responseJSON;
-                    // Show the error message
-                    if (res.errors) {
-                        if (res.errors.score) {
-                            alert(res.errors.score[0]);
-                        }
-                        else if (res.errors.marks) {
-                            alert(res.errors.marks[0]);
-                        }
-                        else {
-                            alert(res.message);
-                        }
+
+            error: function (xhr, status, error) {
+                console.error('AJAX ERROR');
+                console.error('HTTP Status:', xhr.status);
+                console.error('Status:', status);
+                console.error('Error:', error);
+                console.error('Response:', xhr.responseText);
+
+                let message = 'Request failed. Please try again.';
+                if (xhr.responseJSON) {
+                    if (xhr.responseJSON.message) {
+                        message = xhr.responseJSON.message;
                     }
-                    console.log('Validation errors:', res.errors);
-                } else {
-                    alert('Request failed. Please reload and try again.');
+                    if (xhr.responseJSON.errors) {
+                        console.error(
+                            'Validation errors:',
+                            xhr.responseJSON.errors
+                        );
+                    }
                 }
+                alert(message);
+            },
+            complete: function () {
+                $('#save_and_add_more, #save, #save_as_draft')
+                    .prop('disabled', false);
             }
         });
     }


### PR DESCRIPTION
## 🐞 Fix: Course Creation Wizard Redirects to Global Questions Page

### 📌 Description

During the Course Creation workflow, after completing **Step 3: Questions**, clicking the **Next** button incorrectly redirects the admin to the global **Questions Management** datatable instead of proceeding to the next step within the course creation wizard.

This interrupts the multi-step course creation workflow and causes the active course context to be lost.

Issue : #966 
---

## 🔍 Issue

The expected course creation flow is:

Course Details
→ Add Lesson
→ Questions
→ Feedback
→ Weightage
→ Final Submit

However, after completing the Questions step and clicking **Next**, the application redirects to the global Questions Management page.

This prevents the administrator from continuing the course creation process.

---

## 🧪 Steps to Reproduce

1. Login as an admin.
2. Navigate to:
   **Course Management → Courses → Add New**
3. Complete **Step 1: Course Details**.
4. Click **Next**.
5. Complete **Step 2: Add Lesson**.
6. Click **Next**.
7. Complete **Step 3: Questions**.
8. Add a question.
9. Click **Save & Add More** and add another question.
10. Click **Next**.
11. Observe the navigation.

---

## ✅ Expected Result

After clicking **Next** from Step 3:

```text
Step 3: Questions
        ↓
Step 4: Feedback
        ↓
Step 5: Weightage
        ↓
Final Submit
