### PR TITLE
Search and Filters Functionalities are notworking at Courses List Pag…

### DIFF
--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -276,10 +276,18 @@ window.addEventListener('load', function () {
                     type: 'GET',
                     cache: false,
                     data: function (d) {
-                        d.status = $('#filter_status').val();
-                        d.teacher_id = $('#filter_teacher').val() || initialTeacherId;
-                        d.cat_id = $('#filter_category').val() || initialCatId;
-                        if (initialShowDeleted == '1') {
+                        d.status = $('#filter_status').val() || '';
+                        d.teacher_id = $('#filter_teacher').val() || '';
+                        d.cat_id = $('#filter_category').val() || '';
+
+                        console.log('COURSE DATATABLE REQUEST:', {
+                            search: d.search ? d.search.value : '',
+                            status: d.status,
+                            teacher_id: d.teacher_id,
+                            cat_id: d.cat_id
+                        });
+
+                        if (initialShowDeleted === '1') {
                             d.show_deleted = 1;
                         }
                     }
@@ -323,7 +331,9 @@ window.addEventListener('load', function () {
                     },
                     {
                         data: "category",
-                        name: 'category'
+                        name: 'category',
+                        searchable: false,
+                        orderable: false
                     },
                     {
     data: "price",
@@ -335,21 +345,29 @@ window.addEventListener('load', function () {
                         // {data: "id", name: 'id'},
                         {
                             data: "teachers",
-                            name: 'teachers'
+                            name: 'teachers',
+                            searchable: false,
+                            orderable: false
                         },
                     @endcan
                     {
                         data: "total_students_enrolled",
-                        name: "total_students_enrolled"
+                        name: "total_students_enrolled",
+                        searchable: false,
+                        orderable: false
                     },
                     {   
                         data:"duration",
-                        name:"duration"
+                        name:"duration",
+                        searchable: false,
+                        orderable: false
 
                     },
                     {
                         data: "status",
-                        name: "status"
+                        name: "status",
+                        searchable: false,
+                        orderable: false
                     },
                     {
     data: "start_date",
@@ -361,26 +379,38 @@ window.addEventListener('load', function () {
 },
                     {
                         data: "qr_code",
-                        name: "qr_code"
+                        name: "qr_code",
+                        searchable: false,
+                        orderable: false
                     },
                    
                     {
                         data: "lessons",
-                        name: "lessons"
+                        name: "lessons",
+                        searchable: false,
+                        orderable: false
                     },
                     {
                         data: "tests",
-                        name: "tests"
+                        name: "tests",
+                        searchable: false,
+                        orderable: false
                     },
                     {   data: "assignment", 
-                        name: "assignment"
+                        name: "assignment",
+                        searchable: false,
+                        orderable: false
                     },
                     {   data: "feedback", 
-                        name: "feedback"
+                        name: "feedback",
+                        searchable: false,
+                        orderable: false
                     },
                     {
                         data: "actions",
-                        name: "actions"
+                        name: "actions",
+                        searchable: false,
+                        orderable: false
                     }
                 ],
                 @can('course_delete')
@@ -407,7 +437,10 @@ window.addEventListener('load', function () {
                 },
   
                 drawCallback: function () {
-                    addDeleteForms();
+                    // Re-bind delete confirmation handlers after DataTables redraw.
+                    if (typeof addDeleteForms === 'function') {
+                        addDeleteForms();
+                    }
                 },
                 createdRow: function(row, data, dataIndex) {
                     $(row).attr('data-entry-id', data.id);
@@ -425,15 +458,27 @@ window.addEventListener('load', function () {
                 }
             }); 
            
-            $('#btn_filter').click(function(){
-                $('#myTable').DataTable().ajax.reload();
+            $('#btn_filter').on('click', function (e) {
+                e.preventDefault();
+
+                var table = $('#myTable').DataTable();
+
+                table.ajax.reload(null, true);
             });
 
-            $('#btn_reset').click(function(){
+            $('#btn_reset').on('click', function (e) {
+                e.preventDefault();
+
                 $('#filter_status').val('');
                 $('#filter_teacher').val('');
                 $('#filter_category').val('');
-                $('#myTable').DataTable().ajax.reload();
+
+                var table = $('#myTable').DataTable();
+
+                // Clear global DataTables search as well.
+                table.search('');
+
+                table.ajax.reload(null, true);
             });
         });
 


### PR DESCRIPTION
# PR: Fix Search and Filter Not Functioning on Courses List Page

## 🐞 Defect: Search and Filter Not Functioning on Courses List Page

---

### 📝 Description

On the Courses list page, the **global Search input** and **Category filter dropdown** were not functioning as expected.

The existing DataTables implementation was sending requests to the courses AJAX endpoint, but the backend did not explicitly process the global search request. Additionally, filter values could fall back to stale URL parameters, causing the Category and Trainer filters to behave incorrectly after changing or resetting selections.

The Status filter also exposed an **Expired** option without corresponding backend filtering logic.

Issue : #834 

---

### ✅ Expected Behavior

* 🔍 Global Search filters courses by relevant course information
* 📂 Category filter filters courses by the selected category
* 👨‍🏫 Trainer filter filters courses by the selected trainer
* 📊 Status filters correctly return Published, Draft and Expired courses
* 🔄 Apply Filter reloads the DataTable from page 1 using the current selections
* ♻️ Reset clears all filters and global search
* 🔗 Multiple filters can be combined
* ⚡ Filtering remains server-side and compatible with DataTables pagination

---

### Screenshots : 

<img width="1890" height="873" alt="image" src="https://github.com/user-attachments/assets/fd7745f6-b468-44f6-b4a2-d9473b6e7008" />
<img width="1904" height="897" alt="image" src="https://github.com/user-attachments/assets/360ea7c6-f577-4335-8916-b91c17385146" />
<img width="1907" height="901" alt="image" src="https://github.com/user-attachments/assets/4564fbcf-8559-49bc-bc57-ce0866af4a41" />
<img width="1827" height="855" alt="image" src="https://github.com/user-attachments/assets/b0b18099-b51f-48cc-9c59-350a35b2d763" />

---

### 🧪 Testing Performed

The following scenarios were tested:

* [x] Global search by course title
* [x] Global search by course code
* [x] Global search by course language
* [x] Global search by category name
* [x] Global search by trainer name
* [x] Category filter
* [x] Trainer filter
* [x] Published status filter
* [x] Draft status filter
* [x] Expired status filter
* [x] Search + Category combination
* [x] Search + Status combination
* [x] Category + Status combination
* [x] Search + Category + Status combination
* [x] Reset filters
* [x] Pagination after filtering
* [x] Empty search/filter state
* [x] Invalid/non-matching search value

---

### 📊 Result

The Courses list now correctly updates according to the user's search and filter criteria without requiring a full page refresh.

The existing server-side DataTables architecture is preserved while making the search and filter behavior explicit and reliable.

---

### 🎯 Impact

* Restores core Course discovery functionality
* Improves administrator experience
* Prevents stale filter state
* Enables reliable server-side search
* Supports combined filters
* Provides working Expired status filtering
