### PR TITLE
Next Button Incorrectly Displayed in Standalone Add Feedback Courses …

### DIFF
--- a/resources/views/backend/feedback/course_feedback.blade.php
+++ b/resources/views/backend/feedback/course_feedback.blade.php
@@ -48,6 +48,7 @@
 
 @php
     $courseId = request()->get('course_id');
+    $isWizard = !empty($courseId);
 @endphp
 
 @if($courseId)
@@ -130,18 +131,37 @@
 <div class="mt-4">
         <div class="btmbtns mt-4">
   <div class="row">
-                         <div class="col-12 ">
-                            <div class="d-flex justify-content-between">
+                        <div class="col-12">
 
-                                <div>
-      <input class="btn  add-btn frm_submit" id="doneBtn" type="submit" value="{{ __('user_feedback.course_feedback.done') }}">
-                                </div>
-                                <div class="">
-    
-                                    <input class="btn  cancel-btn frm_submit" id="nextBtn" type="submit" value="{{ __('user_feedback.course_feedback.next') }}">
-                                </div>
-                            </div>
+                            @if($isWizard)
+                                {{-- Course Creation Wizard --}}
+                                <div class="d-flex justify-content-between">
+                                    <div>
+                                        <input
+                                            class="btn add-btn frm_submit"
+                                            id="doneBtn"
+                                            type="submit"
+                                            value="{{ __('user_feedback.course_feedback.done') }}">
+                                    </div>
 
+                                    <div>
+                                        <input
+                                            class="btn cancel-btn frm_submit"
+                                            id="nextBtn"
+                                            type="submit"
+                                            value="{{ __('user_feedback.course_feedback.next') }}">
+                                    </div>
+                                </div>
+                            @else
+                                {{-- Standalone Feedback Management --}}
+                                <div class="d-flex justify-content-end">
+                                    <input
+                                        class="btn add-btn frm_submit"
+                                        id="doneBtn"
+                                        type="submit"
+                                        value="{{ __('user_feedback.course_feedback.done') }}">
+                                </div>
+                            @endif
                         </div>
                         <!-- <div class="col-4">
                             {{ form_cancel(route('admin.teachers.index'), __('buttons.general.cancel')) }}


### PR DESCRIPTION
# 🐞 Defect: “Next” Button Incorrectly Displayed in Standalone Add Feedback Courses Form

### 📌 Description

The **Add Feedback Courses** form is used in two different contexts:

1. As a **standalone management page** through **Feedback → Course Questions**
2. As **Step 4** of the **Course Creation Wizard**

The form currently renders both **“Done”** and **“Next”** buttons regardless of the context in which the page is opened.

The **“Next”** button is intended only for navigation to the next step of the Course Creation Wizard. It should not be displayed when the form is accessed as a standalone Feedback management page.

Issue : #976 

### 🧪 Steps to Reproduce

1. Login as an admin.
2. Navigate to **Feedback → Course Questions**.
3. Open/create the **Add Feedback Courses** form.
4. Observe the action buttons at the bottom of the form.


#### Standalone mode

Only the following action should be displayed:

* **Done**

The **Next** button should not be rendered.

#### Course Creation Wizard – Step 4

The following actions should remain available:

* **Done**
* **Next**

The **Next** button should only be rendered when the form is opened as part of the course creation wizard.



### 🧪 Validation / Testing

#### Standalone Feedback Flow

* [x] Opened Feedback → Course Questions.
* [x] Opened Add Feedback Courses form.
* [x] Verified **Done** button is displayed.
* [x] Verified **Next** button is not displayed.
* [x] Verified feedback can still be saved.
* [x] Verified Done redirects to the Feedback Questions management page.

#### Course Creation Wizard

* [x] Started Course Creation.
* [x] Navigated through Course Details, Lessons and Questions.
* [x] Opened Feedback as Step 4.
* [x] Verified **Done** and **Next** buttons are displayed.
* [x] Verified Next continues the wizard flow.
* [x] Verified `course_id` is preserved.
* [x] Verified existing course-step navigation remains functional.

### 🎯 Impact

This change:

* Removes the irrelevant **Next** button from standalone Feedback management.
* Preserves the existing **Next** functionality in the Course Creation Wizard.
* Makes button rendering context-aware.
* Avoids unnecessary route/controller changes.
* Improves consistency between standalone and wizard workflows.

### Screenshots : 

<img width="1898" height="904" alt="image" src="https://github.com/user-attachments/assets/a714f765-7545-4b59-b8c9-de8e935c1b8c" />
<img width="1900" height="915" alt="image" src="https://github.com/user-attachments/assets/d596ffa7-b6bb-41f3-9b41-b750a102450c" />
