### PR TITLE
Unused Invitations Menu Item Displayed Under Courses Management #1012

### DIFF
--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -347,14 +347,14 @@
                                     </li>
                                 @endcan
 
-                                @can('course_invitation_access')
+                                <!-- @can('course_invitation_access')
                                     <li class="nav-item ">
                                         <a class="nav-link {{ $request->segment(2) == 'course-invitation-list' ? 'active' : '' }}"
                                             href="{{ route('admin.assessment_accounts.course-invitation-list') }}">
                                             <span class="title">@lang('menus.backend.sidebar.invitations')</span>
                                         </a>
                                     </li>
-                                @endcan
+                                @endcan -->
 
                                 @if (in_array(Session::get('setvaluesession'), [3]))
                                     <li class="nav-item ">


### PR DESCRIPTION
## Problem

The Courses Management section in the main sidebar displays an outdated "Invitations" submenu item.

The Invitations navigation item is no longer required as part of the main sidebar navigation and creates unnecessary navigation clutter.

Issue : #1012 

## Changes

- Removed the Invitations submenu item from the Courses Management sidebar.
- Kept the existing Invitations route and functionality unchanged.
- Preserved all other Courses Management navigation items.
- No permission, controller, route, or database changes were made.

## Screenshot : 

<img width="1901" height="885" alt="image" src="https://github.com/user-attachments/assets/abd68070-fa34-443e-815d-b37810721915" />