### PR TITLE
Certificate Issued count on Dashboard does not match the actual numbe…

### DIFF
--- a/app/Http/Controllers/Backend/DashboardController.php
+++ b/app/Http/Controllers/Backend/DashboardController.php
@@ -128,8 +128,11 @@ class DashboardController extends Controller
                     ->join('course_user as cu', 'c.id', '=', 'cu.course_id')
                     ->where('cu.user_id', $teacherId);
             })
+            ->whereNull('s.revoked_at')
+            ->where('s.status', '!=', \App\Models\Certificate::STATUS_REISSUED)
             ->whereNull('u.deleted_at')
             ->where('u.active', 1)
+            ->distinct()
             ->count('s.id');
 
         // --- Course completion ---
@@ -300,8 +303,11 @@ class DashboardController extends Controller
                         ->join('course_user as cu', 'c.id', '=', 'cu.course_id')
                         ->where('cu.user_id', $teacherId);
                 })
+                ->whereNull('s.revoked_at')
+                ->where('s.status', '!=', \App\Models\Certificate::STATUS_REISSUED)
                 ->whereNull('u.deleted_at')
                 ->where('u.active', 1)
+                ->distinct()
                 ->count('s.id');
 
             // --- Course Completion stats ---


### PR DESCRIPTION
## PROBLEM

The Dashboard displays an incorrect total for the "Certificate Issued" summary tile.

The Certificates management page and the Dashboard use different logic to determine the number of issued certificates. The Dashboard currently counts certificate records without excluding Reissued certificates, causing the displayed count to be inconsistent with the Certificates management table.

Issue : #580 

## STEPS TO REPRODUCE

1. Login as Admin.
2. Navigate to the **Certificates** section from the sidebar.
3. Check the certificates listed with the **Issued** status.
4. Navigate back to the Dashboard.
5. Observe the **Certificate Issued** summary tile.

## ACTUAL RESULT

The Dashboard displays an incorrect Certificate Issued count.

The count does not match the number of certificates shown as **Issued** in the Certificates management table.

## EXPECTED RESULT

The Dashboard's **Certificate Issued** count should match the number of certificates whose status is **Issued** in the Certificates management section.

Reissued and revoked certificates should not be included in the Issued count.

## ROOT CAUSE

The Dashboard certificate aggregation query counted certificate records without applying the same status rules used by the Certificates management DataTable.

## FIX

Updated the Dashboard certificate count query to:

- Exclude revoked certificates.
- Exclude certificates with the `STATUS_REISSUED` status.
- Count only certificates that qualify as Issued.
- Keep the Dashboard logic consistent with the Certificate management status filter.

Also updated the duplicate/legacy Dashboard cache calculation to use the same certificate status logic.

## TESTING

- Verified issued certificates are included in the Dashboard count.
- Verified reissued certificates are excluded.
- Verified revoked certificates are excluded.
- Cleared Laravel application/cache data before testing.
- Verified the Dashboard count matches the Issued certificates shown in the Certificates management table.

## Screenshot : 

<img width="1907" height="913" alt="image" src="https://github.com/user-attachments/assets/f9dfc693-0efc-406e-8df4-1e7781ad12b4" />
<img width="1897" height="908" alt="image" src="https://github.com/user-attachments/assets/211956e6-2646-40fe-b43c-0b02658e5e9e" />