### PR TITLE
Duplicate KPI Sets Can Be Created for Categories with Existing 100% K…

### DIFF
--- a/app/Http/Controllers/Backend/Admin/KpiController.php
+++ b/app/Http/Controllers/Backend/Admin/KpiController.php
@@ -15,14 +15,18 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use App\Services\Kpi\KpiCategoryConfigurationService;
+use Illuminate\Support\Facades\DB;
 
 class KpiController extends Controller
 {
     protected $snapshotService;
+    protected $categoryConfigurationService;
 
-    public function __construct(KpiSnapshotService $snapshotService)
+    public function __construct(KpiSnapshotService $snapshotService,KpiCategoryConfigurationService $categoryConfigurationService)
     {
         $this->snapshotService = $snapshotService;
+        $this->categoryConfigurationService = $categoryConfigurationService;
     }
 
     public function index(Request $request)
@@ -190,6 +194,12 @@ class KpiController extends Controller
         if (!Gate::allows('kpi_create')) {
             return abort(401);
         }
+        $categories = Category::query()
+            ->orderBy('name')
+            ->select('id', 'name')
+            ->get();
+        $categoryActiveWeights = $this->categoryConfigurationService
+            ->activeWeightsByCategory();
 
         $kpiTypes = $this->getSupportedKpiTypes();
         $maxWeight = config('kpi.max_weight', 100);
@@ -200,7 +210,7 @@ class KpiController extends Controller
         $categories = Category::query()->orderBy('name')->select('id', 'name')->get();
         $courses = Course::query()->orderBy('title')->select('id', 'title', 'course_code')->get();
 
-        return view('backend.kpis.create', compact('kpiTypes', 'maxWeight', 'defaultWeight', 'categories', 'courses', 'activeTotalWeight', 'extremeWeightThreshold', 'totalWeightValidation'));
+        return view('backend.kpis.create', compact('kpiTypes', 'maxWeight', 'defaultWeight', 'categories', 'courses', 'activeTotalWeight', 'extremeWeightThreshold', 'totalWeightValidation','categoryActiveWeights'));
     }
 
     public function store(StoreKpiRequest $request)
@@ -209,44 +219,79 @@ class KpiController extends Controller
             return abort(401);
         }
 
