### PR TITLE
Lessons added from Admin side not visible to assigned course trainer …

### DIFF
--- a/resources/views/backend/lessons/index.blade.php
+++ b/resources/views/backend/lessons/index.blade.php
@@ -199,16 +199,18 @@
                 ],
                 ajax: ajaxRoute,
                 columns: [
-                    @if(request('show_deleted') != 1)
-                        {
-                            data: function (data) {
-                                return '<input type="checkbox" class="single" name="id[]" value="' + data.id + '" />';
+                    @can('lesson_delete')
+                        @if(request('show_deleted') != 1)
+                            {
+                                data: function (data) {
+                                    return '<input type="checkbox" class="single" name="id[]" value="' + data.id + '" />';
+                                },
+                                orderable: false,
+                                searchable: false,
+                                name: 'lessons.id',
                             },
-                            orderable: false,
-                            searchable: false,
-                            name: 'lessons.id',
-                        },
-                    @endif
+                        @endif
+                    @endcan
                     { data: 'DT_RowIndex', name: 'DT_RowIndex', searchable: false, orderable: false },
                     { data: 'title', name: 'lessons.title' },
                     { data: 'course', name: 'course.title', defaultContent: "{{ __('labels.general.not_available') }}" },
@@ -219,12 +221,14 @@
                     { data: 'published', name: 'lessons.published' },
                     { data: 'actions', name: 'actions', searchable: false, orderable: false },
                 ],
-                @if(request('show_deleted') != 1)
-                    columnDefs: [
-                        { width: '5%', targets: 0 },
-                        { className: 'text-center', targets: [0] },
-                    ],
-                @endif
+                @can('lesson_delete')
+                    @if(request('show_deleted') != 1)
+                        columnDefs: [
+                            { width: '5%', targets: 0 },
+                            { className: 'text-center', targets: [0] },
+                        ],
+                    @endif
+                @endcan
                 initComplete: function () {
                     let $searchInput = $('#myTable_filter input[type="search"]');
                     $searchInput


### PR DESCRIPTION
# PR Title

## Description

When lessons are created and published from the Admin side, they do not appear in the assigned Trainer's view for the corresponding course.

This prevents Trainers from accessing or managing lessons that have already been scheduled and published.

The issue was caused by a mismatch between the number of HTML table columns rendered for Trainers and the number of columns configured in the DataTables JavaScript configuration.

Issue : #586 

---

## 🔍 Steps to Reproduce

1. Log in as Trainer/Teacher.
2. Navigate to **Courses Management → Lessons**.
3. Select the course assigned to the Trainer.
4. Observe the Lessons DataTable.

---

## ✅ Expected Result

All lessons created and published under a course should be visible to the assigned Trainer.

The Trainer should be able to:

- View the lesson title
- View the lesson start date
- View the lesson duration
- View the QR code
- View the published status
- View attendance information
- Manage lesson attendance

---

## 🧪 Testing

- Verified that the Trainer is assigned to the affected course.
- Verified that the affected course contains published lessons.
- Verified that the lessons endpoint returns the expected lesson records.
- Verified that published lessons are displayed in the Trainer view.
- Verified that lesson title, date, duration, QR code, and attendance information are available.
- Verified that Admin functionality remains unchanged.
- Verified that the checkbox column is still available for users with the lesson_delete permission.

---

## Screenshot : 

<img width="1901" height="903" alt="image" src="https://github.com/user-attachments/assets/adf7da3c-5594-494c-a3ad-5317e6fdbeff" />
