### PR TITLE
Inconsistent Terminology in Email Filter Label on Learning Pathway Assignments Page #973

### DIFF
--- a/resources/lang/ar/admin_pages.php
+++ b/resources/lang/ar/admin_pages.php
@@ -11,7 +11,7 @@ return array(
   'pathway_assignments' => array(
     'title' => 'تعيينات مسارات التعلم',
     'make_new_assignment' => 'إنشاء تعيين جديد',
-    'select_employee_by_email' => 'اختر الموظف عبر البريد الإلكتروني',
+    'select_employee_by_email' => 'اختر المستخدم عبر البريد الإلكتروني',
     'select_course' => 'اختر الدورة',
     'select' => 'اختر',
     'advance_search' => 'بحث متقدم',

--- a/resources/lang/en/admin_pages.php
+++ b/resources/lang/en/admin_pages.php
@@ -11,7 +11,7 @@ return array(
   'pathway_assignments' => array(
     'title' => 'Learning Pathway Assignments',
     'make_new_assignment' => 'Make New Assignment',
-    'select_employee_by_email' => 'Select Employee By Email',
+    'select_employee_by_email' => 'Select User By Email',
     'select_course' => 'Select Course',
     'select' => 'Select',
     'advance_search' => 'Advance Search',

--- a/resources/lang/es/admin_pages.php
+++ b/resources/lang/es/admin_pages.php
@@ -11,7 +11,7 @@ return array(
   'pathway_assignments' => array(
     'title' => 'Asignaciones de rutas de aprendizaje',
     'make_new_assignment' => 'Crear nueva asignacion',
-    'select_employee_by_email' => 'Seleccionar empleado por correo',
+    'select_employee_by_email' => 'Seleccionar usuario por correo',
     'select_course' => 'Seleccionar curso',
     'select' => 'Seleccionar',
     'advance_search' => 'Busqueda avanzada',

--- a/resources/lang/fr/admin_pages.php
+++ b/resources/lang/fr/admin_pages.php
@@ -11,7 +11,7 @@ return array(
   'pathway_assignments' => array(
     'title' => 'Affectations de parcours d\'apprentissage',
     'make_new_assignment' => 'Créer une nouvelle affectation',
-    'select_employee_by_email' => 'Sélectionner un employé par e-mail',
+    'select_employee_by_email' => 'Sélectionner un utilisateur par e-mail',
     'select_course' => 'Sélectionner le cours',
     'select' => 'Sélectionner',
     'advance_search' => 'Recherche avancée',

--- a/resources/lang/it/admin_pages.php
+++ b/resources/lang/it/admin_pages.php
@@ -11,7 +11,7 @@ return array(
   'pathway_assignments' => array(
     'title' => 'Assegnazioni percorsi di apprendimento',
     'make_new_assignment' => 'Crea nuova assegnazione',
-    'select_employee_by_email' => 'Seleziona dipendente tramite email',
+    'select_employee_by_email' => 'Seleziona utente tramite email',
     'select_course' => 'Seleziona corso',
     'select' => 'Seleziona',
     'advance_search' => 'Ricerca avanzata',


### PR DESCRIPTION
# 📥 Pull Request Template

## 🔧 Description

On the Learning Pathway Assignments page, the filter label above the email search dropdown read "Select Employee By Email", while the assignment table lists all user types (students, employees, etc.) under Assigned Users / User Email. This PR updates the label to "Select User By Email" so the terminology matches the platform's system-wide naming conventions.

The change updates the `pathway_assignments.select_employee_by_email` translation value in all five locale files (`en`, `ar`, `es`, `fr`, `it`) under `resources/lang/*/admin_pages.php`, keeping the label consistent across languages. The translation key itself is unchanged, so no view or controller changes are needed. Other pages that intentionally use "Employee" wording (e.g. the internal attendance report) are untouched.

Fixes: #973

---

## ✅ Type of Change

Select all that apply:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX update
- [ ] 🔐 Security improvement
- [ ] 🔧 Other (please describe):

---

## 📸 Screenshots (if applicable)

_Text-only translation change; the label above the email filter on the Learning Pathway Assignments page now reads "Select User By Email"._

---

## 🚀 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Local environment
- [ ] Browser testing
- [ ] Mobile testing
- [ ] Database migrations tested
- [ ] Unit/Feature tests added
- [x] Other: Verified the view `resources/views/backend/pathway-assignment/index.blade.php` resolves the label via `__('admin_pages.pathway_assignments.select_employee_by_email')`, and grepped to confirm no other page shares this key.

---

## 🧪 Steps to Reproduce (for bug fixes)

1. Log in as admin and navigate to the Learning Pathway Assignments page (`/user/pathway-assignments`).
2. Locate the email filter dropdown and observe the label above it.
3. Before this change it read "Select Employee By Email"; it now reads "Select User By Email".

---

## 🔄 Checklist

Before submitting the PR, ensure you:

- [x] Followed the project's coding guidelines
- [ ] Updated documentation (if needed)
- [ ] Added/Updated tests (if applicable)
- [x] Verified no sensitive data is included
- [x] Ensured the app builds without errors

---

## 🙏 Additional Notes

The non-English locales were updated with the equivalent "user" wording (ar: المستخدم, es: usuario, fr: utilisateur, it: utente) so the fix is consistent in every language.
