### PR TITLE
Missing Empty-State Message on Contact Request Management Page #980

### DIFF
--- a/resources/views/backend/contacts/index.blade.php
+++ b/resources/views/backend/contacts/index.blade.php
@@ -49,16 +49,19 @@
     <script>
 
         $(document).ready(function () {
-            var route = '{{route('admin.contact_requests.get_data')}}';
+
+            var route = '{{ route('admin.contact_requests.get_data') }}';
 
             $('#myTable').DataTable({
                 processing: true,
                 serverSide: true,
                 iDisplayLength: 10,
                 retrieve: true,
-                 dom: "<'table-controls'lf>" +
-                     "<'table-responsive't>" +
-                     "<'d-flex justify-content-between align-items-center mt-3'ip><'actions'>",
+
+                dom: "<'table-controls'lf>" +
+                    "<'table-responsive't>" +
+                    "<'d-flex justify-content-between align-items-center mt-3'ip><'actions'>",
+
                 buttons: [
                     {
                         extend: 'csv',
@@ -74,40 +77,67 @@
                     },
                     'colvis'
                 ],
-                ajax: route,
-                columns: [
 
-             
+                ajax: route,
+
+                columns: [
+                    {
+                        data: 'name',
+                        name: 'name'
+                    },
+                    {
+                        data: 'email',
+                        name: 'email'
+                    },
+                    {
+                        data: 'message',
+                        name: 'message'
+                    },
+                    {
+                        data: 'created_at',
+                        name: 'created_at'
+                    }
                 ],
+
                 @if(request('show_deleted') != 1)
                 columnDefs: [
-                    {"width": "5%", "targets": 0},
-                    {"width": "15%", "targets": 5},
-                    {"className": "text-center", "targets": [0]}
+                    {
+                        "className": "text-center",
+                        "targets": [0]
+                    }
                 ],
                 @endif
 
                 createdRow: function (row, data, dataIndex) {
                     $(row).attr('data-entry-id', data.id);
                 },
-                initComplete: function () {
-                   let $searchInput = $('#myTable_filter input[type="search"]');
-    $searchInput
-        .addClass('custom-search')
-        .wrap('<div class="search-wrapper position-relative d-inline-block"></div>')
-        .after('<i class="fa fa-search search-icon"></i>');
 
-    $('#myTable_length select').addClass('form-select form-select-sm custom-entries');
+                initComplete: function () {
+
+                    let $searchInput = $('#myTable_filter input[type="search"]');
+
+                    $searchInput
+                        .addClass('custom-search')
+                        .wrap('<div class="search-wrapper position-relative d-inline-block"></div>')
+                        .after('<i class="fa fa-search search-icon"></i>');
+
+                    $('#myTable_length select')
+                        .addClass('form-select form-select-sm custom-entries');
                 },
 
-                language:{
-                    url : "//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/{{$locale_full_name}}.json",
-                    buttons :{
-                        colvis : '{{trans("datatable.colvis")}}',
-                        pdf : '{{trans("datatable.pdf")}}',
-                        csv : '{{trans("datatable.csv")}}',
+                language: {
+                    url: "//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/{{$locale_full_name}}.json",
+
+                    emptyTable: "No contact requests found",
+                    zeroRecords: "No contact requests found",
+
+                    buttons: {
+                        colvis: '{{ trans("datatable.colvis") }}',
+                        pdf: '{{ trans("datatable.pdf") }}',
+                        csv: '{{ trans("datatable.csv") }}',
                     },
-                    search:"",
+
+                    search: "",
                 }
             });
 


### PR DESCRIPTION
# Fix: Add Empty-State Message to Contact Request Management

## 🐞 Defect

The Contact Request management DataTable does not display any feedback when no contact request records are available or when the applied search criteria return no matching records.

## 📌 Description

When the Contact Request management page contains no records, the table displays the column headers but the table body remains blank.

Similarly, when a search is performed and no records match the search criteria, no empty-state message is displayed.

This can make users think that the page is still loading or that the DataTable has failed to render.

## 🔄 Steps to Reproduce

1. Login as an admin.
2. Navigate to **Contact Request Management**.
3. Ensure that there are no contact request records available.
4. Observe the Contact Request DataTable.

Alternatively:

1. Open the Contact Request management page.
2. Enter a search value that does not match any existing record.
3. Observe the table.

## ✅ Result

The DataTable should display a clear empty-state message such as:

> No contact requests found

The message should be displayed in both cases:

* When no contact request records exist.
* When no records match the applied search criteria.


## 🧪 Testing

* [x] Verified empty Contact Request table displays the empty-state message.
* [x] Verified searches with no matching records display the empty-state message.
* [x] Verified existing Contact Request records continue to display.
* [x] Verified clearing the search restores existing records.

## Screenshot : 

<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/189bb3cf-8fe5-4658-9bc8-91d084d6048f" />