-        $kpi = Kpi::create([
-            'name' => $request->name,
-            'code' => strtoupper(trim($request->code)),
-            'type' => $request->type,
-            'description' => $request->description,
-            'weight' => $request->weight,
-            'is_active' => true,
-            'created_by' => \Auth::id(),
-            'updated_by' => \Auth::id(),
-        ]);
+        $categoryIds = collect($request->input('category_ids', []))
+            ->map(fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
 
-        $kpi->categories()->sync($request->input('category_ids', []));
-        $kpi->courses()->sync($request->input('course_ids', []));
+        return DB::transaction(function () use ($request, $categoryIds) {
 
-        $created = Kpi::query()->where('code', strtoupper(trim($request->code)))->first();
-        if ($created) {
-            $created->statusHistories()->create([
-                'action' => 'created',
-                'previous_is_active' => null,
-                'new_is_active' => true,
-                'changed_by' => \Auth::id(),
-                'meta' => [
-                    'type' => $created->type,
-                    'weight' => $created->weight,
-                    'category_ids' => $created->categories()->pluck('categories.id')->toArray(),
-                    'course_ids' => $created->courses()->pluck('courses.id')->toArray(),
-                ],
+            /*
+            * Lock selected categories first.
+            *
+            * This prevents two concurrent requests from both seeing
+            * the same category as available and creating duplicates.
+            */
+            $this->categoryConfigurationService
+                ->lockCategories($categoryIds);
+
+            /*
+            * Re-check after acquiring the locks.
+            */
+            $this->categoryConfigurationService
+                ->assertNoConflictingCategories($categoryIds);
+
+            $kpi = Kpi::create([
+                'name' => $request->name,
+                'code' => strtoupper(trim($request->code)),
+                'type' => $request->type,
+                'description' => $request->description,
+                'weight' => $request->weight,
+                'is_active' => true,
+                'created_by' => \Auth::id(),
+                'updated_by' => \Auth::id(),
             ]);
-        }
 
-        $redirect = redirect()->route('admin.kpis.index')->withFlashSuccess(__('kpi.messages.created'));
+            $kpi->categories()->sync($categoryIds);
 
-        $warnings = $this->buildPostSaveWeightWarnings($kpi);
-        if (!empty($warnings)) {
-            $redirect->with('flash_warning', implode(' ', $warnings));
-        }
+            $kpi->courses()->sync(
+                $request->input('course_ids', [])
+            );
+                
+            $kpi->statusHistories()->create([
+                    'action' => 'created',
+                    'previous_is_active' => null,
+                    'new_is_active' => true,
+                    'changed_by' => \Auth::id(),
+                    'meta' => [
+                        'type' => $kpi->type,
+                        'weight' => $kpi->weight,
+                        'category_ids' => $kpi->categories()
+                            ->pluck('categories.id')
+                            ->toArray(),
+                        'course_ids' => $kpi->courses()
+                            ->pluck('courses.id')
+                            ->toArray(),
+                    ],
+                ]);
+                $redirect = redirect()
+                    ->route('admin.kpis.index')
+                    ->withFlashSuccess(__('kpi.messages.created'));
 
-        return $redirect;
+                $warnings = $this->buildPostSaveWeightWarnings($kpi);
+
+                if (!empty($warnings)) {
+                    $redirect->with(
+                        'flash_warning',
+                        implode(' ', $warnings)
+                    );
+                }
+
+
+            return $redirect;
+        });
     }
 
     public function edit($kpi)
@@ -254,6 +299,8 @@ class KpiController extends Controller
         if (!Gate::allows('kpi_edit')) {
             return abort(401);
         }
+        $categoryActiveWeights = $this->categoryConfigurationService
+            ->activeWeightsByCategory([], (int) $kpi->id);
 
         $kpi = Kpi::with('courses', 'categories')->findOrFail($kpi);
 
@@ -265,7 +312,7 @@ class KpiController extends Controller
         $categories = Category::query()->orderBy('name')->select('id', 'name')->get();
         $courses = Course::query()->orderBy('title')->select('id', 'title', 'course_code')->get();
 
-        return view('backend.kpis.edit', compact('kpi', 'kpiTypes', 'maxWeight', 'categories', 'courses', 'activeTotalWeight', 'extremeWeightThreshold', 'totalWeightValidation'));
+        return view('backend.kpis.edit', compact('kpi', 'kpiTypes', 'maxWeight', 'categories', 'courses', 'activeTotalWeight', 'extremeWeightThreshold', 'totalWeightValidation','categoryActiveWeights'));
     }
 
     public function update(UpdateKpiRequest $request, $kpi)
@@ -275,46 +322,90 @@ class KpiController extends Controller
         }
 
         $kpiModel = Kpi::findOrFail($kpi);
-        $oldType = $kpiModel->type;
-        $oldWeight = $kpiModel->weight;
 
