### PR TITLE
Lesson Dropdown Not Populating & No Question Count Indicator in Quiz/…

### DIFF
--- a/app/Http/Controllers/Backend/Admin/TestQuestionController.php
+++ b/app/Http/Controllers/Backend/Admin/TestQuestionController.php
@@ -92,7 +92,8 @@ class TestQuestionController extends Controller
                 ])
             : collect([])->values();
         $lesson_id_preselect = $request->input('lesson_id');
-        $lock_lesson_selection = $request->filled('lesson_id');
+        $lock_lesson_selection = $request->boolean('lock_lesson_selection')
+            && $request->filled('lesson_id');
 
         if (!$lesson_id_preselect && $selected_test && $selected_test->lesson_id) {
             $lesson_id_preselect = (int) $selected_test->lesson_id;


### PR DESCRIPTION
## PROBLEM

When creating questions during the course creation wizard, the **Select Lesson (optional)** dropdown becomes a read-only **Selected Lesson** banner after clicking **Save & Add More**.

When multiple lessons exist in a course, users can add questions to the first selected lesson successfully, but they cannot switch to another lesson or the Final Assessment while continuing to add questions.

The issue occurs because the presence of `lesson_id` is currently used to determine whether the lesson selector should be locked.

Issue : #816 

## STEPS TO REPRODUCE

1. Go to **Create Course**.
2. Click **Next**.
3. Create multiple lessons using **Add More Lesson**.
4. Click **Next** to open the Create Question page.
5. Open **Select Lesson (optional)**.
6. Select a lesson, for example **first lesson**.
7. Fill in the question details.
8. Click **Save & Add More**.
9. On the next question screen, observe the lesson selection area.

### Expected Result

The **Select Lesson (optional)** dropdown should remain available.

The previously selected lesson should remain selected by default, while allowing the user to switch to:

* Another lesson
* A different lesson quiz
* Final Assessment

## EXPECTED BEHAVIOR AFTER FIX

The workflow now behaves as follows:

```text
Create Question
      ↓
Select first lesson
      ↓
Save & Add More
      ↓
Next question page
      ↓
Dropdown remains visible
      ↓
First lesson remains selected
      ↓
User can switch to second lesson
      ↓
Or select Final Assessment
```

## TESTING

### Manual Testing

* [ ] Create a course with multiple lessons.
* [ ] Add a question to the first lesson.
* [ ] Click **Save & Add More**.
* [ ] Verify the lesson dropdown remains visible.
* [ ] Verify the previously selected lesson remains selected.
* [ ] Switch to another lesson.
* [ ] Add another question.
* [ ] Verify the question is mapped to the newly selected lesson.
* [ ] Switch to **Final Assessment (No Lesson)**.
* [ ] Add another question.
* [ ] Verify the question is mapped to the final assessment.
* [ ] Verify existing question creation behavior is unaffected.

## Screenshot : 

<img width="1905" height="907" alt="image" src="https://github.com/user-attachments/assets/5f1d0b3b-4157-4319-a700-737f14bd1723" />
