### PR TITLE
Placeholder Select One Course appearing as a selected tag in multi-se…

### DIFF
--- a/resources/views/backend/assessment_accounts/create_assignment_course.blade.php
+++ b/resources/views/backend/assessment_accounts/create_assignment_course.blade.php
@@ -127,19 +127,27 @@
                     <label class="col-md-12 form-control-label">Select Course</label>
 
                     <div class="col-md-12 custom-select-wrapper">
-                        <select class="form-control custom-select-box select2"
-                                name="course_ids[]" multiple >
+                        @php
+                            $selectedCourses = old('course_ids');
 
+                            if ($selectedCourses === null) {
+                                $selectedCourses = $selectedCourse ? [$selectedCourse] : [];
+                            }
+
+                            $selectedCourses = array_filter((array) $selectedCourses);
+                        @endphp
+
+                        <select
+                            class="form-control custom-select-box select2"
+                            name="course_ids[]"
+                            multiple
+                            data-placeholder="Select One Course"
+                        >
                             @foreach ($courses as $value)
-                                <option value="{{ $value->id }}"
-                                    {{
-                                        in_array(
-                                            $value->id,
-                                            old('course_ids', $selectedCourse ? [$selectedCourse] : [])
-                                        )
-                                            ? 'selected'
-                                            : ''
-                                    }}>
+                                <option
+                                    value="{{ $value->id }}"
+                                    {{ in_array($value->id, $selectedCourses) ? 'selected' : '' }}
+                                >
                                     {{ $value->title }}
                                 </option>
                             @endforeach


### PR DESCRIPTION
## 🐞 Defect: “Select One Course” Placeholder Displayed as a Removable Selection in Create Assignment

### 📌 Description

On the **Create Assignment** page, the **Select Course** field incorrectly displays the placeholder text **“Select One Course”** as an active, removable selection tag.

The placeholder is intended to indicate that no course has been selected. It should not be rendered as an actual selected value.

Issue : #554 

### 📍 Steps to Reproduce

1. Login with valid admin credentials.
2. Navigate to the **Dashboard** page.
3. Navigate to **Assignment**.
4. Select **Add Assignment**.
5. Observe the **Select Course** field.

### ✅ Expected Result

The **Select Course** field should initially display **“Select One Course”** only as placeholder text.

It should:

* Not contain a removable placeholder tag by default.
* Remain empty until an actual course is selected.
* Display an actual course as a removable selection only after the user selects it.
* Preserve valid preselected courses when an assignment is opened with an existing course selection.

### Screenshot:

<img width="1915" height="907" alt="image" src="https://github.com/user-attachments/assets/cad98784-500c-4f69-a4fe-cf82ffe55d52" />


### 🧪 Testing

Verified the following scenarios:

* [x] Create Assignment page loads without a removable “Select One Course” tag.
* [x] Placeholder is displayed when no course is selected.
* [x] Actual course can be selected successfully.
* [x] Selected course appears as a removable tag.
* [x] Removing the selected course restores the placeholder.
* [x] Existing/preselected course remains selected correctly.
* [x] Select Users field remains unaffected.
* [x] Select Department field remains unaffected.
* [x] No unrelated UI/functionality is affected.