-        $kpiModel->name = $request->name;
-        $kpiModel->code = strtoupper(trim($request->code));
-        $kpiModel->type = $request->type;
-        $kpiModel->description = $request->description;
-        $kpiModel->weight = $request->weight;
-        $kpiModel->updated_by = \Auth::id();
-        $kpiModel->save();
-        $kpiModel->categories()->sync($request->input('category_ids', []));
-        $kpiModel->courses()->sync($request->input('course_ids', []));
+        $categoryIds = collect($request->input('category_ids', []))
+            ->map(fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
 
-        $typeChanged = $oldType !== $kpiModel->type;
-        $weightChanged = (float) $oldWeight !== (float) $kpiModel->weight;
-        if ($typeChanged || $weightChanged) {
-            $kpiModel->statusHistories()->create([
-                'action' => 'updated',
-                'previous_is_active' => $kpiModel->is_active,
-                'new_is_active' => $kpiModel->is_active,
-                'changed_by' => \Auth::id(),
-                'meta' => [
-                    'old_type' => $oldType,
-                    'new_type' => $kpiModel->type,
-                    'old_weight' => $oldWeight,
-                    'new_weight' => $kpiModel->weight,
-                    'category_ids' => $kpiModel->categories()->pluck('categories.id')->toArray(),
-                    'course_ids' => $kpiModel->courses()->pluck('courses.id')->toArray(),
-                ],
-            ]);
-        }
+        return DB::transaction(function () use (
+            $request,
+            $kpiModel,
+            $categoryIds
+        ) {
 
-        $redirect = redirect()->route('admin.kpis.index')->withFlashSuccess(__('kpi.messages.updated'));
+            $this->categoryConfigurationService
+                ->lockCategories($categoryIds);
 
-        $warnings = $this->buildPostSaveWeightWarnings($kpiModel);
-        if (!empty($warnings)) {
-            $redirect->with('flash_warning', implode(' ', $warnings));
-        }
+            /*
+            * Re-check while category rows are locked.
+            * Exclude the KPI currently being edited.
+            */
+            $this->categoryConfigurationService
+                ->assertNoConflictingCategories(
+                    $categoryIds,
+                    $kpiModel->id
+                );
 
-        return $redirect;
+            $oldType = $kpiModel->type;
+            $oldWeight = $kpiModel->weight;
+
+            $kpiModel->name = $request->name;
+            $kpiModel->code = strtoupper(trim($request->code));
+            $kpiModel->type = $request->type;
+            $kpiModel->description = $request->description;
+            $kpiModel->weight = $request->weight;
+            $kpiModel->updated_by = \Auth::id();
+            $kpiModel->save();
+
+            $kpiModel->categories()->sync($categoryIds);
+
+            $kpiModel->courses()->sync(
+                $request->input('course_ids', [])
+            );
+
+            $typeChanged = $oldType !== $kpiModel->type;
+            $weightChanged =
+                (float) $oldWeight !== (float) $kpiModel->weight;
+
+            if ($typeChanged || $weightChanged) {
+                $kpiModel->statusHistories()->create([
+                    'action' => 'updated',
+                    'previous_is_active' => $kpiModel->is_active,
+                    'new_is_active' => $kpiModel->is_active,
+                    'changed_by' => \Auth::id(),
+                    'meta' => [
+                        'old_type' => $oldType,
+                        'new_type' => $kpiModel->type,
+                        'old_weight' => $oldWeight,
+                        'new_weight' => $kpiModel->weight,
+                        'category_ids' => $kpiModel->categories()
+                            ->pluck('categories.id')
+                            ->toArray(),
+                        'course_ids' => $kpiModel->courses()
+                            ->pluck('courses.id')
+                            ->toArray(),
+                    ],
+                ]);
+            }
+
+            $redirect = redirect()
+                ->route('admin.kpis.index')
+                ->withFlashSuccess(__('kpi.messages.updated'));
+
+            $warnings = $this->buildPostSaveWeightWarnings($kpiModel);
+
+            if (!empty($warnings)) {
+                $redirect->with(
+                    'flash_warning',
+                    implode(' ', $warnings)
+                );
+            }
+
+            return $redirect;
+        });
     }
 
     public function toggleStatus($kpi)

--- a/app/Http/Requests/Admin/StoreKpiRequest.php
+++ b/app/Http/Requests/Admin/StoreKpiRequest.php
@@ -6,6 +6,7 @@ use App\Models\Kpi;
 use App\Services\Kpi\KpiTypeCatalog;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Services\Kpi\KpiCategoryConfigurationService;
 
 class StoreKpiRequest extends FormRequest
 {
@@ -44,16 +45,58 @@ class StoreKpiRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {
+            $categoryIds = collect($this->input('category_ids', []))
+                ->map(fn ($id) => (int) $id)
+                ->filter()
+                ->unique()
+                ->values()
+                ->all();
+
+            if (!empty($categoryIds)) {
+                $conflicts = app(KpiCategoryConfigurationService::class)
+                    ->conflictingCategories($categoryIds);
+
+                foreach ($conflicts as $category) {
+                    $validator->errors()->add(
+                        'category_ids',
+                        __('kpi.validation.category_configuration_complete', [
+                            'category' => $category['name'],
+                            'weight' => number_format($category['weight'], 2),
+                        ])
+                    );
+                }
+            }
+
+            /*
+            * Existing global active-weight validation.
+            */
             if (!config('kpi.total_weight_validation.enabled', false)) {
                 return;
             }
 
-            $proposedWeight = max(0.0, (float) $this->input('weight', 0));
-            $currentActiveTotal = (float) Kpi::query()->where('is_active', true)->sum('weight');
+            $proposedWeight = max(
+                0.0,
+                (float) $this->input('weight', 0)
+            );
+
+            $currentActiveTotal = (float) Kpi::query()
+                ->where('is_active', true)
+                ->sum('weight');
+
             $projectedTotal = $currentActiveTotal + $proposedWeight;
 
-            $target = (float) config('kpi.total_weight_validation.target', 100);
-            $tolerance = max(0.0, (float) config('kpi.total_weight_validation.tolerance', 0.01));
+            $target = (float) config(
+                'kpi.total_weight_validation.target',
+                100
+            );
+
+            $tolerance = max(
+                0.0,
+                (float) config(
+                    'kpi.total_weight_validation.tolerance',
+                    0.01
+                )
+            );
 
             if (abs($projectedTotal - $target) > $tolerance) {
                 $validator->errors()->add(
@@ -67,7 +110,7 @@ class StoreKpiRequest extends FormRequest
             }
         });
     }
-
+    
     public function messages()
     {
         return [

--- a/app/Http/Requests/Admin/UpdateKpiRequest.php
+++ b/app/Http/Requests/Admin/UpdateKpiRequest.php
@@ -6,6 +6,7 @@ use App\Models\Kpi;
 use App\Services\Kpi\KpiTypeCatalog;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Services\Kpi\KpiCategoryConfigurationService;
 
 class UpdateKpiRequest extends FormRequest
 {
@@ -50,6 +51,36 @@ class UpdateKpiRequest extends FormRequest
 
     public function withValidator($validator)
     {
+        $categoryIds = collect($this->input('category_ids', []))
+            ->map(fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $kpiId = $this->route('kpi');
+
+        if ($kpiId instanceof Kpi) {
+            $kpiId = $kpiId->id;
+        }
+
+        if (!empty($categoryIds)) {
+            $conflicts = app(KpiCategoryConfigurationService::class)
+                ->conflictingCategories(
+                    $categoryIds,
+                    (int) $kpiId
+                );
+
+            foreach ($conflicts as $category) {
+                $validator->errors()->add(
+                    'category_ids',
+                    __('kpi.validation.category_configuration_complete', [
+                        'category' => $category['name'],
+                        'weight' => number_format($category['weight'], 2),
+                    ])
+                );
+            }
+        }
         $validator->after(function ($validator) {
             $kpiId = $this->route('kpi');
             if (!$kpiId) {

--- a/app/Services/Kpi/KpiCategoryConfigurationService.php
+++ b/app/Services/Kpi/KpiCategoryConfigurationService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Services\Kpi;
+
+use App\Models\Category;
+use App\Models\Kpi;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+class KpiCategoryConfigurationService
+{
+    public function activeWeightsByCategory(
+        array $categoryIds = [],
+        ?int $excludeKpiId = null
+    ): array {
+        $query = Kpi::query()
+            ->where('is_active', true)
+            ->with('categories:id');
+
+        if ($excludeKpiId !== null) {
+            $query->where('id', '!=', $excludeKpiId);
+        }
+
+        if (!empty($categoryIds)) {
+            $query->whereHas('categories', function ($query) use ($categoryIds) {
+                $query->whereIn('categories.id', $categoryIds);
+            });
+        }
+
+        $weights = [];
+
+        foreach ($query->get() as $kpi) {
+            foreach ($kpi->categories as $category) {
+                if (!empty($categoryIds) && !in_array((int) $category->id, $categoryIds, true)) {
+                    continue;
+                }
+
+                $categoryId = (int) $category->id;
+
+                $weights[$categoryId] = ($weights[$categoryId] ?? 0)
+                    + (float) $kpi->weight;
+            }
+        }
+
+        return $weights;
+    }
+
+    public function conflictingCategories(
+        array $categoryIds,
+        ?int $excludeKpiId = null
+    ): Collection {
+        $categoryIds = collect($categoryIds)
+            ->map(fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        if (empty($categoryIds)) {
+            return collect();
+        }
+
+        $target = (float) config(
+            'kpi.total_weight_validation.target',
+            100
+        );
+
+        $tolerance = max(
+            0.0,
+            (float) config(
+                'kpi.total_weight_validation.tolerance',
+                0.01
+            )
+        );
+
+        $threshold = $target - $tolerance;
+
+        $weights = $this->activeWeightsByCategory(
+            $categoryIds,
+            $excludeKpiId
+        );
+
+        $conflictingIds = collect($weights)
+            ->filter(fn ($weight) => (float) $weight >= $threshold)
+            ->keys()
+            ->map(fn ($id) => (int) $id)
+            ->values();
+
+        if ($conflictingIds->isEmpty()) {
+            return collect();
+        }
+
+        $categories = Category::query()
+            ->whereIn('id', $conflictingIds)
+            ->pluck('name', 'id');
+
+        return $conflictingIds->map(function ($categoryId) use ($weights, $categories) {
+            return [
+                'id' => $categoryId,
+                'name' => $categories[$categoryId] ?? "Category #{$categoryId}",
+                'weight' => (float) ($weights[$categoryId] ?? 0),
+            ];
+        });
+    }
+
+    public function assertNoConflictingCategories(
+        array $categoryIds,
+        ?int $excludeKpiId = null
+    ): void {
+        $conflicts = $this->conflictingCategories(
+            $categoryIds,
+            $excludeKpiId
+        );
+
+        if ($conflicts->isEmpty()) {
+            return;
+        }
+
+        $messages = [];
+
+        foreach ($conflicts as $category) {
+            $messages[] = __('kpi.validation.category_configuration_complete', [
+                'category' => $category['name'],
+                'weight' => number_format($category['weight'], 2),
+            ]);
+        }
+
+        throw ValidationException::withMessages([
+            'category_ids' => $messages,
+        ]);
+    }
+
+    public function lockCategories(array $categoryIds): void
+    {
+        $categoryIds = collect($categoryIds)
+            ->map(fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        if (empty($categoryIds)) {
+            return;
+        }
+
+        Category::query()
+            ->whereIn('id', $categoryIds)
+            ->lockForUpdate()
+            ->get();
+    }
+}

--- a/resources/lang/en/kpi.php
+++ b/resources/lang/en/kpi.php
@@ -324,6 +324,8 @@ return [
         'template_no_active_items' => 'Template has no active items.',
         'template_duplicate_codes' => 'Template contains duplicate KPI codes.',
         'template_total_weight_positive' => 'Total weight must be greater than 0.',
+        'category_configuration_complete' =>
+        'Category ":category" already has an active KPI configuration with :weight% total weight. Duplicate KPI configuration is not allowed.',
     ],
     'warnings' => [
         'extreme_weight' => 'Warning: :name has weight :weight, which is above the extreme configuration threshold (:threshold).',

--- a/resources/views/backend/kpis/create.blade.php
+++ b/resources/views/backend/kpis/create.blade.php
@@ -100,6 +100,12 @@
                             @endforeach
                         </select>
                         <small class="form-text text-muted">@lang('kpi.help.category_scope')</small>
+                        <div
+                            id="kpi-category-warning"
+                            class="alert alert-danger mt-2"
+                            style="display: none;"
+                        >
+                        </div>
                     </div>
 
                     <div class="col-md-6 form-group">
@@ -143,7 +149,7 @@
                 </div>
 
                 <div class="text-right">
-                    <button type="submit" class="add-btn">@lang('kpi.actions.save_kpi')</button>
+                    <button type="submit" class="add-btn" id="kpi-submit-button">@lang('kpi.actions.save_kpi')</button>
                 </div>
             </form>
 
@@ -260,6 +266,88 @@
     })();
 
     </script>
+    <script>
+        (function () {
+            var categorySelect = document.getElementById('category_ids');
+            var warningEl = document.getElementById('kpi-category-warning');
+            var submitButton = document.getElementById('kpi-submit-button');
 
+            if (!categorySelect || !warningEl || !submitButton) {
+                return;
+            }
+
+            var categoryWeights = @json($categoryActiveWeights);
+            var categoryNames = @json($categories->pluck('name', 'id'));
+
+            var validationTarget = {{ (float) ($totalWeightValidation['target'] ?? 100) }};
+            var validationTolerance = {{ (float) ($totalWeightValidation['tolerance'] ?? 0.01) }};
+            var conflictThreshold = Math.max(
+                0,
+                validationTarget - validationTolerance
+            );
+
+            function checkCategoryConflicts() {
+                var selectedOptions = Array.from(
+                    categorySelect.selectedOptions
+                );
+
+                var conflicts = [];
+
+                selectedOptions.forEach(function (option) {
+                    var categoryId = String(option.value);
+                    var weight = parseFloat(
+                        categoryWeights[categoryId] || 0
+                    );
+
+                    if (weight >= conflictThreshold) {
+                        conflicts.push(
+                            (categoryNames[categoryId] || option.text.trim()) +
+                            ' (' +
+                            weight.toFixed(2) +
+                            '%)'
+                        );
+                    }
+                });
+
+                if (conflicts.length === 0) {
+                    warningEl.style.display = 'none';
+                    warningEl.textContent = '';
+                    submitButton.disabled = false;
+
+                    return true;
+                }
+
+                warningEl.textContent =
+                    'The following category already has a complete KPI ' +
+                    'configuration and cannot be used for another active KPI ' +
+                    'configuration: ' +
+                    conflicts.join(', ') +
+                    '.';
+
+                warningEl.style.display = 'block';
+                submitButton.disabled = true;
+
+                return false;
+            }
+
+            categorySelect.addEventListener(
+                'change',
+                checkCategoryConflicts
+            );
+
+            $('#category_ids').on(
+                'change',
+                checkCategoryConflicts
+            );
+
+            categorySelect.form.addEventListener('submit', function (event) {
+                if (!checkCategoryConflicts()) {
+                    event.preventDefault();
+                }
+            });
+
+            checkCategoryConflicts();
+        })();
+    </script>
 @endpush
 @endsection

--- a/resources/views/backend/kpis/edit.blade.php
+++ b/resources/views/backend/kpis/edit.blade.php
@@ -90,6 +90,11 @@
                             @endforeach
                         </select>
                         <small class="form-text text-muted">@lang('kpi.help.category_scope_edit')</small>
+                        <div
+                            id="kpi-category-warning"
+                            class="alert alert-danger mt-2"
+                            style="display: none;"
+                        ></div>
                     </div>
 
                     <div class="col-12 form-group">
@@ -114,7 +119,7 @@
                 </div>
 
                 <div class="text-right">
-                    <button type="submit" class="add-btn">@lang('kpi.actions.update_kpi')</button>
+                    <button type="submit" class="add-btn" id="kpi-submit-button">@lang('kpi.actions.update_kpi')</button>
                 </div>
             </form>
 
@@ -188,4 +193,79 @@
             updateWeightSummary();
         })();
     </script>
+    <script>
+        (function () {
+            var categorySelect = document.getElementById('category_ids');
+            var warningEl = document.getElementById('kpi-category-warning');
+            var submitButton = document.getElementById('kpi-submit-button');
+
+            if (!categorySelect || !warningEl || !submitButton) {
+                return;
+            }
+
+            var categoryWeights = @json($categoryActiveWeights);
+            var categoryNames = @json($categories->pluck('name', 'id'));
+
+            var validationTarget = {{ (float) ($totalWeightValidation['target'] ?? 100) }};
+            var validationTolerance = {{ (float) ($totalWeightValidation['tolerance'] ?? 0.01) }};
+
+            var conflictThreshold = Math.max(
+                0,
+                validationTarget - validationTolerance
+            );
+
+            function checkCategoryConflicts() {
+                var conflicts = [];
+
+                Array.from(categorySelect.selectedOptions).forEach(function (option) {
+                    var categoryId = String(option.value);
+
+                    var weight = parseFloat(
+                        categoryWeights[categoryId] || 0
+                    );
+
+                    if (weight >= conflictThreshold) {
+                        conflicts.push(
+                            (categoryNames[categoryId] || option.text.trim()) +
+                            ' (' +
+                            weight.toFixed(2) +
+                            '%)'
+                        );
+                    }
+                });
+
+                if (conflicts.length === 0) {
+                    warningEl.style.display = 'none';
+                    warningEl.textContent = '';
+                    submitButton.disabled = false;
+                    return true;
+                }
+
+                warningEl.textContent =
+                    'The following category already has a complete KPI ' +
+                    'configuration and cannot be used for another active KPI ' +
+                    'configuration: ' +
+                    conflicts.join(', ') +
+                    '.';
+
+                warningEl.style.display = 'block';
+                submitButton.disabled = true;
+
+                return false;
+            }
+
+            $('#category_ids').on(
+                'change',
+                checkCategoryConflicts
+            );
+
+            categorySelect.form.addEventListener('submit', function (event) {
+                if (!checkCategoryConflicts()) {
+                    event.preventDefault();
+                }
+            });
+
+            checkCategoryConflicts();
+        })();
+        </script>
 @endsection

--- a/tests/Feature/Backend/Kpi/KpiWeightValidationTest.php
+++ b/tests/Feature/Backend/Kpi/KpiWeightValidationTest.php
@@ -207,4 +207,204 @@ class KpiWeightValidationTest extends TestCase
             'type' => 'completion',
         ]);
     }
+
+    #[Test]
+public function it_rejects_store_when_selected_category_already_has_complete_active_configuration()
+{
+    config()->set('kpi.total_weight_validation.target', 100);
+    config()->set('kpi.total_weight_validation.tolerance', 0.01);
+
+    $admin = $this->loginAsAdmin();
+
+    $categoryA = Category::query()->create([
+        'name' => 'Category A',
+        'slug' => 'category-a',
+        'status' => 1,
+    ]);
+
+    $categoryB = Category::query()->create([
+        'name' => 'Category B',
+        'slug' => 'category-b',
+        'status' => 1,
+    ]);
+
+    $existingKpiOne = Kpi::query()->create([
+        'name' => 'Existing KPI One',
+        'code' => 'EXISTING_KPI_ONE',
+        'type' => 'completion',
+        'description' => 'Existing KPI one.',
+        'weight' => 60,
+        'is_active' => true,
+        'created_by' => $admin->id,
+        'updated_by' => $admin->id,
+    ]);
+
+    $existingKpiTwo = Kpi::query()->create([
+        'name' => 'Existing KPI Two',
+        'code' => 'EXISTING_KPI_TWO',
+        'type' => 'score',
+        'description' => 'Existing KPI two.',
+        'weight' => 40,
+        'is_active' => true,
+        'created_by' => $admin->id,
+        'updated_by' => $admin->id,
+    ]);
+
+    $existingKpiOne->categories()->sync([$categoryA->id]);
+    $existingKpiTwo->categories()->sync([$categoryA->id]);
+
+    $response = $this->post(
+        route('admin.kpis.store'),
+        [
+            'name' => 'Duplicate KPI',
+            'code' => 'DUPLICATE_KPI',
+            'type' => 'completion',
+            'description' => 'Should not be created.',
+            'weight' => 20,
+            'category_ids' => [
+                $categoryB->id,
+                $categoryA->id,
+            ],
+            'course_ids' => [],
+        ]
+    );
+
+    $response->assertSessionHasErrors('category_ids');
+
+    $this->assertDatabaseMissing('kpis', [
+        'code' => 'DUPLICATE_KPI',
+    ]);
+}
+#[Test]
+public function it_allows_store_when_selected_category_has_less_than_complete_active_configuration()
+{
+    $admin = $this->loginAsAdmin();
+
+    $category = Category::query()->create([
+        'name' => 'Incomplete Category',
+        'slug' => 'incomplete-category',
+        'status' => 1,
+    ]);
+
+    $existingKpi = Kpi::query()->create([
+        'name' => 'Existing KPI',
+        'code' => 'INCOMPLETE_EXISTING_KPI',
+        'type' => 'completion',
+        'description' => 'Existing KPI.',
+        'weight' => 60,
+        'is_active' => true,
+        'created_by' => $admin->id,
+        'updated_by' => $admin->id,
+    ]);
+
+    $existingKpi->categories()->sync([$category->id]);
+
+    $response = $this->post(
+        route('admin.kpis.store'),
+        [
+            'name' => 'Additional KPI',
+            'code' => 'ADDITIONAL_KPI',
+            'type' => 'score',
+            'description' => 'Additional KPI.',
+            'weight' => 20,
+            'category_ids' => [$category->id],
+            'course_ids' => [],
+        ]
+    );
+
+    $response->assertRedirect(route('admin.kpis.index'));
+
+    $this->assertDatabaseHas('kpis', [
+        'code' => 'ADDITIONAL_KPI',
+    ]);
+}
+#[Test]
+public function it_allows_editing_an_existing_complete_category_configuration()
+{
+    $admin = $this->loginAsAdmin();
+
+    $category = Category::query()->create([
+        'name' => 'Editable Category',
+        'slug' => 'editable-category',
+        'status' => 1,
+    ]);
+
+    $kpi = Kpi::query()->create([
+        'name' => 'Complete KPI',
+        'code' => 'COMPLETE_KPI',
+        'type' => 'completion',
+        'description' => 'Complete KPI.',
+        'weight' => 100,
+        'is_active' => true,
+        'created_by' => $admin->id,
+        'updated_by' => $admin->id,
+    ]);
+
+    $kpi->categories()->sync([$category->id]);
+
+    $response = $this->put(
+        route('admin.kpis.update', $kpi->id),
+        [
+            'name' => 'Updated Complete KPI',
+            'code' => 'COMPLETE_KPI',
+            'type' => 'completion',
+            'description' => 'Updated description.',
+            'weight' => 100,
+            'category_ids' => [$category->id],
+            'course_ids' => [],
+        ]
+    );
+
+    $response->assertRedirect(route('admin.kpis.index'));
+
+    $this->assertDatabaseHas('kpis', [
+        'id' => $kpi->id,
+        'name' => 'Updated Complete KPI',
+        'weight' => 100,
+    ]);
+}
+#[Test]
+public function it_ignores_inactive_kpis_when_checking_category_configuration()
+{
+    $admin = $this->loginAsAdmin();
+
+    $category = Category::query()->create([
+        'name' => 'Inactive Category',
+        'slug' => 'inactive-category',
+        'status' => 1,
+    ]);
+
+    $inactiveKpi = Kpi::query()->create([
+        'name' => 'Inactive KPI',
+        'code' => 'INACTIVE_KPI',
+        'type' => 'completion',
+        'description' => 'Inactive KPI.',
+        'weight' => 100,
+        'is_active' => false,
+        'created_by' => $admin->id,
+        'updated_by' => $admin->id,
+    ]);
+
+    $inactiveKpi->categories()->sync([$category->id]);
+
+    $response = $this->post(
+        route('admin.kpis.store'),
+        [
+            'name' => 'New Active KPI',
+            'code' => 'NEW_ACTIVE_KPI',
+            'type' => 'score',
+            'description' => 'New active KPI.',
+            'weight' => 50,
+            'category_ids' => [$category->id],
+            'course_ids' => [],
+        ]
+    );
+
+    $response->assertRedirect(route('admin.kpis.index'));
+
+    $this->assertDatabaseHas('kpis', [
+        'code' => 'NEW_ACTIVE_KPI',
+        'is_active' => true,
+    ]);
+}
 }


### PR DESCRIPTION
### Defect: Duplicate KPI Sets Can Be Created for Categories with Existing 100% KPI Allocation

---

### 📌 Description

When creating a new KPI configuration, the system allows an existing course category to be selected even when that category already has an active KPI configuration with a combined weightage of 100%.

The existing validation checks the overall active KPI weight but does not validate the total active KPI weight for each selected mapped category.

This allows duplicate KPI configurations to be created for the same category, which can cause ambiguity in KPI evaluation, dashboards, and reporting.

Issue : #992 
---

### 🔄 Steps to Reproduce

1. Navigate to **KPI Management**.
2. Ensure **Category A** has active KPI types configured with a total weightage of **100%**.
3. Navigate to **Create KPI**.
4. Select a new category (**Category B**).
5. Also select **Category A** under **Mapped Course Categories**.
6. Configure the KPI type and weight.
7. Submit the KPI form.
8. Observe that the configuration can be saved.

---

### ✅ Expected Result

The system should validate each selected mapped category before saving.

If a selected category already has an active KPI configuration with a total weightage of 100%, creation of another KPI configuration for that category should be prevented.

A clear validation message should be displayed, for example:

> **"Category A already has an active KPI configuration with 100% total weight. Duplicate KPI configuration is not allowed."**

Validation is implemented on both client side and server side.

---

### 🛠️ Fix Implemented

- Added category-level active KPI weight calculation.
- Added validation for selected categories that already have 100% active KPI allocation.
- Added category-specific validation messages.
- Added client-side validation to prevent submission when a complete category is selected.
- Added server-side validation to prevent bypassing client-side checks.
- Added transactional category locking and a second validation before KPI creation to protect against concurrent submissions.
- Excluded the current KPI during edit validation so existing KPI configurations can still be edited.
- Added feature tests covering duplicate, partial, multiple-category, and edit scenarios.

---

### Screenshot : 

<img width="1900" height="916" alt="image" src="https://github.com/user-attachments/assets/d6825c2a-43a2-4360-bdd8-eb0b50b0a5c3" />
<img width="1897" height="907" alt="image" src="https://github.com/user-attachments/assets/ab54ec71-5d7b-42c6-ac88-e532741dd1e3" />
